### PR TITLE
chore: update create-github-app-token to v3 and use client ID instead of app ID

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -20,7 +20,7 @@ on:
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         required: true
-      CLAUDE_REVIEW_APP_ID:
+      CLAUDE_REVIEW_APP_CLIENT_ID:
         required: false
       CLAUDE_REVIEW_APP_PRIVATE_KEY:
         required: false
@@ -272,19 +272,19 @@ jobs:
           fi
 
       # Optional: GitHub App token for a custom review identity.
-      # Requires all three secrets: APP_ID + APP_PRIVATE_KEY + APP_SLUG.
+      # Requires all three secrets: APP_CLIENT_ID + APP_PRIVATE_KEY + APP_SLUG.
       # APP_SLUG is needed because installation tokens can't query /user.
       # Without these, falls back to GITHUB_TOKEN (github-actions[bot]).
       - name: Generate review token
         id: review_token
         shell: bash
         env:
-          APP_ID: ${{ secrets.CLAUDE_REVIEW_APP_ID }}
+          APP_CLIENT_ID: ${{ secrets.CLAUDE_REVIEW_APP_CLIENT_ID }}
           APP_SLUG: ${{ secrets.CLAUDE_REVIEW_APP_SLUG }}
         run: |
-          if [ -n "$APP_ID" ]; then
+          if [ -n "$APP_CLIENT_ID" ]; then
             if [ -z "$APP_SLUG" ]; then
-              echo "::error::CLAUDE_REVIEW_APP_ID is set but CLAUDE_REVIEW_APP_SLUG is not."
+              echo "::error::CLAUDE_REVIEW_APP_CLIENT_ID is set but CLAUDE_REVIEW_APP_SLUG is not."
               echo "::error::APP_SLUG is required to identify the bot user for review dismissal."
               echo "::error::Find your app slug in the App's settings URL (github.com/apps/<slug>)"
               echo "::error::and add it as a repo secret named CLAUDE_REVIEW_APP_SLUG."
@@ -298,9 +298,9 @@ jobs:
       - name: Create GitHub App token
         id: app_token
         if: steps.review_token.outputs.has_app == 'true'
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.1.4
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.CLAUDE_REVIEW_APP_ID }}
+          client-id: ${{ secrets.CLAUDE_REVIEW_APP_CLIENT_ID }}
           private-key: ${{ secrets.CLAUDE_REVIEW_APP_PRIVATE_KEY }}
 
       - name: Resolve review identity

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Add `CLAUDE_CODE_OAUTH_TOKEN` as a repo or org secret. Generate it with:
 claude setup-token
 ```
 
-Optional: for a custom review bot identity, also set `CLAUDE_REVIEW_APP_ID`, `CLAUDE_REVIEW_APP_PRIVATE_KEY`, and `CLAUDE_REVIEW_APP_SLUG`.
+Optional: for a custom review bot identity, also set `CLAUDE_REVIEW_APP_CLIENT_ID`, `CLAUDE_REVIEW_APP_PRIVATE_KEY`, and `CLAUDE_REVIEW_APP_SLUG`.
 
 ### 3. (Optional) Add project config
 

--- a/prompts/setup-review.md
+++ b/prompts/setup-review.md
@@ -89,7 +89,7 @@ read-only `GITHUB_TOKEN` scope (see inline comment above).
 ```yaml
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-      CLAUDE_REVIEW_APP_ID: ${{ secrets.CLAUDE_REVIEW_APP_ID }}
+      CLAUDE_REVIEW_APP_CLIENT_ID: ${{ secrets.CLAUDE_REVIEW_APP_CLIENT_ID }}
       CLAUDE_REVIEW_APP_PRIVATE_KEY: ${{ secrets.CLAUDE_REVIEW_APP_PRIVATE_KEY }}
       CLAUDE_REVIEW_APP_SLUG: ${{ secrets.CLAUDE_REVIEW_APP_SLUG }}
 ```
@@ -349,7 +349,7 @@ The OAuth token is required for every repo; the App-token path is how reviews ge
 
 1. `CLAUDE_CODE_OAUTH_TOKEN` (required) — generate with `claude setup-token` and add as a repo or org secret. Without it the workflow fails at the first step with `::error::CLAUDE_CODE_OAUTH_TOKEN secret is not configured.`
 
-2. `CLAUDE_REVIEW_APP_ID`, `CLAUDE_REVIEW_APP_PRIVATE_KEY`, `CLAUDE_REVIEW_APP_SLUG` (recommended) — these are typically already set as **Panenco org secrets** with "All repositories" visibility, so `secrets: inherit` picks them up automatically for any new repo. If they're not, ask a Panenco org owner to add them once, org-wide.
+2. `CLAUDE_REVIEW_APP_CLIENT_ID`, `CLAUDE_REVIEW_APP_PRIVATE_KEY`, `CLAUDE_REVIEW_APP_SLUG` (recommended) — these are typically already set as **Panenco org secrets** with "All repositories" visibility, so `secrets: inherit` picks them up automatically for any new repo. If they're not, ask a Panenco org owner to add them once, org-wide.
 
 3. **Install the `panenco-claude-reviewer` App on the repo** (already org-installed in most cases — the app lives inside Panenco). Go to `github.com/organizations/Panenco/settings/installations` → `panenco-claude-reviewer` → Configure → add the repo if not already covered by "All repositories".
 
@@ -381,14 +381,14 @@ Go to `github.com/organizations/<your-org>/settings/apps` → **New GitHub App**
 
 Create, then on the App's settings page:
 
-1. Note the **App ID** at the top (integer, e.g. `3442056`) — this is `CLAUDE_REVIEW_APP_ID`.
+1. Note the **Client ID** (string starting with `Iv`, e.g. `Iv23li...`) — this is `CLAUDE_REVIEW_APP_CLIENT_ID`.
 2. Click **Generate a private key** — downloads a `.pem` file. Its full contents (including `-----BEGIN RSA PRIVATE KEY-----` and `-----END RSA PRIVATE KEY-----` lines) become `CLAUDE_REVIEW_APP_PRIVATE_KEY`.
 3. Record the slug from the App's settings URL (`github.com/organizations/<org>/settings/apps/<slug>`) — this becomes `CLAUDE_REVIEW_APP_SLUG`.
 
 **Step B2 — Set the four secrets on the target repo (or external org).**
 
 - `CLAUDE_CODE_OAUTH_TOKEN` — generate with `claude setup-token`.
-- `CLAUDE_REVIEW_APP_ID`, `CLAUDE_REVIEW_APP_PRIVATE_KEY`, `CLAUDE_REVIEW_APP_SLUG` — from Step B1.
+- `CLAUDE_REVIEW_APP_CLIENT_ID`, `CLAUDE_REVIEW_APP_PRIVATE_KEY`, `CLAUDE_REVIEW_APP_SLUG` — from Step B1.
 
 **Step B3 — Install your App on the target repo.**
 


### PR DESCRIPTION
This update removes warnings about node 20.
The new version deprecated `app-id` and replaced it with `client-id`. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the PR review workflow’s GitHub App authentication inputs/secrets, which could break token generation and review posting if repos aren’t updated with the new `CLAUDE_REVIEW_APP_CLIENT_ID` secret.
> 
> **Overview**
> Updates the PR review reusable workflow to use `actions/create-github-app-token` v3 and migrate from `app-id`/`CLAUDE_REVIEW_APP_ID` to `client-id`/`CLAUDE_REVIEW_APP_CLIENT_ID` for GitHub App review identity tokens.
> 
> Documentation (`README.md`, `prompts/setup-review.md`) is updated accordingly to instruct consumers to set the new secret and follow the Client ID-based setup path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3a1fa7556fabcfcdd1922277f2732d46bbdabd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->