### PR TITLE
docs(setup-review): add external-org track + required permissions block

### DIFF
--- a/prompts/setup-review.md
+++ b/prompts/setup-review.md
@@ -60,6 +60,18 @@ jobs:
     # under "Accepted supply-chain trade-offs" so the reviewer does not
     # re-flag `@v1 + secrets: inherit` on every PR.
     uses: panenco/claude-review/.github/workflows/pr-review.yml@v1
+    # Grant the reusable workflow the write scopes it needs. Reusable
+    # workflows cannot elevate permissions above the caller, and GitHub's
+    # default `GITHUB_TOKEN` since 2023 is read-only at both org and repo
+    # level. Without this block the run fails at startup with `startup_failure`,
+    # zero jobs, and no downloadable logs — extremely painful to debug.
+    # Required scopes: `contents: write` (push screenshots to the
+    # review-assets branch), `pull-requests: write` + `issues: write`
+    # (post reviews and comments).
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     with:
       pr_number: ${{ inputs.pr_number || '' }}
     secrets: inherit
@@ -68,7 +80,21 @@ jobs:
 Note: the `concurrency:` block and the `if:` draft guard are required — omitting
 either causes recurring reviewer noise (cursor-style bots flag missing concurrency
 alongside all other repo workflows, and the pipeline re-runs on every `synchronize`
-against draft PRs, wasting budget).
+against draft PRs, wasting budget). The `permissions:` block is also required;
+its omission is the #1 startup failure for repos in orgs with the GitHub-default
+read-only `GITHUB_TOKEN` scope (see inline comment above).
+
+**If `secrets: inherit` fails with `Secret CLAUDE_CODE_OAUTH_TOKEN is required, but not provided while calling`** — even though the secret is clearly set on the repo — swap `inherit` for the explicit form as a fallback:
+
+```yaml
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      CLAUDE_REVIEW_APP_ID: ${{ secrets.CLAUDE_REVIEW_APP_ID }}
+      CLAUDE_REVIEW_APP_PRIVATE_KEY: ${{ secrets.CLAUDE_REVIEW_APP_PRIVATE_KEY }}
+      CLAUDE_REVIEW_APP_SLUG: ${{ secrets.CLAUDE_REVIEW_APP_SLUG }}
+```
+
+This has been observed on same-repo PRs in at least one external org and is likely caused by an org-level policy interacting with `inherit`. The explicit form unblocks the run; root cause can be investigated later.
 
 ## Step 3: Create bugbot.md
 
@@ -317,23 +343,79 @@ If any check fails, fix before committing. The pipeline's reviewer will catch th
 
 ## Step 6: Verify secrets and App install
 
-Three required secrets, one optional tracker secret, and one App install decision. **The install and the secrets are independent — miss either and the workflow breaks in a different way.** Walk through the required set, then confirm the optional fourth if Step 4.6 opted in:
+The OAuth token is required for every repo; the App-token path is how reviews get posted under a branded bot identity instead of `github-actions[bot]`. **Which track you follow depends on whether the repo is inside the Panenco org or external.** Pick one:
+
+### Track A — Repos inside the Panenco org (short path)
 
 1. `CLAUDE_CODE_OAUTH_TOKEN` (required) — generate with `claude setup-token` and add as a repo or org secret. Without it the workflow fails at the first step with `::error::CLAUDE_CODE_OAUTH_TOKEN secret is not configured.`
 
-2. `CLAUDE_REVIEW_APP_ID`, `CLAUDE_REVIEW_APP_PRIVATE_KEY`, `CLAUDE_REVIEW_APP_SLUG` (optional, recommended for orgs) — set all three as org secrets with "All repositories" visibility so new repos inherit them automatically via `secrets: inherit`. Without them the workflow still runs but posts as `github-actions[bot]`.
+2. `CLAUDE_REVIEW_APP_ID`, `CLAUDE_REVIEW_APP_PRIVATE_KEY`, `CLAUDE_REVIEW_APP_SLUG` (recommended) — these are typically already set as **Panenco org secrets** with "All repositories" visibility, so `secrets: inherit` picks them up automatically for any new repo. If they're not, ask a Panenco org owner to add them once, org-wide.
 
-3. **Install the `panenco-claude-reviewer` GitHub App on the target repo (or org-wide, matching #2)**. This is separate from the secrets and both are required. Symptoms when each is missing:
+3. **Install the `panenco-claude-reviewer` App on the repo** (already org-installed in most cases — the app lives inside Panenco). Go to `github.com/organizations/Panenco/settings/installations` → `panenco-claude-reviewer` → Configure → add the repo if not already covered by "All repositories".
 
-   | Missing | Failure mode |
-   |---|---|
-   | Secrets only | "Create GitHub App token" step is **skipped** → `github-actions[bot]` posts the review. |
-   | Secrets set, App not installed on repo | "Create GitHub App token" step **fails** with `RequestError [HttpError]: Not Found` / `Failed to create token for "<repo>": Not Found`. Downstream steps skip or abort. Fix: go to `github.com/organizations/<org>/settings/installations` → `panenco-claude-reviewer` → Configure → add the repo (or switch to "All repositories"). |
-   | Both set correctly | "Create GitHub App token" = `success`, "Resolve review identity" logs `Review identity: panenco-claude-reviewer[bot]`. |
+Verify after the first PR run: the job log should contain `Review identity: panenco-claude-reviewer[bot]`.
 
-   Verify after the first PR run by opening the job log and grepping for `Review identity:` — it should print the App slug, not `github-actions`.
+### Track B — Repos outside the Panenco org (external-org path)
 
-4. `TRACKER_SECRETS` (optional, required only if Step 4.6 opted into an external tracker) — single multiline secret with newline-separated `KEY=VALUE` pairs that your `fetch-issue.sh` will read as env vars. Without it, the hook runs but every env var the script references is empty — the Actions log will show a `::warning::` from `fetch-issue.sh`, the review completes without external-spec context.
+The shared Panenco app can't be installed on a different org (its visibility is typically private to Panenco). You create your own GitHub App in the external org, wire up the same four secrets pointing at *your* app, and install *your* app on the repo.
+
+**Step B1 — Create your own GitHub App in the external org.**
+
+Go to `github.com/organizations/<your-org>/settings/apps` → **New GitHub App**. Fill in:
+
+- **GitHub App name** — anything, e.g. `<org>-claude-reviewer`. Must be globally unique across GitHub. The URL slug is auto-derived from this name (lowercased, spaces → hyphens, apostrophes stripped) — this slug becomes the value of `CLAUDE_REVIEW_APP_SLUG`.
+- **Homepage URL** — anything; not used by the pipeline.
+- **Webhook** — uncheck **Active**. The pipeline calls GitHub's API; it does not receive webhook events.
+- **Repository permissions** — set exactly these:
+
+  | Permission | Access |
+  |---|---|
+  | Contents | Read |
+  | Pull requests | Read and write |
+  | Issues | Read and write |
+  | Metadata | Read (auto-selected) |
+
+  A freshly-created App defaults to **No permissions**. The pipeline's "Create GitHub App token" call will succeed against a no-perms App (it just issues an empty-scope token), but subsequent API calls — posting reviews, pushing assets — silently fail. Set all four above before installing.
+
+- **Where can this GitHub App be installed?** — "Only on this account".
+
+Create, then on the App's settings page:
+
+1. Note the **App ID** at the top (integer, e.g. `3442056`) — this is `CLAUDE_REVIEW_APP_ID`.
+2. Click **Generate a private key** — downloads a `.pem` file. Its full contents (including `-----BEGIN RSA PRIVATE KEY-----` and `-----END RSA PRIVATE KEY-----` lines) become `CLAUDE_REVIEW_APP_PRIVATE_KEY`.
+3. Record the slug from the App's settings URL (`github.com/organizations/<org>/settings/apps/<slug>`) — this becomes `CLAUDE_REVIEW_APP_SLUG`.
+
+**Step B2 — Set the four secrets on the target repo (or external org).**
+
+- `CLAUDE_CODE_OAUTH_TOKEN` — generate with `claude setup-token`.
+- `CLAUDE_REVIEW_APP_ID`, `CLAUDE_REVIEW_APP_PRIVATE_KEY`, `CLAUDE_REVIEW_APP_SLUG` — from Step B1.
+
+**Step B3 — Install your App on the target repo.**
+
+In the App's left sidebar click **Install App** → choose the external org → pick "All repositories" or select the target repo.
+
+**Then verify on the installation page (`github.com/organizations/<your-org>/settings/installations` → `<your-app>` → Configure) that BOTH fields are correctly populated:**
+
+- **Repository access** — shows the target repo (or "All repositories"). If it says "No repositories", the App is technically "installed" but can't act on anything; the token call returns `Not Found`.
+- **Permissions** — shows the four permissions from Step B1. If it says "No permissions", you created the App without setting them and need to go back to App settings → Permissions & events → add them → request/approve new permissions on the installation.
+
+It is common to fix one and miss the other on a first setup; the installation page surfaces both in the same view. Check both before re-running.
+
+### Symptom table (both tracks)
+
+| Missing / misconfigured | Failure mode |
+|---|---|
+| `CLAUDE_CODE_OAUTH_TOKEN` | First step fails: `::error::CLAUDE_CODE_OAUTH_TOKEN secret is not configured.` |
+| `CLAUDE_REVIEW_APP_*` secrets | "Create GitHub App token" step is **skipped** → `github-actions[bot]` posts the review. Functionally OK, just the wrong identity. |
+| `CLAUDE_REVIEW_APP_*` secrets set, App not installed on repo | "Create GitHub App token" step **fails** with `RequestError [HttpError]: Not Found` / `Failed to create token for "<repo>": Not Found`. Fix: add the repo under the installation's Repository access. |
+| App installed but with "No repositories" | Same `Not Found` as above. Installation record exists but is empty. |
+| App installed but with "No permissions" | Token creation **succeeds**, posting the review **fails** with 403s in later steps. Fix: add Contents R / Pull requests RW / Issues RW / Metadata R in App settings, then approve the updated permissions on the installation. |
+| Caller workflow missing `permissions:` block | `startup_failure`, zero jobs, no logs. Happens when the org's default `GITHUB_TOKEN` is read-only. Fix: add the `permissions:` block from Step 2. |
+| All correct | "Create GitHub App token" = `success`, "Resolve review identity" logs `Review identity: <your-app-slug>[bot]`. |
+
+### `TRACKER_SECRETS` (optional, for Step 4.6 opt-in)
+
+Single multiline secret with newline-separated `KEY=VALUE` pairs that your `fetch-issue.sh` reads as env vars. Without it, the hook runs but every referenced env var is empty — the Actions log will show a `::warning::` from `fetch-issue.sh`, and the review completes without external-spec context.
 
 ## Step 7: Test
 


### PR DESCRIPTION
## Summary

Three changes driven by friction setting this pipeline up on an external-org repo (`FaunosAI/faunos`). All doc-only; no pipeline behaviour changes.

1. **Caller-workflow template now includes a `permissions:` block.** Without it, repos in orgs whose default `GITHUB_TOKEN` is read-only (GitHub's post-2023 default) fail at startup with `startup_failure`, zero jobs, and no downloadable logs — an extremely painful debug path. Reusable workflows cannot elevate permissions above the caller, so the `permissions:` has to live on the caller side. Added the three required scopes (`contents: write`, `pull-requests: write`, `issues: write`) to the Step 2 template with an explanatory inline comment.

2. **`secrets: inherit` fallback documented.** Observed on a same-repo PR in an external org: `inherit` failed with `Secret CLAUDE_CODE_OAUTH_TOKEN is required, but not provided while calling` even though the secret was clearly set on the repo. Swapping to the explicit `secrets: <name>: ${{ secrets.<name> }}` form unblocks it. Root cause likely an org-level policy quirk interacting with `inherit`; documented as a fallback for now rather than deep-diving.

3. **Step 6 split into Track A (Panenco-internal, short path) and Track B (external org, full self-hosted setup).** The previous single flow implicitly assumed the `panenco-claude-reviewer` App was installable from every org, which isn't true when the App's visibility is scoped to Panenco only. Track B spells out:
   - creating a GitHub App in the external org
   - the exact repository-permission checklist the App needs (`Contents` R, `PRs` RW, `Issues` RW, `Metadata` R) — a freshly-created App defaults to no permissions and the failure mode is subtle (token call succeeds; subsequent API calls 403)
   - that the slug is auto-derived from the App name, and names are globally unique
   - the two-field check on the installation page (Repository access AND Permissions), since it's common to fix one and miss the other on a first setup

Expanded the symptom table with the new failure modes: "No permissions" on the installation, "No repositories" on the installation, and the startup_failure from a missing `permissions:` block.

## Test plan

- [ ] A second-time reader of setup-review.md (external org) can go from zero to a green review in one pass without hitting the startup_failure, 404-on-token, or no-permissions cliffs
- [ ] Panenco-internal repos continue to follow the short Track A path unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this is documentation-only, but it changes the recommended GitHub Actions `permissions`/secret setup guidance which could affect adopters’ workflow configuration if misunderstood.
> 
> **Overview**
> Updates `prompts/setup-review.md` to make the caller workflow template include an explicit `permissions:` block (`contents: write`, `pull-requests: write`, `issues: write`) to avoid reusable-workflow `startup_failure` in orgs with read-only default `GITHUB_TOKEN` scopes.
> 
> Adds troubleshooting guidance for cases where `secrets: inherit` doesn’t pass required secrets, including an explicit secrets mapping fallback.
> 
> Reworks Step 6 into two setup tracks: a Panenco-internal path using the existing `panenco-claude-reviewer` app and an external-org path that walks through creating/permissioning/installing a new GitHub App, plus an expanded symptom/failure-mode table (including “no repositories”, “no permissions”, and missing `permissions:` block).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 997396909d9419bd646a559de5706098abd1015b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->