### PR TITLE
fix: large screenshots silently dropped from review body

### DIFF
--- a/scripts/build-review.sh
+++ b/scripts/build-review.sh
@@ -167,12 +167,23 @@ if [ -n "$SCREENSHOT_DIR" ]; then
 
   TREE_ENTRIES="[]"
   UPLOAD_COUNT=0
+  FAILED_COUNT=0
+  TOTAL_COUNT=$(ls "$SCREENSHOT_DIR"/*.png 2>/dev/null | wc -l)
   for img in "$SCREENSHOT_DIR"/*.png; do
     BASENAME=$(basename "$img")
-    B64=$(base64 -w0 < "$img" 2>/dev/null || base64 < "$img")
     UPLOAD_PATH="pr-${PR_NUMBER}/${BASENAME}"
-    BLOB_SHA=$(GH_TOKEN="$GITHUB_REPO_TOKEN" gh api "repos/$GITHUB_REPOSITORY/git/blobs" \
-      --method POST -f content="$B64" -f encoding="base64" --jq '.sha' 2>/dev/null) || true
+    # Pipe the base64 payload via stdin + --input rather than `-f content=`.
+    # The argv-form field silently fails for blobs above ~200 KB on GitHub
+    # runners (form-encoded body outgrows some internal buffer), leaving
+    # `BLOB_SHA` empty and the image silently dropped. argenx-argo-map#227
+    # run 24578947702 uploaded 4/9 screenshots exactly along the 26 KB
+    # boundary — every larger PNG (map view, user menu, SAML redirect)
+    # was dropped and only survived as a "see build artifacts" link. A
+    # JSON body through stdin sidesteps the form-encoding path entirely.
+    BLOB_SHA=$(base64 -w0 < "$img" 2>/dev/null | \
+      jq -Rs '{content: ., encoding: "base64"}' | \
+      GH_TOKEN="$GITHUB_REPO_TOKEN" gh api "repos/$GITHUB_REPOSITORY/git/blobs" \
+        --method POST --input - --jq '.sha' 2>/tmp/blob-err.log) || true
     if [ -n "$BLOB_SHA" ]; then
       TREE_ENTRIES=$(echo "$TREE_ENTRIES" | jq --arg p "$UPLOAD_PATH" --arg s "$BLOB_SHA" \
         '. + [{"path": $p, "mode": "100644", "type": "blob", "sha": $s}]')
@@ -180,8 +191,16 @@ if [ -n "$SCREENSHOT_DIR" ]; then
       SCREENSHOT_URLS=$(echo "$SCREENSHOT_URLS" | jq --arg k "$BASENAME" --arg v "$URL" '. + {($k): $v}')
       echo "  $BASENAME -> $URL"
       UPLOAD_COUNT=$((UPLOAD_COUNT + 1))
+    else
+      FAILED_COUNT=$((FAILED_COUNT + 1))
+      SIZE=$(wc -c < "$img" | tr -d ' ')
+      ERR_TAIL=$(tail -c 200 /tmp/blob-err.log 2>/dev/null | tr '\n' ' ')
+      echo "::warning::Blob upload failed for $BASENAME ($SIZE bytes) — will render as fallback link. API err: ${ERR_TAIL:-<empty>}"
     fi
   done
+  if [ "$FAILED_COUNT" -gt 0 ]; then
+    echo "::warning::Screenshot upload: $UPLOAD_COUNT/$TOTAL_COUNT succeeded ($FAILED_COUNT failed). Failed images fall back to 'see build artifacts' text in the review body."
+  fi
 
   if [ "$UPLOAD_COUNT" -gt 0 ]; then
     echo "$TREE_ENTRIES" > /tmp/tree-entries.json
@@ -206,7 +225,7 @@ if [ -n "$SCREENSHOT_DIR" ]; then
         GH_TOKEN="$GITHUB_REPO_TOKEN" gh api "repos/$GITHUB_REPOSITORY/git/refs" \
           --method POST -f ref="refs/heads/review-assets" -f sha="$COMMIT" >/dev/null 2>&1
       fi
-      echo "Uploaded $UPLOAD_COUNT screenshots (1 orphan commit, old URLs preserved)"
+      echo "Uploaded $UPLOAD_COUNT/$TOTAL_COUNT screenshots (1 orphan commit, old URLs preserved)"
     fi
   fi
 fi


### PR DESCRIPTION
Caught reviewing argenx-argo-map#227 — the user pointed out that the posted review claimed "9 screenshots" but only 4 were inlined as images, and the MAJOR finding ("avatar shows ??") pointed at a screenshot that was rendered as a plain-text "see build artifacts" link.

## Diagnosis

Run 24578947702, `build-review.sh`:
```
Found 9 screenshot(s):
  01-login-page.png             26927   ← uploaded
  02-post-login-map.png        327313   ← dropped
  03-user-menu.png             326604   ← dropped
  04-null-name-avatar-bug.png  332756   ← dropped  (the f1 evidence shot!)
  05-unauth-map-access.png     321394   ← dropped
  06-post-signout.png           26927   ← uploaded
  07-unauth-redirect-to-login  26927   ← uploaded
  08-login-okta-button.png      26927   ← uploaded
  09-okta-saml-redirect.png    232905   ← dropped
Uploaded 4 screenshots (1 orphan commit, old URLs preserved)
```

Every successful upload is 26,927 bytes; every dropped image is >200 KB. Root cause: `gh api --method POST -f content="$B64" -f encoding=base64` passes the payload as a form field via argv/form-encoding, which silently fails above ~200 KB of base64 on GitHub runners. The call returns empty, the `|| true` suppresses the error, and the `if [ -n "$BLOB_SHA" ]` gate lets the loop quietly skip the image.

## Fix

Three small changes to `scripts/build-review.sh`:

1. **Pipe the JSON body through stdin** (`jq -Rs | gh api --input -`). Side-steps form-encoding entirely — the binary is isolated to stdin and the blobs endpoint gets a clean `{"content":"...","encoding":"base64"}` POST body.
2. **Emit `::warning::` per failed blob** with size and API error tail. Next silent-skip lands in the job log instead of hiding behind a count mismatch.
3. **Summary now reads `Uploaded N/M screenshots`** so partial uploads jump out.

## Test plan

- [ ] Merge, cut v1.4.2, move v1
- [ ] Re-run argenx-argo-map#227 and confirm: all 9 screenshots land on `review-assets/pr-227/`, the review body inlines every image (no `see build artifacts` fallback), and the job log shows `Uploaded 9/9 screenshots`.
- [ ] Small-screenshot path still works (tiny PNGs unaffected — the stdin path is a strict superset of the argv path).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the GitHub blob upload mechanism in `build-review.sh`, which could affect review artifact publishing if the new `gh api --input`/`jq` pipeline misbehaves on runners.
> 
> **Overview**
> Fixes review screenshot publishing so **large PNGs are no longer silently skipped** during upload to the `review-assets` branch.
> 
> `build-review.sh` now posts blob content as a JSON payload via stdin (`jq -Rs | gh api --input -`) instead of `-f content=...`, and adds per-file and summary `::warning::` logs (including file size and API error tail) when an upload returns an empty SHA, reporting results as `Uploaded N/M`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5ccc6cf7d879ea22984270d9a8d18b55d9e58b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->