### PR TITLE
ci+skill+setup: pre-warm MCP + guard linked_issue + document dev-stack extras

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -700,6 +700,23 @@ jobs:
           MCPEOF
           sed -i 's/^[[:space:]]*//' /tmp/mcp-playwright.json
 
+          # Pre-warm the @playwright/mcp npm cache. The functional tester's
+          # `npx @playwright/mcp@latest ...` spawn happens inside Claude
+          # Code CLI's MCP-init timeout window. With a heavy consumer dev
+          # stack (multiple Node services + emulators competing for
+          # disk/network during the tester's launch), the first cold
+          # `npm install` of @playwright/mcp + its Playwright deps can
+          # exceed that window, leaving the tester with no MCP tools
+          # registered — it reports "ToolSearch for mcp__playwright__*
+          # returned no matches (MCP server did not connect)" and falls
+          # back to static analysis with zero screenshots. Running `--help`
+          # here downloads + caches the package now, so the later npx spawn
+          # hits the cache and completes within Claude's init timeout.
+          # Non-fatal on failure: the tester still runs, just without the
+          # cache warmed.
+          npx --yes @playwright/mcp@latest --help > /dev/null 2>&1 \
+            || echo "::warning::Pre-warm of @playwright/mcp failed — functional tester may hit MCP init timeout under heavy runner load."
+
       # Pre-start dev environment for functional testing.
       - name: Pre-start dev environment for test runner
         if: steps.code_check.outputs.needs_build == 'true' && steps.install.outputs.install_ok == 'true' && steps.check_context.outputs.exists == 'true'

--- a/prompts/setup-review.md
+++ b/prompts/setup-review.md
@@ -234,6 +234,50 @@ Rules:
 
 If the project has no services to start (pure-docs repo, lib-only package), do **not** create this file. Its absence triggers degraded mode (core + sweep reviewers run; no functional tester). An empty-but-present `dev-start.sh` will fail the step — either commit a real one or don't commit one at all.
 
+### Common extras (add only when the repo actually needs them)
+
+These aren't generic enough for the scaffold above, but are common enough to keep hitting — recognize the shape and fold the snippet in when the repo has the prerequisite. Do not add any of these blindly.
+
+- **AWS SDK against LocalStack.** If the backend talks to LocalStack (DynamoDB / SNS / SQS / S3), the AWS SDK's credential provider chain still runs on every call. A runner with no `~/.aws` and no env-var creds raises `CredentialsProviderError: Could not load credentials from any providers` and the service either loops on retry or crashes on startup. LocalStack accepts anything, so stub:
+  ```bash
+  export AWS_ACCESS_KEY_ID=test
+  export AWS_SECRET_ACCESS_KEY=test
+  export AWS_REGION=<your-region>   # must match what the app's config expects
+  ```
+  Put this in the service's env line or export it at the top of the script, before the service boots.
+
+- **Firebase auth emulator for apps that verify Firebase JWTs.** If the backend's auth stack is Firebase, the functional tester can't sign in against real Firebase from a runner (no whitelisted OAuth redirect for `localhost`). Bring up the emulator instead and point the backend at it via `FIREBASE_AUTH_EMULATOR_HOST`. Requires `firebase.json` + `.firebaserc` checked in and `firebase-tools` installed (dev-dep or global). Skeleton:
+  ```bash
+  # Start the auth emulator (port from firebase.json; 59099 is a common override).
+  pnpm firebase emulators:start --only auth --project <your-project-id> > /tmp/firebase.log 2>&1 &
+  FB_READY=false
+  for i in $(seq 1 60); do
+    # Any HTTP response (even 404) means the emulator bound the port.
+    curl -s -o /dev/null --max-time 2 -w '%{http_code}' http://127.0.0.1:<port>/ | grep -qE '^[0-9]+$' \
+      && { FB_READY=true; break; }
+    sleep 2
+  done
+  [ "$FB_READY" = "true" ] || { echo "::error::Firebase emulator never bound within 120s"; tail -n 200 /tmp/firebase.log; exit 1; }
+
+  # Then boot the backend with FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:<port>.
+  ```
+  With the emulator running, any email/password combo signs in successfully — the tester can create a test user via your `/auth/sign-up` endpoint and reach authenticated pages without a real Google account.
+
+- **Vite dev server mode selection.** If `apps/web/.env.development` points `VITE_API_BASE_URL` at a *hosted* dev API (the common case), starting Vite in its default mode makes the tester talk to the hosted API from the runner — which typically fails auth or hits rate limits. Add an `.env.test` (or similar) with URLs pointing at `127.0.0.1:<port>` and start Vite with `--mode test` so it loads that env file:
+  ```bash
+  pnpm --filter <web-app> start:test   # or: vite --host --mode test
+  ```
+  The generic rule: pick the Vite mode whose env file points at the local backend you just started. Same pattern applies to Next.js (`NEXT_PUBLIC_API_URL` in `.env.local`), CRA (`REACT_APP_API_URL`), etc.
+
+- **Detaching background services correctly.** GitHub-hosted runners SIGKILL every process in the step's process group at step-end, so a plain `pnpm start &` does **not** survive into the tester's step — by the time the tester probes `http://localhost:<port>`, the Node process has already been reaped. All three of `setsid`, `nohup`, and `disown` are required:
+  ```bash
+  setsid nohup bash -c 'NODE_ENV=test pnpm --filter <service> start' \
+    < /dev/null > /tmp/<service>.log 2>&1 &
+  pid=$!
+  disown "$pid" 2>/dev/null || true
+  ```
+  `setsid` detaches from the step's process group; `nohup` + stdin-from-`/dev/null` ignores SIGHUP and drops the controlling terminal; `disown` removes the job from the shell's job table. macOS runners don't always ship `setsid`, so fall back to plain `nohup` there for local dev — the pipeline itself runs on ubuntu-latest where all three are present.
+
 ## Step 4.6: External issue tracker (optional)
 
 The default spec sources are the linked GitHub issue and any `docs/prds/*.md` referenced from it. Repos that track specs in Linear / Jira / Monday / Notion / etc. can opt into an extra hook that fetches the external spec and includes it in the reviewer's context. The pipeline ships **no provider-specific code** — the consumer owns the script and the API call.

--- a/skills/review-core.md
+++ b/skills/review-core.md
@@ -139,6 +139,7 @@ Do NOT set it for:
 
 - `spec_compliance` is ALWAYS filled in — even when there are findings. Summarizes what the PR does right or wrong vs the spec.
 - `spec_sources` extracts the linked issue number, external tracker identifier, PRD path, and which convention rules applied — read these from context.md. Use `null` for missing values.
+- `linked_issue` must come ONLY from the context-builder's `**Linked GitHub issues:**` line (derived from GitHub's `closingIssuesReferences`). **Do NOT** scrape `#N` patterns from the PR title, PR body, branch name, or conventional-commit suffixes — those often carry the PR number itself or stale references, and "Linked issue: #<PR-number>" in the summary confuses reviewers. If the context-builder line reads `none (closingIssuesReferences is empty)` or the section is absent, use `null` — even when the PR title contains `(#123)` or similar.
 - `external_issue` is the tracker identifier (e.g. `ABC-123`, `ENG-214`, `MON-1234`) surfaced by the consumer's optional `.github/claude-review/fetch-issue.sh` hook. Parse it from the heading at the top of the `## Linked external issue` section in context.md — the hook convention is `## Linked <tracker> issue: <IDENTIFIER>` as its first line. If the section is absent or no identifier can be parsed, set to `null`.
 
 Write `[]` for empty findings. ALWAYS write both files.


### PR DESCRIPTION
Stacked on #8. Three follow-ups from curewiki's first-time setup. Traded the earlier README-only draft for higher-leverage spots: the workflow (every run), a reviewer skill (every review), and the init prompt (every new consumer scaffolding).

## 1. `.github/workflows/pr-review.yml` — pre-warm `@playwright/mcp`

**Problem** — on curewiki's first run with the full dev stack (Firebase emulator + matching-service + matching-test-service + Vite) the functional tester reported `ToolSearch for mcp__playwright__* returned no matches (MCP server did not connect)` and fell back to static analysis with **zero screenshots**. Two back-to-back reruns — not flake.

**Root cause** — the tester spawns `npx @playwright/mcp@latest` as an MCP server inside Claude Code CLI's MCP-init timeout window. Under heavier consumer stacks, disk/network are contended during the tester's launch and the cold `npm install @playwright/mcp` + Playwright deps exceeds the timeout; the server never registers its tools; ToolSearch comes back empty.

**Fix** — one-line `npx --yes @playwright/mcp@latest --help` inside the existing `Setup Playwright MCP for test runner` step, right after the config JSON is written. Primes the npm cache so the tester's later spawn hits it. Non-fatal.

**Evidence it works** — added on curewiki as a diagnostic first (expected it to surface an error); the tester passed on the same commit with 5 real screenshots. Only change between the 0-screenshot run and the 5-screenshot run was this warm-up.

## 2. `skills/review-core.md` — guard `spec_sources.linked_issue`

Seen on curewiki's review of a PR without `closingIssuesReferences`: the reviewer set `linked_issue: 36` by scraping `#36` from the PR URL/title, and the summary rendered `Linked issue: #36 (external tracker: CUR-97)` — pointing the reader at the PR itself.

Clarifies the schema note: `linked_issue` comes ONLY from the context-builder's `**Linked GitHub issues:**` line (derived from `closingIssuesReferences`). Never from the PR title, body, branch, or conventional-commit suffix. When the line says `none (closingIssuesReferences is empty)`, the field is `null` regardless of whatever `#N` patterns the title contains.

## 3. `prompts/setup-review.md` — "Common extras" for dev-start.sh

The generic `dev-start.sh` scaffold covers Postgres + one web service. Four patterns it doesn't cover but backends keep needing — each gated on "add only when the repo actually needs it" so the setup agent doesn't stuff them into unrelated projects:

- **AWS dummy creds** for AWS-SDK-against-LocalStack. Without `AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_REGION=<region>` the SDK's credential chain raises `CredentialsProviderError: Could not load credentials from any providers` and the service loops forever on the first DynamoDB call.
- **Firebase auth emulator** for apps that verify Firebase JWTs. `localhost` isn't whitelisted for real Google OAuth, so the tester can't sign in without the emulator; with it, any email/password combo signs in and patient pages become reachable.
- **Vite `--mode test`** (or equivalent) when `.env.development` points `VITE_API_BASE_URL` at a *hosted* dev API. Default mode makes the tester talk to the hosted backend from the runner and fail auth/rate limits; `--mode test` loads `.env.test` with local URLs.
- **`setsid + nohup + disown`** to detach background services. GitHub's runner SIGKILLs the step's process group at step-end, so a plain `pnpm start &` doesn't survive into the tester's step. All three are required on ubuntu-latest.

## Test plan

- [ ] Next consumer with a heavy dev stack: no `::warning::Pre-warm of @playwright/mcp failed`, tester produces screenshots. Verified once on curewiki#36 (5 screenshots after the warm-up was in place).
- [ ] Next PR without a `closingIssuesReferences` linked issue: `Linked issue: none found` (or the external-tracker variant), not `#<PR-number>`.
- [ ] Next setup against a repo with AWS/Firebase/Vite-envs: the agent picks up the relevant snippet and the tester can authenticate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)