### PR TITLE
feat: surface external tracker identifier in spec_sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,12 @@ Env in:
   ISSUE_CANDIDATES_FILE=/tmp/external-issue-candidates.json  (always set)
   <anything you put in TRACKER_SECRETS>                      (your chosen names)
 Stdout:  markdown. Inlined verbatim under "## Linked external issue" in context.md.
+         For best results, make the first line a heading that surfaces the
+         tracker identifier, e.g. "## Linked Linear issue: LIN-123" — the
+         core reviewer extracts this into spec_sources.external_issue so
+         the final review summary can show the tracker ID alongside any
+         GitHub #N link. Omit the identifier and external_issue stays null;
+         the section body is still read for acceptance-criteria extraction.
 Exit:    0 with output     = success.
          0 with no output  = no external issue for this PR (normal).
          non-zero          = soft-fail: ::warning:: logged, review continues.

--- a/scripts/build-review.sh
+++ b/scripts/build-review.sh
@@ -349,7 +349,7 @@ jq -n \
     verdict: $verdict,
     summary: $summary,
     spec_compliance: $spec_compliance,
-    spec_sources: ($meta.spec_sources // {linked_issue: null, prd_path: null, convention_rules: []}),
+    spec_sources: ($meta.spec_sources // {linked_issue: null, external_issue: null, prd_path: null, convention_rules: []}),
     findings: $findings,
     requires_human_review: ($meta.requires_human_review // false),
     requires_human_review_reason: ($meta.requires_human_review_reason // null),
@@ -366,13 +366,28 @@ jq -n \
   }' > review-result.json
 
 # ── Build /tmp/review-body.md ──
+# `linked_issue` is the GitHub-native issue number (from closingIssuesReferences).
+# `external_issue` is the tracker identifier (e.g. ABC-123) surfaced by the
+# consumer's optional fetch-issue.sh hook. Show #N when present, otherwise the
+# external identifier, falling back to "none found" only when neither exists.
 ISSUE=$(jq -r '.spec_sources.linked_issue // "none found"' review-result.json)
+EXTERNAL=$(jq -r '.spec_sources.external_issue // empty' review-result.json)
 {
   echo "## Claude PR Review — $VERDICT"
   echo ""
   echo "### Spec sources"
   echo ""
-  echo "- Linked issue: $([ "$ISSUE" != "null" ] && [ "$ISSUE" != "none found" ] && echo "#$ISSUE" || echo "none found")"
+  if [ "$ISSUE" != "null" ] && [ "$ISSUE" != "none found" ]; then
+    if [ -n "$EXTERNAL" ] && [ "$EXTERNAL" != "null" ]; then
+      echo "- Linked issue: #$ISSUE (external tracker: $EXTERNAL)"
+    else
+      echo "- Linked issue: #$ISSUE"
+    fi
+  elif [ -n "$EXTERNAL" ] && [ "$EXTERNAL" != "null" ]; then
+    echo "- Linked issue: $EXTERNAL (external tracker)"
+  else
+    echo "- Linked issue: none found"
+  fi
   RULES=$(jq -r '.spec_sources.convention_rules // [] | map("`\(.)`") | join(", ")' review-result.json)
   echo "- Convention rules: ${RULES:-none identified}"
   echo ""

--- a/skills/review-core.md
+++ b/skills/review-core.md
@@ -130,6 +130,7 @@ Do NOT set it for:
   "spec_compliance": "Brief statement of spec alignment (1-2 sentences).",
   "spec_sources": {
     "linked_issue": 42,
+    "external_issue": "ABC-123",
     "prd_path": "path or null",
     "convention_rules": ["rules applied"]
   }
@@ -137,6 +138,7 @@ Do NOT set it for:
 ```
 
 - `spec_compliance` is ALWAYS filled in — even when there are findings. Summarizes what the PR does right or wrong vs the spec.
-- `spec_sources` extracts the linked issue number, PRD path, and which convention rules applied — read these from context.md. Use `null` for missing values.
+- `spec_sources` extracts the linked issue number, external tracker identifier, PRD path, and which convention rules applied — read these from context.md. Use `null` for missing values.
+- `external_issue` is the tracker identifier (e.g. `ABC-123`, `ENG-214`, `MON-1234`) surfaced by the consumer's optional `.github/claude-review/fetch-issue.sh` hook. Parse it from the heading at the top of the `## Linked external issue` section in context.md — the hook convention is `## Linked <tracker> issue: <IDENTIFIER>` as its first line. If the section is absent or no identifier can be parsed, set to `null`.
 
 Write `[]` for empty findings. ALWAYS write both files.


### PR DESCRIPTION
## Summary

Stacked on `feat/pluggable-tracker-hook`. Threads the external tracker identifier (e.g. `CUR-97`, `ENG-214`, `MON-1234`) through the existing `spec_sources` JSON → review body pipeline so the final review comment's **Spec sources** section actually reflects what the tracker hook loaded.

## Why

The pluggable `fetch-issue.sh` hook in the base branch already:
- writes external spec content to `/tmp/external-issue.md`
- gets inlined into `context.md` under `## Linked external issue`
- is read by `review-core` for acceptance-criteria extraction

…but the summary renderer in `scripts/build-review.sh` only knew about `spec_sources.linked_issue` (the GitHub-native `closingIssuesReferences` number). Consumers tracking PRs in Linear/Jira/Monday get the full benefit of spec-compliance checks, but the top-line summary reads:

```
### Spec sources
- Linked issue: none found
```

…even when a valid external ticket was fetched and used. That's confusing — the rest of the review clearly references the ticket by ID, but the summary denies it.

Observed in the wild while stacking the tracker hook on `curewiki` (Linear CUR-97) — the review body cites "all six CUR-97 acceptance criteria" but the Spec-sources header says "Linked issue: none found".

## What changes

- **`skills/review-core.md`** — extends the `/tmp/core-meta.json` schema with an optional `spec_sources.external_issue` field + one sentence telling the reviewer to parse it from the `## Linked external issue` heading in context.md. Convention: `## Linked <tracker> issue: <IDENTIFIER>` as the first line of the hook's stdout.
- **`scripts/build-review.sh`** — renders the external identifier in the summary:
  - `#42 (external tracker: ABC-123)` when both exist
  - `#42` when only GitHub is linked (unchanged)
  - `ABC-123 (external tracker)` when only the hook resolved a ticket
  - `none found` when neither (unchanged)
  - Also backfills `external_issue: null` into the default `spec_sources` so legacy `core-meta.json` files without the new field still render "none found" via the existing `// "none found"` jq path.
- **`README.md`** — documents the heading convention in the fetch-issue.sh contract so other consumers know how to make their hook output parseable.

## Fully provider-neutral

No Linear/Jira/Monday/Notion awareness anywhere. The pipeline relies entirely on the hook's chosen heading — consumers can name their tracker however they want. Hooks that omit the identifier still work fine: `external_issue` stays `null`, the body is still read for acceptance-criteria extraction, and the summary falls through to "none found".

## Backward compatibility

- Agents producing old-schema `core-meta.json` (no `external_issue` field): the `// empty` jq default yields an empty string, `EXTERNAL` stays unset, renders exactly as before.
- Agents writing the new schema with `external_issue: null`: same behavior.
- Consumers without a `fetch-issue.sh` hook: `external_issue` is always `null`, rendering is identical to pre-change behavior.

## Test plan

- [x] `bash -n scripts/build-review.sh` passes.
- [x] All four rendering paths exercised locally with synthetic `review-result.json` inputs (both, external-only, gh-only, neither) → produce the expected one-liner.
- [x] Legacy schema (missing `external_issue` field) → renders "none found" via the `// "none found"` fallback.
- [ ] Run a real review with a Linear-linked PR and confirm the summary header shows `Linked issue: CUR-XX (external tracker)` instead of `none found`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only extends metadata/schema and adjusts review-body rendering logic, with backward-compatible defaults; main risk is minor formatting/regression in the generated review comment.
> 
> **Overview**
> The review pipeline now carries an optional external tracker identifier (`spec_sources.external_issue`) from core reviewer metadata into `review-result.json` and renders it in the final review comment’s **Spec sources** line.
> 
> `scripts/build-review.sh` backfills `external_issue: null` for older `core-meta.json` outputs and updates the “Linked issue” display logic to show `#<gh>` plus the external ID when both exist, or the external ID alone when no GitHub issue is linked. Documentation and the `review-core` schema are updated to instruct `fetch-issue.sh` hooks to emit a parseable heading so the core reviewer can populate `external_issue`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f673f60ddfa5fc9b06d22847f6177f322641a43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->