### PR TITLE
fix: surface functional tester crash in review-result.json

### DIFF
--- a/scripts/build-review.sh
+++ b/scripts/build-review.sh
@@ -292,6 +292,23 @@ fi
 echo "Verdict: $VERDICT (blocking=$HAS_BLOCKING, any=$HAS_ANY, human=$HUMAN_REVIEW, functional=$FUNCTIONAL_OVERALL)"
 
 # ── Build review-result.json ──
+# Crash-aware functional_meta view, used ONLY for the JSON artifact. If
+# the tester exited non-zero without writing /tmp/functional-meta.json,
+# the workflow wrote a synthetic {strategy:"skip",overall:"PASS"} so
+# downstream jq never sees a missing file. That placeholder is
+# indistinguishable from an intentional skip — anyone reading
+# review-result.json would see "skip / PASS" while the review body
+# clearly renders a CRASHED section (that path reads FUNCTIONAL_OK
+# directly). Override here so the JSON reflects the crash too. The
+# FUNCTIONAL_STRATEGY / FUNCTIONAL_OVERALL shell vars that drive body
+# rendering are deliberately left untouched — the existing
+# `elif FUNCTIONAL_OK == 0` branch below still fires as before.
+JSON_FUNCTIONAL_META="$FUNCTIONAL_META"
+if [ "${FUNCTIONAL_OK:-1}" -eq 0 ] && [ "$FUNCTIONAL_STRATEGY" = "skip" ] && [ "$FUNCTIONAL_OVERALL" = "PASS" ]; then
+  echo "::notice::functional tester exited non-zero without writing meta — review-result.json will record strategy=crashed"
+  JSON_FUNCTIONAL_META=$(echo "$FUNCTIONAL_META" | jq '. + {strategy: "crashed", overall: "CRASH", summary: "Functional tester agent did not complete; see crash log in review body."}')
+fi
+
 SPEC_COMPLIANCE=$(echo "$CORE_META" | jq -r '.spec_compliance // ""')
 FUNCTIONAL_SUMMARY_TEXT=$(echo "$FUNCTIONAL_META" | jq -r '.summary // ""')
 if [ "$(echo "$ALL_FINDINGS" | jq 'length')" -eq 0 ]; then
@@ -307,7 +324,7 @@ jq -n \
   --arg spec_compliance "$SPEC_COMPLIANCE" \
   --argjson findings "$ALL_FINDINGS" \
   --argjson meta "$CORE_META" \
-  --argjson functional_meta "$FUNCTIONAL_META" \
+  --argjson functional_meta "$JSON_FUNCTIONAL_META" \
   '{
     pr_number: ($pr | tonumber),
     verdict: $verdict,


### PR DESCRIPTION
Third in the audit chain, this one cosmetic but real. Context in #1, #2.

When the functional tester crashes before writing `/tmp/functional-meta.json`, the workflow falls back to a synthetic `{strategy: "skip", overall: "PASS"}` placeholder so downstream jq never sees a missing file. That placeholder is indistinguishable from an intentional skip, so the review-result.json artifact records `functional_validation.strategy = "skip" / overall = "PASS"` — even though the posted review body (which reads `FUNCTIONAL_OK` directly) correctly renders a CRASHED section with the crash log tail.

Net: JSON consumers (dashboards, jq scripts, future tooling) see "skip / PASS" and conclude functional testing was never attempted. argenx-argo-map#227 run 24578947702 is the repro — posted body showed ❌ CRASHED (Reached max turns 40), JSON said skip/PASS.

**Fix:** detect the exact synthetic-placeholder fingerprint combined with `FUNCTIONAL_OK=0` and override a JSON-only copy of FUNCTIONAL_META with `strategy: "crashed"`, `overall: "CRASH"`. The shell variables that drive body rendering are deliberately untouched so the existing `elif FUNCTIONAL_OK == 0` body branch keeps firing identically.

## Test plan

- [ ] Merge, cut v1.4.1, move v1
- [ ] Force a crash (e.g. temporarily lower `--max-turns 5` on the tester, run against any PR) and confirm:
  - `review-result.json.functional_validation.strategy == "crashed"`, `overall == "CRASH"`
  - Review body still shows the existing ❌ CRASHED section unchanged
- [ ] Normal skip (PR with `## Strategy: skip` in test-plan.md) still records `strategy: "skip", overall: "N/A"` — unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts how `review-result.json` records functional validation metadata in a specific crash/placeholder scenario, without changing the posted review body logic.
> 
> **Overview**
> Ensures `review-result.json` no longer reports functional validation as `skip`/`PASS` when the functional tester actually crashed before writing `/tmp/functional-meta.json`.
> 
> `scripts/build-review.sh` now detects the synthetic placeholder fingerprint combined with `FUNCTIONAL_OK=0` and overrides a JSON-only copy of `FUNCTIONAL_META` to record `strategy: "crashed"`, `overall: "CRASH"`, and a crash summary, while leaving the existing review-body rendering behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d61da3ce93fe819f7c40564bc1e51bbc598a0e2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->