### PR TITLE
fix: context-builder turn budget + fail-fast + verdict-gate bot identity

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -421,7 +421,7 @@ jobs:
             --setting-sources user
             --allowedTools Bash,Read,Glob,Grep,Write
             --disallowedTools Edit,WebFetch,WebSearch
-            --max-turns 30
+            --max-turns 60
           show_full_output: 'true'
 
       # Post Turn-4 "Fixed in this revision" replies from the context-builder.
@@ -482,8 +482,27 @@ jobs:
           done < <(jq -c '.[]' "$REPLIES_FILE")
           echo "Turn-4 replies: posted=$POSTED, dropped=$DROPPED, total=$TOTAL"
 
+      # Fail-fast gate: if the context builder didn't leave a context.md on
+      # disk (usually because it hit --max-turns), skip the expensive dev-env
+      # bring-up. The analyzer step below would abort the job anyway — this
+      # saves ~2 minutes of Docker pull + pnpm install + dev-start.sh that
+      # can never be consumed. We keep `continue-on-error: true` on the
+      # builder itself because a partial context.md written just before the
+      # turn limit is still better than no context.
+      - name: Check context.md exists
+        id: check_context
+        shell: bash
+        run: |
+          if [ -f context.md ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "context.md present ($(wc -l < context.md) lines) — continuing to analyzer"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::error::context.md was not written by the context builder. Check the 'Review: build context' step log — max-turns is the most common cause. Skipping dev-env setup; the analyzer step will abort the job."
+          fi
+
       - name: Setup Playwright MCP for test runner
-        if: steps.code_check.outputs.needs_build == 'true'
+        if: steps.code_check.outputs.needs_build == 'true' && steps.check_context.outputs.exists == 'true'
         shell: bash
         run: |
           # Force --output-dir so screenshots land in a known location.
@@ -504,7 +523,7 @@ jobs:
 
       # Pre-start dev environment for functional testing.
       - name: Pre-start dev environment for test runner
-        if: steps.code_check.outputs.needs_build == 'true' && steps.install.outputs.install_ok == 'true'
+        if: steps.code_check.outputs.needs_build == 'true' && steps.install.outputs.install_ok == 'true' && steps.check_context.outputs.exists == 'true'
         id: dev_env
         shell: bash
         env:
@@ -722,7 +741,10 @@ jobs:
         env:
           ANALYZER_OUTCOME: ${{ steps.claude_run.outcome }}
           POSTER_OUTCOME: ${{ steps.review_poster.outcome }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Post the "Claude Review — incomplete" crash notification as the
+          # same bot identity as the successful reviews. Falls back to
+          # GITHUB_TOKEN (github-actions[bot]) when no App is configured.
+          GH_TOKEN: ${{ steps.review_identity.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
         run: .review-scripts/verdict-gate.sh
 


### PR DESCRIPTION
## Summary

Three linked fixes for the failure mode caught on [argenx-argo-map PR 227](https://github.com/Panenco/argenx-argo-map/pull/227) (run [24574690322](https://github.com/Panenco/argenx-argo-map/actions/runs/24574690322)):

**1. Bump context-builder \`--max-turns 30 → 60\`**

The run exited with \`errors: [\"Reached maximum number of turns (30)\"]\`, \`num_turns: 31\`, \`terminal_reason: max_turns\` — the Sonnet agent was reading 21 diff chunks plus convention files and ran out of budget before writing \`context.md\`. The skill still targets ≤10 turns for normal PRs; 60 is a safety ceiling for outliers like a full auth-stack overhaul.

**2. Skip dev-env bring-up when \`context.md\` is missing**

New \`Check context.md exists\` step after the builder. When \`context.md\` isn't on disk (max-turns / OOM / token expiry), the Playwright-MCP and Pre-start-dev-env steps are now gated off — saving ~2 minutes of Postgres pull + \`pnpm install\` + \`dev-start.sh\` bring-up that can never be consumed because the analyzer aborts anyway on the existing \`[ ! -f context.md ]\` guard. \`continue-on-error: true\` stays on the builder so partial output (written just before the turn limit) still survives.

**3. Verdict-gate crash notification uses the App token**

The \"Claude Review — incomplete\" comment was being posted as \`github-actions[bot]\` while successful reviews come from \`panenco-claude-reviewer[bot]\`. Change \`GH_TOKEN\` on the verdict-gate step from \`secrets.GITHUB_TOKEN\` to \`steps.review_identity.outputs.token\`, which already falls back to \`GITHUB_TOKEN\` when no App is configured.

## Why ship via PR

This bumps \`main\` and implicitly \`v1\` (mutable tag). Want review before propagation; argenx-argo-map's re-run on PR 227 is the natural smoke test once this merges and \`v1\` is moved.

## Test plan

- [ ] Merge to \`main\`
- [ ] Cut \`v1.3.0\` and move \`v1\` to it
- [ ] Re-run the failed workflow on argenx-argo-map#227 and confirm:
  - Context builder completes (\`num_turns\` well under 60)
  - \`context.md\` lands on disk, analyzer runs all four reviewers
  - Verdict is posted by \`panenco-claude-reviewer[bot]\`
- [ ] (Negative path) On a PR where max-turns is still hit, confirm dev-env steps are skipped and the crash comment is posted by \`panenco-claude-reviewer[bot]\`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes that adjust CI gating and token selection; main risk is unintentionally skipping functional test setup or altering comment authoring in edge failure paths.
> 
> **Overview**
> Increases the context-builder agent budget by raising `--max-turns` from 30 to 60 to reduce runs failing before writing `context.md`/`test-plan.md`.
> 
> Adds a fail-fast check that gates Playwright MCP setup and dev-environment prestart on `context.md` existing, avoiding unnecessary build/bring-up work when the context builder fails.
> 
> Updates the verdict-gate step to use the resolved review bot token (`steps.review_identity.outputs.token`) instead of `secrets.GITHUB_TOKEN`, so “incomplete” crash notifications come from the same bot identity as successful reviews.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ba0feb37e0196cf5602bd7f0683e22de86051f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->