### PR TITLE
fix: bump functional tester --max-turns 40 to 80

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -671,7 +671,7 @@ jobs:
                 --mcp-config /tmp/mcp-playwright.json \
                 --permission-mode dontAsk \
                 --allowedTools "Bash,Read,Write,ToolSearch,mcp__playwright__browser_navigate,mcp__playwright__browser_take_screenshot,mcp__playwright__browser_snapshot,mcp__playwright__browser_console_messages,mcp__playwright__browser_click,mcp__playwright__browser_fill_form,mcp__playwright__browser_wait_for,mcp__playwright__browser_close,mcp__playwright__browser_select_option,mcp__playwright__browser_press_key,mcp__playwright__browser_type,mcp__playwright__browser_hover,mcp__playwright__browser_resize,mcp__playwright__browser_tabs,mcp__playwright__browser_navigate_back,mcp__playwright__browser_evaluate" \
-                --max-turns 40 > /tmp/functional-output.txt 2>&1 &
+                --max-turns 80 > /tmp/functional-output.txt 2>&1 &
               PID_FUNCTIONAL=$!
             else
               echo "Functional tester skipped — strategy: skip"


### PR DESCRIPTION
Follow-up to #1. Functional tester crashed with `Error: Reached max turns (40)` on argenx-argo-map#227 after capturing 3 of ~10 screenshots. The Playwright MCP agent is tool-use heavy (navigate → snapshot → click per scenario), so a multi-scenario plan naturally burns dozens of turns. Raising to 80 doubles headroom without touching the simpler text-only reviewers (core=10, sweep=8, spec=8).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that just raises an LLM turn limit; main risk is longer runtime/quota consumption, not code or security behavior.
> 
> **Overview**
> Increases the GitHub Actions PR review workflow’s Playwright-based functional tester budget by bumping `claude --max-turns` from 40 to 80, reducing premature failures on multi-scenario UI test plans.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 498d01de74fa0c5e5bfebb93804b212f4f719248. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->