### PR TITLE
fix: helper-script failure no longer orphans reviewer agents

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -595,6 +595,23 @@ jobs:
           # this block points at its own trigger line.
           set -x
 
+          # Safety net: if anything between the reviewer launches and `wait`
+          # fails under `set -e`, the shell would exit before waiting, the
+          # runner would SIGTERM the backgrounded `claude` processes, and
+          # core/sweep output files would be empty — which is exactly how this
+          # step silently failed in the past. Trap EXIT reaps any still-running
+          # reviewer PIDs so we preserve their output even on abort.
+          PID_CORE=""; PID_SWEEP=""; PID_SPEC=""; PID_FUNCTIONAL=""
+          reap_on_exit() {
+            local rc=$?
+            set +x
+            for pid in "$PID_CORE" "$PID_SWEEP" "$PID_SPEC" "$PID_FUNCTIONAL"; do
+              [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null && wait "$pid" 2>/dev/null || true
+            done
+            exit "$rc"
+          }
+          trap reap_on_exit EXIT
+
           # Core reviewer: bugs, spec-mismatches, security (Opus)
           ~/.local/bin/claude -p "You are the core reviewer for PR #$PR_NUMBER. context.md at the repo root contains the full diff and project context — Read it. Follow the skill below exactly, including writing the JSON output files it specifies.${BUGBOT_BLOCK}
 
@@ -649,14 +666,21 @@ jobs:
             echo "Spec-compliance reviewer skipped — no PRD detected"
           fi
 
-          # Generate functional prompt from template
-          .review-scripts/generate-functional-prompt.sh
+          # Generate functional prompt from template.
+          # Never let helper-script failure kill the whole step — the core and
+          # sweep reviewers have already been launched (PID_CORE / PID_SWEEP) and
+          # errexit here would trip before `wait`, orphaning them and producing
+          # an "analyzer crashed" outcome with two zero-byte output files.
+          # Functional testing is best-effort: if the prompt can't be built we
+          # warn and skip the tester, then still wait on core/sweep.
+          .review-scripts/generate-functional-prompt.sh \
+            || echo "::warning::generate-functional-prompt.sh failed — functional tester will be skipped (core + sweep continue)"
 
           # Functional tester: single AI agent with Playwright MCP + Bash.
           # Tests through the UI first (Playwright), uses browser_evaluate fetch
           # for authenticated API calls, falls back to curl only when needed.
           PID_FUNCTIONAL=""
-          if [ "$NEEDS_BUILD" = "true" ] && [ "$WEB_READY" = "true" ] && [ -f test-plan.md ]; then
+          if [ "$NEEDS_BUILD" = "true" ] && [ "$WEB_READY" = "true" ] && [ -f test-plan.md ] && [ -s /tmp/functional-prompt.txt ]; then
             # `|| true` guards against test-plan.md missing a '## Strategy:' line.
             # Without it, grep's non-zero exit would abort the whole analyze step
             # under `set -euo pipefail`. Treat missing strategy as "unknown" and

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -105,8 +105,11 @@ jobs:
           fetch-depth: 50
 
       # Install review pipeline skills + scripts from the central repo.
+      # TESTING: pin to branch during PR #3 validation so helper-script and
+      # build-review changes are actually installed (not just the workflow).
+      # Revert to @v1 before merging so v1-tracking works for consumers.
       - name: Install review pipeline
-        uses: panenco/claude-review@v1
+        uses: panenco/claude-review@fix/helper-script-orphan-reviewers
 
       # Validate review-config.md sections (warn on missing recommended sections)
       # and sanity-check that file paths it references actually exist in the repo.

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -789,5 +789,13 @@ jobs:
             /tmp/functional-output.txt
             /tmp/functional-prompt.txt
             /tmp/prd-content.md
+            /tmp/core-findings.json
+            /tmp/sweep-findings.json
+            /tmp/spec-findings.json
+            /tmp/functional-findings.json
+            /tmp/core-meta.json
+            /tmp/functional-meta.json
+            /tmp/*-findings.invalid.json
+            /tmp/*-meta.invalid.json
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -105,11 +105,8 @@ jobs:
           fetch-depth: 50
 
       # Install review pipeline skills + scripts from the central repo.
-      # TESTING: pin to branch during PR #3 validation so helper-script and
-      # build-review changes are actually installed (not just the workflow).
-      # Revert to @v1 before merging so v1-tracking works for consumers.
       - name: Install review pipeline
-        uses: panenco/claude-review@fix/helper-script-orphan-reviewers
+        uses: panenco/claude-review@v1
 
       # Validate review-config.md sections (warn on missing recommended sections)
       # and sanity-check that file paths it references actually exist in the repo.

--- a/scripts/build-review.sh
+++ b/scripts/build-review.sh
@@ -30,12 +30,71 @@ set -euo pipefail
 
 echo "::group::Merge findings + build review"
 
-# Guard: check which agents produced output
+# Guard: check which agents produced VALID output. An agent's findings
+# file being present but not JSON (e.g. an invalid escape in a free-text
+# `evidence` field) used to crash the whole step with `jq: parse error`
+# on the slurpfile below. Now we validate up front, warn, and preserve
+# the malformed file for artifact upload so the agent output can be
+# inspected without re-running.
+is_valid_findings() {
+  # Accept only a JSON array — agents are required to write `[]` at minimum.
+  [ -f "$1" ] && jq -e 'type == "array"' "$1" >/dev/null 2>&1
+}
+is_valid_json() {
+  [ -f "$1" ] && jq empty "$1" >/dev/null 2>&1
+}
+preserve_invalid() {
+  local src="$1"
+  [ -f "$src" ] || return 0
+  cp "$src" "${src%.json}.invalid.json" 2>/dev/null || true
+  # Show the first parse error in logs for immediate diagnosis
+  jq empty "$src" 2>&1 | head -3 || true
+}
+
 CORE_HAS_OUTPUT=false; SWEEP_HAS_OUTPUT=false; SPEC_HAS_OUTPUT=false; FUNCTIONAL_HAS_OUTPUT=false
-[ -f /tmp/core-findings.json ] && CORE_HAS_OUTPUT=true
-[ -f /tmp/sweep-findings.json ] && SWEEP_HAS_OUTPUT=true
-[ -f /tmp/spec-findings.json ] && SPEC_HAS_OUTPUT=true
-[ -f /tmp/functional-findings.json ] && FUNCTIONAL_HAS_OUTPUT=true
+if [ -f /tmp/core-findings.json ]; then
+  if is_valid_findings /tmp/core-findings.json; then
+    CORE_HAS_OUTPUT=true
+  else
+    echo "::warning::Core reviewer findings are not a valid JSON array — treating as failed."
+    preserve_invalid /tmp/core-findings.json
+  fi
+fi
+if [ -f /tmp/sweep-findings.json ]; then
+  if is_valid_findings /tmp/sweep-findings.json; then
+    SWEEP_HAS_OUTPUT=true
+  else
+    echo "::warning::Sweep reviewer findings are not a valid JSON array — treating as failed."
+    preserve_invalid /tmp/sweep-findings.json
+  fi
+fi
+if [ -f /tmp/spec-findings.json ]; then
+  if is_valid_findings /tmp/spec-findings.json; then
+    SPEC_HAS_OUTPUT=true
+  else
+    echo "::warning::Spec-compliance findings are not a valid JSON array — treating as failed."
+    preserve_invalid /tmp/spec-findings.json
+  fi
+fi
+if [ -f /tmp/functional-findings.json ]; then
+  if is_valid_findings /tmp/functional-findings.json; then
+    FUNCTIONAL_HAS_OUTPUT=true
+  else
+    echo "::warning::Functional tester findings are not a valid JSON array — treating as failed."
+    preserve_invalid /tmp/functional-findings.json
+  fi
+fi
+# Meta files are also agent-written JSON — fall back to empty if malformed.
+if [ -f /tmp/core-meta.json ] && ! is_valid_json /tmp/core-meta.json; then
+  echo "::warning::Core reviewer meta is not valid JSON — falling back to {}."
+  preserve_invalid /tmp/core-meta.json
+  echo '{}' > /tmp/core-meta.json
+fi
+if [ -f /tmp/functional-meta.json ] && ! is_valid_json /tmp/functional-meta.json; then
+  echo "::warning::Functional tester meta is not valid JSON — falling back to {}."
+  preserve_invalid /tmp/functional-meta.json
+  echo '{}' > /tmp/functional-meta.json
+fi
 
 if [ "$CORE_HAS_OUTPUT" = "false" ] && [ "$SWEEP_HAS_OUTPUT" = "false" ]; then
   echo "::error::Both code reviewers failed to produce output — cannot generate a verdict."

--- a/scripts/generate-functional-prompt.sh
+++ b/scripts/generate-functional-prompt.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
-set -euo pipefail
+# `-x` makes every command visible in the job log. The caller runs us from a
+# step that already has `set -x` on, but that trace stops at the script
+# boundary — if we die silently under `set -e`, the reviewer processes we were
+# launched alongside get orphan-killed and the whole review looks like
+# "analyzer crashed" with no evidence. Tracing here points future debugging
+# at the exact failing line.
+set -Eeuxo pipefail
 
 # generate-functional-prompt.sh — Build the functional tester prompt from the template.
 #
@@ -43,7 +49,10 @@ for cf in docker-compose.yml docker-compose.yaml compose.yml compose.yaml; do
 done
 [ -n "$COMPOSE_FILE" ] && ENV_HINT+="Docker services are running via docker compose. "
 [ -f .env ] && ENV_HINT+=".env exists. "
-PRISMA_FOUND=$(find . -maxdepth 5 -path '*/prisma/schema.prisma' -not -path '*/node_modules/*' 2>/dev/null | head -1)
+# `head -1` closes the pipe as soon as it reads a match, which gives `find`
+# SIGPIPE → under `pipefail` the whole command substitution exits 141 and
+# errexit aborts the script. `|| true` keeps the detection best-effort.
+PRISMA_FOUND=$(find . -maxdepth 5 -path '*/prisma/schema.prisma' -not -path '*/node_modules/*' 2>/dev/null | head -1 || true)
 [ -n "$PRISMA_FOUND" ] && ENV_HINT+="Prisma is generated and migrated. "
 ENV_HINT+="Skip setup steps that are already done."
 
@@ -89,7 +98,9 @@ if [ -n "$FUNC_TEMPLATE" ] && [ -f "$FUNC_TEMPLATE" ]; then
   TEMPLATE_CONTENT="${TEMPLATE_CONTENT//\{\{AUTH_INSTRUCTIONS\}\}/$AUTH_INSTRUCTIONS}"
   TEMPLATE_CONTENT="${TEMPLATE_CONTENT//\{\{ENV_HINT\}\}/$ENV_HINT}"
   TEMPLATE_CONTENT="${TEMPLATE_CONTENT//\{\{PIPELINE_DIR\}\}/$PIPELINE_DIR_VAL}"
-  echo "$TEMPLATE_CONTENT" > /tmp/functional-prompt.txt
+  # `printf '%s\n'` over `echo` — if the template ever starts with `-n`/`-e`,
+  # echo would swallow it as a flag and silently drop the first line.
+  printf '%s\n' "$TEMPLATE_CONTENT" > /tmp/functional-prompt.txt
   printf '\n%s\n' "$ENV_HINT" >> /tmp/functional-prompt.txt
 else
   echo "::warning::No functional-prompt template found -- using minimal fallback"


### PR DESCRIPTION
## Summary
- Silent failure in `scripts/generate-functional-prompt.sh` was aborting the analyze step between the core/sweep reviewer launches and the `wait` calls. The runner SIGTERM'd the backgrounded `claude` processes, leaving `core-output.txt` and `sweep-output.txt` at 0 bytes. Surfaced only as "Analyzer agent crashed" with no evidence of the trigger.
- Repros as valcori PR #14 attempt 3 (Panenco/valcori actions run 24564423987) — both reviewer logs empty; orphan-terminate lines for the claude PIDs in the tail of the job log.

## Fixes
1. `.github/workflows/pr-review.yml` — make the helper call best-effort (`|| echo ::warning::`). Gate the functional-tester launch on `-s /tmp/functional-prompt.txt` since its prompt comes from that helper. Core + sweep are independent and now always reach `wait`.
2. `scripts/generate-functional-prompt.sh` — `set -Eeuxo pipefail` so future failures point at the failing line. Guard `PRISMA_FOUND=$(find ... | head -1)` with `|| true` (SIGPIPE + pipefail trip). Use `printf '%s\n'` over `echo` for template output.
3. Defensive EXIT trap in the analyze step: if any future helper trips errexit again, the trap reaps any still-running reviewer PIDs instead of orphan-killing them. Output is preserved either way.

## Test plan
- [ ] Merge + move `v1` tag to the merge commit.
- [ ] Re-run valcori PR #14 workflow. Expect: step 23 succeeds, `core-output.txt` and `sweep-output.txt` non-empty, verdict gate runs, bot posts a review.
- [ ] If it still fails, the new `set -x` inside `generate-functional-prompt.sh` will name the exact failing line.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes execution/error-handling in the PR review GitHub Actions workflow and merge script; missteps could cause reviewers/tests to be skipped or outputs to be misclassified, but impact is limited to CI automation.
> 
> **Overview**
> Hardens the PR review workflow against mid-step aborts by adding an `EXIT` trap to always reap background reviewer/tester PIDs and preserve their outputs.
> 
> Makes functional testing *best-effort*: `generate-functional-prompt.sh` failures no longer fail the analyze step, the functional tester only launches when `/tmp/functional-prompt.txt` exists and is non-empty, and additional agent JSON outputs (plus `*.invalid.json` fallbacks) are uploaded as artifacts.
> 
> Adds defensive JSON validation in `build-review.sh` so malformed agent `*-findings.json`/`*-meta.json` won’t crash the merge; invalid files are preserved for debugging while treating that agent as failed. Improves `generate-functional-prompt.sh` robustness via tracing (`set -Eeuxo pipefail`), a `SIGPIPE`-safe Prisma detection, and safer template rendering with `printf`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a371bd84dfcd17bc5d4488c70469942357441672. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->