### PR TITLE
Feat/pluggable tracker hook

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -26,6 +26,9 @@ on:
         required: false
       CLAUDE_REVIEW_APP_SLUG:
         required: false
+      TRACKER_SECRETS:
+        required: false
+        description: "Optional. Newline-separated KEY=VALUE pairs exposed as env vars to .github/claude-review/fetch-issue.sh. Populated from the caller repo's secret of the same name via `secrets: inherit`."
 
 jobs:
   review:
@@ -399,6 +402,182 @@ jobs:
             : > /tmp/prd-files.txt
             : > /tmp/prd-content.md
           fi
+
+      # Extract every recognized ticket-reference pattern from the branch name,
+      # PR title, and PR body into a structured candidates file. Provider-agnostic:
+      # we never hardcode a tracker's host or ID format. The optional hook script
+      # (next step) reads this file and decides which signal matches its tracker.
+      # Runs unconditionally — the file is always present and well-formed even when
+      # nothing matches, so downstream readers don't need a guard.
+      - name: Extract external-issue candidates
+        shell: bash
+        env:
+          # PR metadata flows through env vars (never inlined into run: via ${{ }})
+          # to avoid command injection from a maliciously-crafted PR body/title/branch.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          set -uo pipefail
+          # Pre-create /tmp/external-issue.md as empty so the context-builder skill's
+          # "ALWAYS read" invariant holds for pure-GitHub consumers (no hook script).
+          # The hook step below overwrites this on opt-in; otherwise it stays empty
+          # and Turn 6-7 omits the "Linked external issue" section.
+          : > /tmp/external-issue.md
+
+          python3 <<'PY'
+          import json, os, re
+
+          pr_title = os.environ.get('PR_TITLE') or ''
+          pr_body = os.environ.get('PR_BODY') or ''
+          head_ref = os.environ.get('HEAD_REF') or ''
+
+          TICKET_RE = re.compile(r'\b[A-Z][A-Z0-9]+-\d+\b')
+          URL_RE = re.compile(r'https?://[^\s)\]>]+')
+          URL_WITH_HOST_RE = re.compile(r'https?://([^/\s)\]>]+)')
+          # Lines like "Key: value" — we filter to values that contain a URL or
+          # ticket ID, otherwise every "Status: WIP" line becomes a marker.
+          LINE_MARKER_RE = re.compile(
+              r'^\s*([A-Za-z][A-Za-z0-9_-]*)\s*:\s*(.+?)\s*$',
+              re.MULTILINE,
+          )
+          # Closing-keyword style: "Fixes LIN-123", "Closes https://..."
+          CLOSING_RE = re.compile(
+              r'\b(fixes?|closes?|resolves?|implements?|refs?|tracks?)\s+'
+              r'(https?://\S+|[A-Z][A-Z0-9]+-\d+)',
+              re.IGNORECASE,
+          )
+
+          def strip_trailing_punct(s):
+              return s.rstrip('.,;:!?')
+
+          explicit_markers = []
+          closing_keywords = []
+          urls = []
+          ids = []
+
+          # Tier 1: explicit markers in PR body.
+          for key, value in LINE_MARKER_RE.findall(pr_body):
+              if URL_RE.search(value) or TICKET_RE.search(value):
+                  explicit_markers.append({
+                      'key': key,
+                      'value': value.strip(),
+                      'source': 'pr_body_line',
+                  })
+
+          # Tier 2: closing-keyword matches in PR body.
+          seen_closing = set()
+          for keyword, target in CLOSING_RE.findall(pr_body):
+              target = strip_trailing_punct(target)
+              sig = (keyword.lower(), target)
+              if sig in seen_closing:
+                  continue
+              seen_closing.add(sig)
+              closing_keywords.append({
+                  'keyword': keyword,
+                  'target': target,
+                  'source': 'pr_body',
+              })
+
+          # Tier 3: URLs in PR body, host exposed.
+          seen_urls = set()
+          for url in URL_RE.findall(pr_body):
+              url = strip_trailing_punct(url)
+              if url in seen_urls:
+                  continue
+              seen_urls.add(url)
+              m = URL_WITH_HOST_RE.match(url)
+              host = m.group(1) if m else ''
+              urls.append({'url': url, 'host': host, 'source': 'pr_body'})
+
+          # Tier 4: branch-name ticket tokens.
+          branch_seen = set()
+          for m in TICKET_RE.finditer(head_ref):
+              tok = m.group(0)
+              if tok in branch_seen:
+                  continue
+              branch_seen.add(tok)
+              ids.append({'id': tok, 'source': 'branch_name'})
+
+          # Tier 5: PR-body ticket tokens (dedup per-source).
+          body_seen = set()
+          for m in TICKET_RE.finditer(pr_body):
+              tok = m.group(0)
+              if tok in body_seen:
+                  continue
+              body_seen.add(tok)
+              ids.append({'id': tok, 'source': 'pr_body'})
+
+          # PR-title ticket tokens (dedup per-source). Titles often carry a
+          # `[LIN-123]` prefix; catching them here means a ticket mentioned only
+          # in the title still surfaces even if the branch naming convention
+          # isn't followed.
+          title_seen = set()
+          for m in TICKET_RE.finditer(pr_title):
+              tok = m.group(0)
+              if tok in title_seen:
+                  continue
+              title_seen.add(tok)
+              ids.append({'id': tok, 'source': 'pr_title'})
+
+          out = {
+              'explicit_markers': explicit_markers,
+              'closing_keywords': closing_keywords,
+              'urls': urls,
+              'ids': ids,
+          }
+          with open('/tmp/external-issue-candidates.json', 'w') as f:
+              json.dump(out, f, indent=2)
+
+          branch_ids = sum(1 for i in ids if i['source'] == 'branch_name')
+          body_ids = sum(1 for i in ids if i['source'] == 'pr_body')
+          title_ids = sum(1 for i in ids if i['source'] == 'pr_title')
+          print(
+              f"External-issue candidates: {len(explicit_markers)} markers, "
+              f"{len(closing_keywords)} keywords, {len(urls)} urls, "
+              f"{branch_ids} branch-ids, {body_ids} body-ids, {title_ids} title-ids"
+          )
+          PY
+
+      # Optional hook: if the consumer repo has a fetch-issue.sh script, run it
+      # with PR metadata + candidates-file path + TRACKER_SECRETS-derived env
+      # vars. Stdout is inlined into context.md as the external-spec section.
+      # Soft-fails — a bad credential or tracker outage must not block reviews.
+      # GH_TOKEN is deliberately NOT forwarded; consumers who need authenticated
+      # GitHub calls put their own PAT in TRACKER_SECRETS.
+      - name: Fetch external linked issue (optional hook)
+        if: hashFiles('.github/claude-review/fetch-issue.sh') != ''
+        continue-on-error: true
+        shell: bash
+        env:
+          # Untrusted PR inputs flow through env only (never ${{ }} in run:).
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          HEAD_REF: ${{ github.head_ref }}
+          BASE_REF: ${{ github.base_ref }}
+          REPO: ${{ github.repository }}
+          ISSUE_CANDIDATES_FILE: /tmp/external-issue-candidates.json
+          TRACKER_SECRETS: ${{ secrets.TRACKER_SECRETS }}
+        run: |
+          set -uo pipefail
+          # Expose each KEY=VALUE line of TRACKER_SECRETS as an env var to the
+          # script. Consumers pick their own names ($LINEAR_API_KEY, $JIRA_EMAIL,
+          # whatever). Blank lines and `# comments` are skipped; everything after
+          # the first `=` is preserved verbatim so tokens containing `=` survive.
+          if [ -n "${TRACKER_SECRETS:-}" ]; then
+            while IFS= read -r line; do
+              case "$line" in ''|'#'*) continue ;; esac
+              [[ "$line" != *=* ]] && continue
+              export "${line%%=*}=${line#*=}"
+            done <<< "$TRACKER_SECRETS"
+          fi
+          chmod +x .github/claude-review/fetch-issue.sh
+          .github/claude-review/fetch-issue.sh > /tmp/external-issue.md 2> /tmp/fetch-issue.stderr || {
+            echo "::warning::fetch-issue.sh exited non-zero — continuing without external spec"
+            cat /tmp/fetch-issue.stderr >&2 || true
+            : > /tmp/external-issue.md
+          }
 
       - name: 'Review: build context'
         id: context_builder

--- a/README.md
+++ b/README.md
@@ -238,6 +238,82 @@ Authentication for functional testing:
 | Web | http://localhost:3000 | |
 ```
 
+### `.github/claude-review/fetch-issue.sh` (optional — external issue trackers)
+
+The default spec sources are the linked GitHub issue and any `docs/prds/*.md` referenced from the PR/issue body. Repos that track specs in Linear, Jira, Monday, Notion, etc. can opt into a hook that fetches the external spec and includes it in `context.md` alongside the GitHub one. **No provider is built in here** — the consumer owns the script and picks whatever API call makes sense for their tracker.
+
+Three steps to opt in:
+
+**1. Create a repo secret `TRACKER_SECRETS`** with your credentials in `KEY=VALUE` lines (blank lines and `# comments` are skipped). Pick any names that make sense for your tracker — the workflow exports each line as an env var to your script:
+
+```
+LINEAR_API_KEY=lin_api_xxxxx
+LINEAR_WORKSPACE=panenco
+```
+
+**2. Drop `.github/claude-review/fetch-issue.sh`**. Adapt the `jq` filters and the `curl` call to your tracker:
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+
+# 1. Pick the best ticket reference from the pre-extracted candidates.
+#    Prefer explicit markers, then URLs whose host matches your tracker, then
+#    keyword-qualified targets, then bare IDs. Exit 0 with no output if nothing
+#    matches — that's a normal case, the workflow handles it cleanly.
+TICKET=$(jq -r '
+    [.explicit_markers[] | select(.key | ascii_downcase == "<your-tracker>") | .value][0]
+    // [.urls[] | select(.host == "<your-tracker-host>") | .url][0]
+    // [.closing_keywords[] | .target][0]
+    // [.ids[] | .id][0]
+    // empty
+  ' "$ISSUE_CANDIDATES_FILE")
+[ -z "${TICKET:-}" ] && exit 0
+
+# 2. Fetch from your tracker using env vars you set via TRACKER_SECRETS.
+curl -sS --fail-with-body "<your-tracker-api-url>" \
+  -H "Authorization: $YOUR_API_KEY" \
+  -H "Accept: application/json" \
+| jq -r '"# " + .title + "\n\n" + .description'
+```
+
+**3. (Optional, recommended) Add a `Ticket:` line to your PR template** so authors paste the tracker URL — this lands in the highest-confidence bucket:
+
+```
+Ticket: https://linear.app/team/issue/LIN-123/...
+```
+
+#### Contract
+
+```
+Script:  .github/claude-review/fetch-issue.sh  (presence = opt-in)
+Env in:
+  PR_NUMBER, PR_TITLE, PR_BODY, HEAD_REF, BASE_REF, REPO    (always set)
+  ISSUE_CANDIDATES_FILE=/tmp/external-issue-candidates.json  (always set)
+  <anything you put in TRACKER_SECRETS>                      (your chosen names)
+Stdout:  markdown. Inlined verbatim under "## Linked external issue" in context.md.
+Exit:    0 with output     = success.
+         0 with no output  = no external issue for this PR (normal).
+         non-zero          = soft-fail: ::warning:: logged, review continues.
+```
+
+`GH_TOKEN` is deliberately **not** forwarded. If your script needs authenticated GitHub calls, add your own PAT via `TRACKER_SECRETS`.
+
+#### `$ISSUE_CANDIDATES_FILE` schema
+
+A workflow step scans the branch name, PR title, and PR body for every recognized ticket-reference pattern and writes the result here before your script runs. The file is always present and always valid JSON (empty arrays when nothing matches). Your script picks the signal that matches your tracker.
+
+```json
+{
+  "explicit_markers": [{"key": "Linear", "value": "LIN-123", "source": "pr_body_line"}],
+  "closing_keywords": [{"keyword": "Fixes", "target": "LIN-123", "source": "pr_body"}],
+  "urls":             [{"url": "https://linear.app/...", "host": "linear.app", "source": "pr_body"}],
+  "ids":              [{"id": "LIN-123", "source": "branch_name"}]
+}
+```
+
+Confidence tiers (in extraction priority order): (1) `explicit_markers` — `Ticket: …` / `<Provider>: …` lines in the PR body; (2) `closing_keywords` — `Fixes LIN-123` / `Closes https://…`; (3) `urls` in the PR body (host exposed so you can filter); (4) `ids` from the branch name; (5) `ids` from the PR body without a keyword; (6) `ids` from the PR title (often a `[LIN-123]` prefix). Source field on each `ids` entry is one of `branch_name`, `pr_body`, `pr_title`.
+
 ---
 
 ## Degradation Matrix
@@ -245,6 +321,7 @@ Authentication for functional testing:
 | Missing file | Impact | Behavior |
 |---|---|---|
 | `.github/claude-review/dev-start.sh` | Expected for degraded mode | Functional tester skipped. Core + sweep reviewers still run. |
+| `.github/claude-review/fetch-issue.sh` | Expected when only GitHub is used | Skipped silently. GitHub-issue lookup remains the default spec source. |
 | `review-config.md` | Reduced | No build prep doc, no convention-rule routing, no Known-service-ports URLs to probe, no auth setup. |
 | `bugbot.md` | Minor | Reviewers use generic methodology only (no project-specific rules, no accepted-trade-offs exemptions). |
 | `CLAUDE.md` | Minor | No architecture context. Reviewers rely on diff + issue. |

--- a/README.md
+++ b/README.md
@@ -292,6 +292,12 @@ Env in:
   ISSUE_CANDIDATES_FILE=/tmp/external-issue-candidates.json  (always set)
   <anything you put in TRACKER_SECRETS>                      (your chosen names)
 Stdout:  markdown. Inlined verbatim under "## Linked external issue" in context.md.
+         For best results, make the first line a heading that surfaces the
+         tracker identifier, e.g. "## Linked Linear issue: LIN-123" — the
+         core reviewer extracts this into spec_sources.external_issue so
+         the final review summary can show the tracker ID alongside any
+         GitHub #N link. Omit the identifier and external_issue stays null;
+         the section body is still read for acceptance-criteria extraction.
 Exit:    0 with output     = success.
          0 with no output  = no external issue for this PR (normal).
          non-zero          = soft-fail: ::warning:: logged, review continues.

--- a/prompts/setup-review.md
+++ b/prompts/setup-review.md
@@ -208,6 +208,35 @@ Rules:
 
 If the project has no services to start (pure-docs repo, lib-only package), do **not** create this file. Its absence triggers degraded mode (core + sweep reviewers run; no functional tester). An empty-but-present `dev-start.sh` will fail the step — either commit a real one or don't commit one at all.
 
+## Step 4.6: External issue tracker (optional)
+
+The default spec sources are the linked GitHub issue and any `docs/prds/*.md` referenced from it. Repos that track specs in Linear / Jira / Monday / Notion / etc. can opt into an extra hook that fetches the external spec and includes it in the reviewer's context. The pipeline ships **no provider-specific code** — the consumer owns the script and the API call.
+
+Walk through this decision even if the project looks GitHub-only; confirm it explicitly so you don't leave a Linear-using repo silently missing spec context.
+
+1. **Detect passively.** Look for tracker evidence without asking first:
+   - `README.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE*`, `.github/ISSUE_TEMPLATE/*` — grep for `linear.app`, `*.atlassian.net`, `jira.`, `monday.com`, `notion.so`, `app.clickup.com`, `app.shortcut.com`, `app.asana.com`.
+   - Recent PR bodies and branch names: `gh pr list --json body,headRefName --limit 20` — look for the same hosts plus any recurring `[A-Z]+-\d+` token convention in branch names.
+   - Note what you found (or didn't) for the user.
+
+2. **Confirm with the user.** Use `AskUserQuestion` to ask:
+   > "Does this repo track specs in an external system (Linear / Jira / Monday / Notion / other)? If yes, which? If no, choose **GitHub only**."
+   Ask this whether detection succeeded or not — a grep hit might be a one-off link, and a miss might just mean the history is sparse. The user's answer wins.
+
+3. **If GitHub only** — print "No tracker integration needed. Skipping." and go to Step 5. Do not create `fetch-issue.sh` and do not list any extra secrets.
+
+4. **If a tracker was chosen** — do NOT generate the hook script or any tracker code yourself. Output three concrete to-dos for the user to complete:
+
+   - "**Add a repo secret named `TRACKER_SECRETS`** with your credentials in newline-separated `KEY=VALUE` form. For `<chosen tracker>`, a typical minimum is something like:
+     ```
+     <PROVIDER>_API_KEY=<your key>
+     ```
+     Get your key at `<the provider's API-key page URL>`."
+   - "**Create `.github/claude-review/fetch-issue.sh`**. It reads `$ISSUE_CANDIDATES_FILE` (pre-extracted ticket references), calls your tracker, and prints markdown to stdout. See the README section **External issue trackers** (`.github/claude-review/fetch-issue.sh`) for the full contract, the candidates-file schema, and a provider-neutral skeleton to adapt."
+   - "**Optional but recommended:** add a `Ticket: <url>` line to your PR template so authors paste the tracker URL into every PR — this gives the highest-confidence lookup (Tier-1 explicit marker)."
+
+   Emphasize: `fetch-issue.sh` must be committed and `chmod +x`'d. Without `TRACKER_SECRETS` the hook runs but every env var the script references is empty, and the script will soft-fail on the first `curl` — the Actions log will show a `::warning::`.
+
 ### Auth
 
 Document how to authenticate for testing:
@@ -288,7 +317,7 @@ If any check fails, fix before committing. The pipeline's reviewer will catch th
 
 ## Step 6: Verify secrets and App install
 
-Three secrets + one app install decision. **The install and the secrets are independent — miss either and the workflow breaks in a different way.** Walk through all four:
+Three required secrets, one optional tracker secret, and one App install decision. **The install and the secrets are independent — miss either and the workflow breaks in a different way.** Walk through the required set, then confirm the optional fourth if Step 4.6 opted in:
 
 1. `CLAUDE_CODE_OAUTH_TOKEN` (required) — generate with `claude setup-token` and add as a repo or org secret. Without it the workflow fails at the first step with `::error::CLAUDE_CODE_OAUTH_TOKEN secret is not configured.`
 
@@ -303,6 +332,8 @@ Three secrets + one app install decision. **The install and the secrets are inde
    | Both set correctly | "Create GitHub App token" = `success`, "Resolve review identity" logs `Review identity: panenco-claude-reviewer[bot]`. |
 
    Verify after the first PR run by opening the job log and grepping for `Review identity:` — it should print the App slug, not `github-actions`.
+
+4. `TRACKER_SECRETS` (optional, required only if Step 4.6 opted into an external tracker) — single multiline secret with newline-separated `KEY=VALUE` pairs that your `fetch-issue.sh` will read as env vars. Without it, the hook runs but every env var the script references is empty — the Actions log will show a `::warning::` from `fetch-issue.sh`, the review completes without external-spec context.
 
 ## Step 7: Test
 

--- a/scripts/build-review.sh
+++ b/scripts/build-review.sh
@@ -349,7 +349,7 @@ jq -n \
     verdict: $verdict,
     summary: $summary,
     spec_compliance: $spec_compliance,
-    spec_sources: ($meta.spec_sources // {linked_issue: null, prd_path: null, convention_rules: []}),
+    spec_sources: ($meta.spec_sources // {linked_issue: null, external_issue: null, prd_path: null, convention_rules: []}),
     findings: $findings,
     requires_human_review: ($meta.requires_human_review // false),
     requires_human_review_reason: ($meta.requires_human_review_reason // null),
@@ -366,13 +366,28 @@ jq -n \
   }' > review-result.json
 
 # ── Build /tmp/review-body.md ──
+# `linked_issue` is the GitHub-native issue number (from closingIssuesReferences).
+# `external_issue` is the tracker identifier (e.g. ABC-123) surfaced by the
+# consumer's optional fetch-issue.sh hook. Show #N when present, otherwise the
+# external identifier, falling back to "none found" only when neither exists.
 ISSUE=$(jq -r '.spec_sources.linked_issue // "none found"' review-result.json)
+EXTERNAL=$(jq -r '.spec_sources.external_issue // empty' review-result.json)
 {
   echo "## Claude PR Review — $VERDICT"
   echo ""
   echo "### Spec sources"
   echo ""
-  echo "- Linked issue: $([ "$ISSUE" != "null" ] && [ "$ISSUE" != "none found" ] && echo "#$ISSUE" || echo "none found")"
+  if [ "$ISSUE" != "null" ] && [ "$ISSUE" != "none found" ]; then
+    if [ -n "$EXTERNAL" ] && [ "$EXTERNAL" != "null" ]; then
+      echo "- Linked issue: #$ISSUE (external tracker: $EXTERNAL)"
+    else
+      echo "- Linked issue: #$ISSUE"
+    fi
+  elif [ -n "$EXTERNAL" ] && [ "$EXTERNAL" != "null" ]; then
+    echo "- Linked issue: $EXTERNAL (external tracker)"
+  else
+    echo "- Linked issue: none found"
+  fi
   RULES=$(jq -r '.spec_sources.convention_rules // [] | map("`\(.)`") | join(", ")' review-result.json)
   echo "- Convention rules: ${RULES:-none identified}"
   echo ""

--- a/skills/review-context-builder.md
+++ b/skills/review-context-builder.md
@@ -518,6 +518,7 @@ Issue a single turn with parallel Read calls for ALL of these:
 - `/tmp/issue.json` (if it exists)
 - `/tmp/project-card.json` (if it exists)
 - **`/tmp/prd-content.md`** — ALWAYS read this file. If non-empty, it contains the full content of the linked PRD (auto-detected by a prior workflow step). PRDs are the authoritative spec: field definitions, validation rules, default values, status transitions. You MUST include it verbatim in context.md under a `## PRD` section. If empty, note "No PRD linked."
+- **`/tmp/external-issue.md`** — ALWAYS read this file. If non-empty, the consumer repo has an optional `.github/claude-review/fetch-issue.sh` hook that fetched spec content from an external tracker (Linear, Jira, Monday, etc.). Include it verbatim in context.md under a `## Linked external issue` section. If empty, skip the section entirely — do not render an empty heading.
 - `.github/review-config.md` (if it exists)
 - `CLAUDE.md`
 
@@ -580,7 +581,8 @@ Check `.github/review-config.md` for build preparation commands. Run them, then 
 - Full diff content (or summary if >800 lines)
 - Linked issue number + full issue body (or "none found")
 - **PRD content** — paste the full content of `/tmp/prd-content.md` verbatim. This is the authoritative spec: field definitions, validation rules, default values, status transitions, UI expectations. Reviewers and the functional tester use it for precise spec-mismatch detection. If empty, note "No PRD linked."
-- **Acceptance criteria** — extract from issue body AND PRD (if available): checkboxes, "should/must/needs to" statements, sections titled "Acceptance Criteria", field definitions, validation rules, default values. If none found, extract intent from PR title + body as 2-3 bullet points.
+- **Linked external issue** — if `/tmp/external-issue.md` is non-empty, add a `## Linked external issue` section with its content verbatim. This is spec content fetched by the consumer's optional tracker hook (Linear/Jira/Monday/etc.) and should be treated as spec-authoritative alongside the PRD and the GitHub issue. If empty, omit the section entirely — do not render an empty heading.
+- **Acceptance criteria** — extract from issue body, PRD, AND the external-issue content (if available): checkboxes, "should/must/needs to" statements, sections titled "Acceptance Criteria", field definitions, validation rules, default values. If none found, extract intent from PR title + body as 2-3 bullet points.
 - GitHub Projects v2 card fields (if available)
 - Review config: stack-specific focus areas from `.github/review-config.md` (if exists)
 - Convention rules: which files apply and their full content

--- a/skills/review-core.md
+++ b/skills/review-core.md
@@ -130,6 +130,7 @@ Do NOT set it for:
   "spec_compliance": "Brief statement of spec alignment (1-2 sentences).",
   "spec_sources": {
     "linked_issue": 42,
+    "external_issue": "ABC-123",
     "prd_path": "path or null",
     "convention_rules": ["rules applied"]
   }
@@ -137,6 +138,7 @@ Do NOT set it for:
 ```
 
 - `spec_compliance` is ALWAYS filled in — even when there are findings. Summarizes what the PR does right or wrong vs the spec.
-- `spec_sources` extracts the linked issue number, PRD path, and which convention rules applied — read these from context.md. Use `null` for missing values.
+- `spec_sources` extracts the linked issue number, external tracker identifier, PRD path, and which convention rules applied — read these from context.md. Use `null` for missing values.
+- `external_issue` is the tracker identifier (e.g. `ABC-123`, `ENG-214`, `MON-1234`) surfaced by the consumer's optional `.github/claude-review/fetch-issue.sh` hook. Parse it from the heading at the top of the `## Linked external issue` section in context.md — the hook convention is `## Linked <tracker> issue: <IDENTIFIER>` as its first line. If the section is absent or no identifier can be parsed, set to `null`.
 
 Write `[]` for empty findings. ALWAYS write both files.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds an optional workflow hook that executes a repo-provided script with injected secrets to fetch external spec content; while soft-failing, it touches CI orchestration and secret/env handling so misconfiguration or unsafe scripts could impact review runs.
> 
> **Overview**
> The review workflow now **optionally enriches spec context from external trackers** via a consumer-provided `.github/claude-review/fetch-issue.sh`, fed by a new `TRACKER_SECRETS` secret and a generated `/tmp/external-issue-candidates.json` extracted from branch/title/body.
> 
> Pipeline outputs are updated to **carry and display an `external_issue` identifier** alongside the linked GitHub issue (JSON + rendered review body), and the context-builder/core-reviewer skills now always read `/tmp/external-issue.md` and incorporate it (when non-empty) as a spec source and acceptance-criteria input.
> 
> Docs (`README.md`, `prompts/setup-review.md`) document the hook contract, secret format, candidates schema, and degraded behavior when the hook is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da29c70d5342482b4d55bebe30d3ed6ce5b054e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->