### PR TITLE
First-review thoroughness boost (double-pass + gap-finder critic)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -346,18 +346,31 @@ jobs:
         run: |
           set -uo pipefail
           IS_FIRST="false"
-          REVIEWS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" 2>/dev/null) || REVIEWS=""
-          COMMENTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/comments" 2>/dev/null) || COMMENTS=""
-          if [ -n "$REVIEWS" ] || [ -n "$COMMENTS" ]; then
-            PRIOR=$(echo "${REVIEWS:-[]}" | jq --arg bot "$BOT_USER" \
-              '[.[] | select(.user.login == $bot and (.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "COMMENTED"))] | length' 2>/dev/null || echo 0)
-            MARKER=$(echo "${COMMENTS:-[]}" | jq --arg bot "$BOT_USER" \
-              '[.[] | select(.user.login == $bot)] | length' 2>/dev/null || echo 0)
-            if [ "${PRIOR:-0}" -eq 0 ] && [ "${MARKER:-0}" -eq 0 ]; then
+          # Track each gh call independently so a partial failure (one OK,
+          # one network/auth error) is visible — the pre-existing single
+          # warning only fired when BOTH calls failed, masking the more
+          # likely "comments paginated and timed out mid-stream" case.
+          REVIEWS_OK=true; COMMENTS_OK=true
+          REVIEWS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" 2>/dev/null) || { REVIEWS=""; REVIEWS_OK=false; }
+          COMMENTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/comments" 2>/dev/null) || { COMMENTS=""; COMMENTS_OK=false; }
+          if [ "$REVIEWS_OK" = "false" ] || [ "$COMMENTS_OK" = "false" ]; then
+            echo "::warning::gh API failure on first-review detection (reviews_ok=$REVIEWS_OK, comments_ok=$COMMENTS_OK) — defaulting IS_FIRST_REVIEW=false (fail-closed)."
+          else
+            # gh api --paginate concatenates per-page arrays as separate
+            # JSON inputs (newline-separated). Without -s the jq filter
+            # runs once per page and produces multi-line counts, which
+            # then crash the `[ -eq 0 ]` test with "integer expression
+            # expected" — silently leaving IS_FIRST=false.
+            # `-s 'add'` slurps all pages into one array first.
+            PRIOR=$(echo "${REVIEWS:-[]}" | jq -s --arg bot "$BOT_USER" \
+              'add | [.[] | select(.user.login == $bot and (.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "COMMENTED"))] | length' 2>/dev/null || echo "?")
+            MARKER=$(echo "${COMMENTS:-[]}" | jq -s --arg bot "$BOT_USER" \
+              'add | [.[] | select(.user.login == $bot)] | length' 2>/dev/null || echo "?")
+            if ! [[ "$PRIOR" =~ ^[0-9]+$ ]] || ! [[ "$MARKER" =~ ^[0-9]+$ ]]; then
+              echo "::warning::Could not parse review/comment counts (PRIOR='$PRIOR' MARKER='$MARKER') — defaulting IS_FIRST_REVIEW=false (fail-closed)."
+            elif [ "$PRIOR" -eq 0 ] && [ "$MARKER" -eq 0 ]; then
               IS_FIRST="true"
             fi
-          else
-            echo "::warning::Could not query prior reviews/comments — defaulting IS_FIRST_REVIEW=false (fail-closed)"
           fi
           echo "is_first=$IS_FIRST" >> "$GITHUB_OUTPUT"
           echo "First-review boost: IS_FIRST_REVIEW=$IS_FIRST"
@@ -865,15 +878,31 @@ jobs:
           # so the union catches issues that any single pass might miss
           # (per-run recall is well below 100%). Pass-2 findings flow through
           # build-review.sh's existing dedup with the rest, so duplicates
-          # collapse automatically. Output paths are overridden in the
-          # prompt suffix to avoid clobbering pass-1 outputs.
+          # collapse automatically.
+          #
+          # Output-path safety: we sed-rewrite the embedded skill text so the
+          # agent's "ALWAYS write /tmp/core-findings.json + /tmp/core-meta.json"
+          # / "ALWAYS write /tmp/sweep-findings.json" instructions become
+          # "/tmp/core-findings-2.json + /tmp/core-meta-2.json" /
+          # "/tmp/sweep-findings-2.json". A naked prompt-suffix override
+          # would fight the embedded skill text and risk pass-2 clobbering
+          # pass-1's verdict-critical core-meta.json (manual_spec_present,
+          # requires_human_review, spec_compliance) — the spec-presence and
+          # human-review verdict gates introduced by 50cc139 must survive the
+          # boost. Sed substitution removes the conflict at the source.
           if [ "${IS_FIRST_REVIEW:-false}" = "true" ]; then
             echo "First-review boost: launching core + sweep pass-2 in parallel"
-            ~/.local/bin/claude -p "You are the core reviewer for PR #$PR_NUMBER (PASS 2 — independent re-review). context.md at the repo root contains the full diff and project context — Read it. Follow the skill below exactly. **Override**: write findings to /tmp/core-findings-2.json and meta to /tmp/core-meta-2.json (NOT the default paths). Do not touch the pass-1 outputs.${BUGBOT_BLOCK}
+            CORE_SKILL_PASS2=$(echo "$CORE_SKILL" | sed \
+              -e 's|/tmp/core-findings\.json|/tmp/core-findings-2.json|g' \
+              -e 's|/tmp/core-meta\.json|/tmp/core-meta-2.json|g')
+            SWEEP_SKILL_PASS2=$(echo "$SWEEP_SKILL" | sed \
+              -e 's|/tmp/sweep-findings\.json|/tmp/sweep-findings-2.json|g')
+
+            ~/.local/bin/claude -p "You are the core reviewer for PR #$PR_NUMBER (PASS 2 — independent re-review). context.md at the repo root contains the full diff and project context — Read it. Follow the skill below exactly, including writing the JSON output files it specifies (the skill has been pre-edited to point at pass-2 output paths so it will not clobber pass-1).${BUGBOT_BLOCK}
 
           === review-core skill (follow exactly) ===
 
-          $CORE_SKILL" \
+          $CORE_SKILL_PASS2" \
               --model ${{ inputs.model_high }} \
               --permission-mode dontAsk \
               --setting-sources user \
@@ -882,11 +911,11 @@ jobs:
               --max-turns 10 > /tmp/core-output-2.txt 2>&1 &
             PID_CORE2=$!
 
-            ~/.local/bin/claude -p "You are the sweep reviewer for PR #$PR_NUMBER (PASS 2 — independent re-review). context.md at the repo root contains the full diff and project context — Read it. Follow the skill below exactly. **Override**: write findings to /tmp/sweep-findings-2.json (NOT the default path). Do not touch the pass-1 output.${BUGBOT_BLOCK}
+            ~/.local/bin/claude -p "You are the sweep reviewer for PR #$PR_NUMBER (PASS 2 — independent re-review). context.md at the repo root contains the full diff and project context — Read it. Follow the skill below exactly, including writing the JSON output file it specifies (the skill has been pre-edited to point at the pass-2 output path so it will not clobber pass-1).${BUGBOT_BLOCK}
 
           === review-sweep skill (follow exactly) ===
 
-          $SWEEP_SKILL" \
+          $SWEEP_SKILL_PASS2" \
               --model ${{ inputs.model_standard }} \
               --permission-mode dontAsk \
               --setting-sources user \
@@ -1026,14 +1055,30 @@ jobs:
             else
               GAP_SKILL=$(cat "$SKILLS_DIR/review-gap-finder.md")
               # Concatenate all prior-stage findings into one input file for
-              # the critic to read. `2>/dev/null || echo '[]'` keeps the file
-              # valid even when one pass-2 input is missing (e.g. that pass
-              # crashed) — the agent reads the file unconditionally per skill.
-              jq -s 'add' \
-                /tmp/core-findings.json /tmp/core-findings-2.json \
-                /tmp/sweep-findings.json /tmp/sweep-findings-2.json \
-                2>/dev/null > /tmp/prior-pass-findings.json \
-                || echo '[]' > /tmp/prior-pass-findings.json
+              # the critic to read. Per-file validation: `jq -s 'add'` on
+              # multiple files fails-the-whole-call if ANY input is missing
+              # or malformed, silently producing []. That would blind the
+              # gap-finder's dedup contract — every pass-1 finding becomes
+              # a "net-new" candidate, wasting Opus turns and producing
+              # rephrased duplicates that the merge step's path+line ±5
+              # dedup may not catch (line shifts > 5). We keep the valid
+              # inputs and emit a ::warning:: per excluded file so the
+              # cause is visible in the workflow log.
+              SAFE_INPUTS=()
+              for ppf in /tmp/core-findings.json /tmp/core-findings-2.json \
+                         /tmp/sweep-findings.json /tmp/sweep-findings-2.json; do
+                if [ -f "$ppf" ] && jq -e 'type == "array"' "$ppf" >/dev/null 2>&1; then
+                  SAFE_INPUTS+=("$ppf")
+                elif [ -f "$ppf" ]; then
+                  echo "::warning::$ppf is not a valid JSON array — excluding from gap-finder dedup input. Gap-finder may re-flag issues this pass already covered."
+                fi
+              done
+              if [ "${#SAFE_INPUTS[@]}" -eq 0 ]; then
+                echo "::warning::All prior-pass findings inputs unusable — gap-finder will run with empty dedup input."
+                echo '[]' > /tmp/prior-pass-findings.json
+              else
+                jq -s 'add' "${SAFE_INPUTS[@]}" > /tmp/prior-pass-findings.json
+              fi
               echo "::group::Gap-finder critic (Opus, sequential)"
               ~/.local/bin/claude -p "You are the gap-finder critic for PR #$PR_NUMBER. context.md at the repo root has the diff + project context — Read it. /tmp/prior-pass-findings.json contains every finding the prior pairs already produced — Read it. Follow the skill below exactly, including writing the JSON output file it specifies.${BUGBOT_BLOCK}
 
@@ -1047,7 +1092,16 @@ jobs:
                 --disallowedTools Bash,Edit,Glob,Grep,WebFetch,WebSearch \
                 --max-turns 12 > /tmp/gap-output.txt 2>&1 \
                 || echo "::warning::gap-finder exited non-zero — continuing with prior findings only"
-              [ -f /tmp/gap-findings.json ] || echo '[]' > /tmp/gap-findings.json
+              # Distinguish "agent ran clean and found nothing" from "agent
+              # exited 0 but never wrote the file" (e.g. hit max-turns
+              # mid-draft, or refused to write). The skill documents
+              # `[]` as the success state, so a synthesized [] is shape-
+              # identical to a successful clean run — emit a warning so
+              # a reviewer reading the log can see this happened.
+              if [ ! -f /tmp/gap-findings.json ]; then
+                echo "::warning::gap-finder did not write /tmp/gap-findings.json despite exiting cleanly — likely hit max-turns. Synthesizing [] (no critic findings)."
+                echo '[]' > /tmp/gap-findings.json
+              fi
               echo "::endgroup::"
               echo "::group::Gap-finder log"
               [ -f /tmp/gap-output.txt ] && cat /tmp/gap-output.txt || echo "(no output)"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -323,6 +323,45 @@ jobs:
           echo "bot_user=$BOT_USER" >> "$GITHUB_OUTPUT"
           echo "Review identity: $BOT_USER"
 
+      # First-review detection. Re-reviews are common; first reviews are not.
+      # The "first-review boost" — double-pass core+sweep + gap-finder critic —
+      # only fires when no prior review or top-level review-comment by this
+      # bot exists on the PR. Detection is fail-closed: if the API can't be
+      # queried we default to false rather than spending the +2.5x cost on
+      # every push when auth glitches. This naturally distinguishes the
+      # synchronize event (re-review, prior comments present) from
+      # opened/reopened/ready_for_review (first review, none) and correctly
+      # treats workflow_dispatch re-runs against a reviewed PR as re-reviews.
+      #
+      # All untrusted PR inputs (number) and bot identity (token, BOT_USER)
+      # flow through env vars — never inlined into run: via ${{ }} — so
+      # this step is not vulnerable to workflow-command injection.
+      - name: Detect first review
+        id: first_review
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.review_identity.outputs.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+          BOT_USER: ${{ steps.review_identity.outputs.bot_user }}
+        run: |
+          set -uo pipefail
+          IS_FIRST="false"
+          REVIEWS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" 2>/dev/null) || REVIEWS=""
+          COMMENTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/comments" 2>/dev/null) || COMMENTS=""
+          if [ -n "$REVIEWS" ] || [ -n "$COMMENTS" ]; then
+            PRIOR=$(echo "${REVIEWS:-[]}" | jq --arg bot "$BOT_USER" \
+              '[.[] | select(.user.login == $bot and (.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "COMMENTED"))] | length' 2>/dev/null || echo 0)
+            MARKER=$(echo "${COMMENTS:-[]}" | jq --arg bot "$BOT_USER" \
+              '[.[] | select(.user.login == $bot)] | length' 2>/dev/null || echo 0)
+            if [ "${PRIOR:-0}" -eq 0 ] && [ "${MARKER:-0}" -eq 0 ]; then
+              IS_FIRST="true"
+            fi
+          else
+            echo "::warning::Could not query prior reviews/comments — defaulting IS_FIRST_REVIEW=false (fail-closed)"
+          fi
+          echo "is_first=$IS_FIRST" >> "$GITHUB_OUTPUT"
+          echo "First-review boost: IS_FIRST_REVIEW=$IS_FIRST"
+
       # ── Review pipeline ─────────────────────────────────────────
       # Stage 1: Context Builder (Sonnet) — gathers PR data, runs build,
       #          writes context.md AND test-plan.md (test planning folded in)
@@ -726,6 +765,7 @@ jobs:
           WEB_READY: ${{ steps.dev_env.outputs.web_ready || 'false' }}
           WEB_URL: ${{ steps.dev_env.outputs.web_url || '' }}
           AUTH_READY: ${{ steps.dev_env.outputs.auth_ready || 'false' }}
+          IS_FIRST_REVIEW: ${{ steps.first_review.outputs.is_first }}
         run: |
           set -euo pipefail
 
@@ -780,11 +820,11 @@ jobs:
           # core/sweep output files would be empty — which is exactly how this
           # step silently failed in the past. Trap EXIT reaps any still-running
           # reviewer PIDs so we preserve their output even on abort.
-          PID_CORE=""; PID_SWEEP=""; PID_SPEC=""; PID_FUNCTIONAL=""
+          PID_CORE=""; PID_SWEEP=""; PID_SPEC=""; PID_FUNCTIONAL=""; PID_CORE2=""; PID_SWEEP2=""
           reap_on_exit() {
             local rc=$?
             set +x
-            for pid in "$PID_CORE" "$PID_SWEEP" "$PID_SPEC" "$PID_FUNCTIONAL"; do
+            for pid in "$PID_CORE" "$PID_SWEEP" "$PID_SPEC" "$PID_FUNCTIONAL" "$PID_CORE2" "$PID_SWEEP2"; do
               [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null && wait "$pid" 2>/dev/null || true
             done
             exit "$rc"
@@ -818,6 +858,43 @@ jobs:
             --disallowedTools Bash,Edit,Glob,Grep,WebFetch,WebSearch \
             --max-turns 8 > /tmp/sweep-output.txt 2>&1 &
           PID_SWEEP=$!
+
+          # First-review boost: on the first review of a PR, run a second
+          # independent pass of core + sweep in parallel. The two passes use
+          # the same skills/prompts but their LLM sampling is independent,
+          # so the union catches issues that any single pass might miss
+          # (per-run recall is well below 100%). Pass-2 findings flow through
+          # build-review.sh's existing dedup with the rest, so duplicates
+          # collapse automatically. Output paths are overridden in the
+          # prompt suffix to avoid clobbering pass-1 outputs.
+          if [ "${IS_FIRST_REVIEW:-false}" = "true" ]; then
+            echo "First-review boost: launching core + sweep pass-2 in parallel"
+            ~/.local/bin/claude -p "You are the core reviewer for PR #$PR_NUMBER (PASS 2 — independent re-review). context.md at the repo root contains the full diff and project context — Read it. Follow the skill below exactly. **Override**: write findings to /tmp/core-findings-2.json and meta to /tmp/core-meta-2.json (NOT the default paths). Do not touch the pass-1 outputs.${BUGBOT_BLOCK}
+
+          === review-core skill (follow exactly) ===
+
+          $CORE_SKILL" \
+              --model ${{ inputs.model_high }} \
+              --permission-mode dontAsk \
+              --setting-sources user \
+              --allowedTools Read,Write \
+              --disallowedTools Bash,Edit,Glob,Grep,WebFetch,WebSearch \
+              --max-turns 10 > /tmp/core-output-2.txt 2>&1 &
+            PID_CORE2=$!
+
+            ~/.local/bin/claude -p "You are the sweep reviewer for PR #$PR_NUMBER (PASS 2 — independent re-review). context.md at the repo root contains the full diff and project context — Read it. Follow the skill below exactly. **Override**: write findings to /tmp/sweep-findings-2.json (NOT the default path). Do not touch the pass-1 output.${BUGBOT_BLOCK}
+
+          === review-sweep skill (follow exactly) ===
+
+          $SWEEP_SKILL" \
+              --model ${{ inputs.model_standard }} \
+              --permission-mode dontAsk \
+              --setting-sources user \
+              --allowedTools Read,Write \
+              --disallowedTools Bash,Edit,Glob,Grep,WebFetch,WebSearch \
+              --max-turns 8 > /tmp/sweep-output-2.txt 2>&1 &
+            PID_SWEEP2=$!
+          fi
 
           # Spec-compliance reviewer: PRD vs code comparison (Sonnet)
           # Only runs when a PRD was detected — otherwise no spec to compare against.
@@ -887,10 +964,13 @@ jobs:
           [ -f /tmp/functional-findings.json ] || echo '[]' > /tmp/functional-findings.json
           [ -f /tmp/functional-meta.json ] || echo '{"strategy":"skip","areas_tested":[],"screenshots":[],"overall":"PASS","summary":"Functional testing skipped.","uncertain_observations":[]}' > /tmp/functional-meta.json
 
-          echo "Core PID=$PID_CORE, Sweep PID=$PID_SWEEP, Spec PID=${PID_SPEC:-skipped}, Functional PID=${PID_FUNCTIONAL:-skipped}"
+          echo "Core PID=$PID_CORE, Sweep PID=$PID_SWEEP, Spec PID=${PID_SPEC:-skipped}, Functional PID=${PID_FUNCTIONAL:-skipped}, Core2 PID=${PID_CORE2:-skipped}, Sweep2 PID=${PID_SWEEP2:-skipped}"
 
           # Wait for all launched agents to complete
           CORE_OK=0; SWEEP_OK=0; SPEC_OK=0; FUNCTIONAL_OK=0
+          # Boost passes default to OK=1 ("not launched = OK") so the success
+          # log doesn't show FAILED on re-reviews where the boost is disabled.
+          CORE2_OK=1; SWEEP2_OK=1
           wait $PID_CORE && CORE_OK=1 || true
           wait $PID_SWEEP && SWEEP_OK=1 || true
           if [ -n "$PID_SPEC" ]; then
@@ -903,7 +983,15 @@ jobs:
           else
             FUNCTIONAL_OK=1  # skipped = OK
           fi
-          echo "Core: $([ $CORE_OK -eq 1 ] && echo OK || echo FAILED), Sweep: $([ $SWEEP_OK -eq 1 ] && echo OK || echo FAILED), Spec: $([ $SPEC_OK -eq 1 ] && echo OK || echo FAILED), Functional: $([ $FUNCTIONAL_OK -eq 1 ] && echo OK || echo FAILED)"
+          if [ -n "$PID_CORE2" ]; then
+            CORE2_OK=0
+            wait $PID_CORE2 && CORE2_OK=1 || true
+          fi
+          if [ -n "$PID_SWEEP2" ]; then
+            SWEEP2_OK=0
+            wait $PID_SWEEP2 && SWEEP2_OK=1 || true
+          fi
+          echo "Core: $([ $CORE_OK -eq 1 ] && echo OK || echo FAILED), Sweep: $([ $SWEEP_OK -eq 1 ] && echo OK || echo FAILED), Spec: $([ $SPEC_OK -eq 1 ] && echo OK || echo FAILED), Functional: $([ $FUNCTIONAL_OK -eq 1 ] && echo OK || echo FAILED), Core(2): $([ $CORE2_OK -eq 1 ] && echo OK || echo FAILED), Sweep(2): $([ $SWEEP2_OK -eq 1 ] && echo OK || echo FAILED)"
           echo "::endgroup::"
 
           # Print each agent's log in its own group for clean readability
@@ -919,6 +1007,53 @@ jobs:
           echo "::group::Functional tester (Playwright + Bash) log"
           [ -f /tmp/functional-output.txt ] && cat /tmp/functional-output.txt || echo "(skipped or no output)"
           echo "::endgroup::"
+          echo "::group::Core reviewer pass-2 (Opus) log"
+          [ -f /tmp/core-output-2.txt ] && cat /tmp/core-output-2.txt || echo "(skipped or no output)"
+          echo "::endgroup::"
+          echo "::group::Sweep reviewer pass-2 (Sonnet) log"
+          [ -f /tmp/sweep-output-2.txt ] && cat /tmp/sweep-output-2.txt || echo "(skipped or no output)"
+          echo "::endgroup::"
+
+          # First-review boost: gap-finder critic. Sequential — runs AFTER
+          # core+sweep (and any pass-2 / spec) finish, so the critic sees
+          # the union of every prior finding and explicitly hunts for what
+          # they missed. Output goes through the same dedup as the others,
+          # so any candidate that overlaps prior passes collapses cleanly
+          # in build-review.sh.
+          if [ "${IS_FIRST_REVIEW:-false}" = "true" ]; then
+            if [ ! -f "$SKILLS_DIR/review-gap-finder.md" ]; then
+              echo "::warning::review-gap-finder.md not found at $SKILLS_DIR — skipping gap-finder stage"
+            else
+              GAP_SKILL=$(cat "$SKILLS_DIR/review-gap-finder.md")
+              # Concatenate all prior-stage findings into one input file for
+              # the critic to read. `2>/dev/null || echo '[]'` keeps the file
+              # valid even when one pass-2 input is missing (e.g. that pass
+              # crashed) — the agent reads the file unconditionally per skill.
+              jq -s 'add' \
+                /tmp/core-findings.json /tmp/core-findings-2.json \
+                /tmp/sweep-findings.json /tmp/sweep-findings-2.json \
+                2>/dev/null > /tmp/prior-pass-findings.json \
+                || echo '[]' > /tmp/prior-pass-findings.json
+              echo "::group::Gap-finder critic (Opus, sequential)"
+              ~/.local/bin/claude -p "You are the gap-finder critic for PR #$PR_NUMBER. context.md at the repo root has the diff + project context — Read it. /tmp/prior-pass-findings.json contains every finding the prior pairs already produced — Read it. Follow the skill below exactly, including writing the JSON output file it specifies.${BUGBOT_BLOCK}
+
+          === review-gap-finder skill (follow exactly) ===
+
+          $GAP_SKILL" \
+                --model ${{ inputs.model_high }} \
+                --permission-mode dontAsk \
+                --setting-sources user \
+                --allowedTools Read,Write \
+                --disallowedTools Bash,Edit,Glob,Grep,WebFetch,WebSearch \
+                --max-turns 12 > /tmp/gap-output.txt 2>&1 \
+                || echo "::warning::gap-finder exited non-zero — continuing with prior findings only"
+              [ -f /tmp/gap-findings.json ] || echo '[]' > /tmp/gap-findings.json
+              echo "::endgroup::"
+              echo "::group::Gap-finder log"
+              [ -f /tmp/gap-output.txt ] && cat /tmp/gap-output.txt || echo "(no output)"
+              echo "::endgroup::"
+            fi
+          fi
 
           # Export FUNCTIONAL_OK for build-review.sh (it uses it for crash section)
           export FUNCTIONAL_OK
@@ -974,6 +1109,14 @@ jobs:
             /tmp/functional-findings.json
             /tmp/core-meta.json
             /tmp/functional-meta.json
+            /tmp/core-findings-2.json
+            /tmp/sweep-findings-2.json
+            /tmp/gap-findings.json
+            /tmp/core-meta-2.json
+            /tmp/core-output-2.txt
+            /tmp/sweep-output-2.txt
+            /tmp/gap-output.txt
+            /tmp/prior-pass-findings.json
             /tmp/*-findings.invalid.json
             /tmp/*-meta.invalid.json
           if-no-files-found: ignore

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ runs:
         # Verify the action download is complete — catch a broken release here
         # instead of letting the failure surface 3 minutes later in the analyze
         # step with a cryptic "skill not found" message.
-        EXPECTED_SKILLS="review-core review-sweep review-context-builder review-functional-tester review-spec-compliance review-test-planner"
+        EXPECTED_SKILLS="review-core review-sweep review-context-builder review-functional-tester review-spec-compliance review-test-planner review-gap-finder"
         MISSING=""
         for s in $EXPECTED_SKILLS; do
           if [ ! -f "$PIPELINE_DIR/skills/${s}.md" ]; then

--- a/scripts/build-review.sh
+++ b/scripts/build-review.sh
@@ -326,29 +326,46 @@ META1='{}'
 META2='{}'
 [ -f /tmp/core-meta.json ] && META1=$(cat /tmp/core-meta.json)
 [ -f /tmp/core-meta-2.json ] && META2=$(cat /tmp/core-meta-2.json)
-CORE_META=$(jq -n --argjson m1 "$META1" --argjson m2 "$META2" '
-  def or_bool(k): (($m1[k] // false) or ($m2[k] // false));
-  # has() is required because manual_spec_present absence must default to
-  # true (legacy behavior preserved for re-reviews where only pass-1 ran).
-  # `// true` would also fire on explicit false — wrong direction.
-  def and_present:
-    (if ($m1 | type == "object" and has("manual_spec_present")) then $m1.manual_spec_present else true end)
-    and
-    (if ($m2 | type == "object" and has("manual_spec_present")) then $m2.manual_spec_present else true end);
-  def prefer_prose(k): ($m1[k] // $m2[k] // null);
-  def union_arr(k): (($m1[k] // []) + ($m2[k] // []));
-  {
-    requires_human_review: or_bool("requires_human_review"),
-    requires_human_review_reason: prefer_prose("requires_human_review_reason"),
-    uncertain_observations: union_arr("uncertain_observations"),
-    prompt_injection_detected: or_bool("prompt_injection_detected"),
-    reviewer_self_modification: or_bool("reviewer_self_modification"),
-    build_unavailable: or_bool("build_unavailable"),
-    manual_spec_present: and_present,
-    spec_compliance: prefer_prose("spec_compliance"),
-    spec_sources: ($m1.spec_sources // $m2.spec_sources // null)
-  }
-')
+# Externalize the merge program so it can be exercised by fixture tests
+# without re-running the whole script, mirroring the existing dedup.jq
+# pattern above. The leading `as $m1obj | as $m2obj` coerces non-object
+# inputs (e.g. an agent that wrote `[]` to its meta — is_valid_json
+# accepts that since it only checks `jq empty`) to `{}` so subsequent
+# `.[k]` lookups don't error on jq 1.7+ (ubuntu-24.04 default).
+cat > /tmp/meta-merge.jq <<'JQEOF'
+def or_bool(k): (($m1[k] // false) or ($m2[k] // false));
+# has() requires manual_spec_present absence to default to true (legacy
+# behavior preserved for re-reviews where only pass-1 ran). `// true`
+# would also fire on explicit false — wrong direction.
+def and_present:
+  (if $m1 | has("manual_spec_present") then $m1.manual_spec_present else true end)
+  and
+  (if $m2 | has("manual_spec_present") then $m2.manual_spec_present else true end);
+def prefer_prose(k): ($m1[k] // $m2[k] // null);
+def union_arr(k): (($m1[k] // []) + ($m2[k] // []));
+{
+  requires_human_review: or_bool("requires_human_review"),
+  requires_human_review_reason: prefer_prose("requires_human_review_reason"),
+  uncertain_observations: union_arr("uncertain_observations"),
+  prompt_injection_detected: or_bool("prompt_injection_detected"),
+  reviewer_self_modification: or_bool("reviewer_self_modification"),
+  build_unavailable: or_bool("build_unavailable"),
+  manual_spec_present: and_present,
+  spec_compliance: prefer_prose("spec_compliance"),
+  spec_sources: ($m1.spec_sources // $m2.spec_sources // null)
+}
+JQEOF
+# Top-level guard: coerce non-object meta to {} before binding $m1/$m2 so
+# the helpers in meta-merge.jq can index uniformly without per-call type
+# guards. Without this, an agent that writes `[]` (a valid JSON array
+# that passes is_valid_json) crashes the merge on jq 1.7+ with
+# "Cannot index array with string".
+NORM_META1=$(jq 'if type == "object" then . else {} end' <<<"$META1")
+NORM_META2=$(jq 'if type == "object" then . else {} end' <<<"$META2")
+CORE_META=$(jq -n \
+  --argjson m1 "$NORM_META1" \
+  --argjson m2 "$NORM_META2" \
+  -f /tmp/meta-merge.jq)
 
 CORE_COUNT=$(jq 'length' /tmp/merged-core.json)
 SWEEP_COUNT=$(jq 'length' /tmp/merged-sweep.json)

--- a/scripts/build-review.sh
+++ b/scripts/build-review.sh
@@ -328,43 +328,43 @@ META2='{}'
 [ -f /tmp/core-meta-2.json ] && META2=$(cat /tmp/core-meta-2.json)
 # Externalize the merge program so it can be exercised by fixture tests
 # without re-running the whole script, mirroring the existing dedup.jq
-# pattern above. The leading `as $m1obj | as $m2obj` coerces non-object
-# inputs (e.g. an agent that wrote `[]` to its meta — is_valid_json
-# accepts that since it only checks `jq empty`) to `{}` so subsequent
-# `.[k]` lookups don't error on jq 1.7+ (ubuntu-24.04 default).
+# pattern above. The leading `as $m1` / `as $m2` rebinds at the top of
+# the program coerce non-object inputs (e.g. an agent that wrote `[]`
+# to its meta — is_valid_json accepts that since it only checks
+# `jq empty`) to `{}` so subsequent `$m1[k]` / `$m1 | has(...)` calls
+# don't error on jq 1.7+ (ubuntu-24.04 default) with "Cannot index
+# array with string" / "Cannot check whether array has a string key".
+# The coercion lives inside the .jq so the program is self-contained
+# and safe to invoke directly from a fixture test, not just from the
+# bash wrapper.
 cat > /tmp/meta-merge.jq <<'JQEOF'
-def or_bool(k): (($m1[k] // false) or ($m2[k] // false));
-# has() requires manual_spec_present absence to default to true (legacy
-# behavior preserved for re-reviews where only pass-1 ran). `// true`
-# would also fire on explicit false — wrong direction.
-def and_present:
-  (if $m1 | has("manual_spec_present") then $m1.manual_spec_present else true end)
-  and
-  (if $m2 | has("manual_spec_present") then $m2.manual_spec_present else true end);
-def prefer_prose(k): ($m1[k] // $m2[k] // null);
-def union_arr(k): (($m1[k] // []) + ($m2[k] // []));
-{
-  requires_human_review: or_bool("requires_human_review"),
-  requires_human_review_reason: prefer_prose("requires_human_review_reason"),
-  uncertain_observations: union_arr("uncertain_observations"),
-  prompt_injection_detected: or_bool("prompt_injection_detected"),
-  reviewer_self_modification: or_bool("reviewer_self_modification"),
-  build_unavailable: or_bool("build_unavailable"),
-  manual_spec_present: and_present,
-  spec_compliance: prefer_prose("spec_compliance"),
-  spec_sources: ($m1.spec_sources // $m2.spec_sources // null)
-}
+($m1 | if type == "object" then . else {} end) as $m1
+| ($m2 | if type == "object" then . else {} end) as $m2
+| def or_bool(k): (($m1[k] // false) or ($m2[k] // false));
+  # has() requires manual_spec_present absence to default to true (legacy
+  # behavior preserved for re-reviews where only pass-1 ran). `// true`
+  # would also fire on explicit false — wrong direction.
+  def and_present:
+    (if $m1 | has("manual_spec_present") then $m1.manual_spec_present else true end)
+    and
+    (if $m2 | has("manual_spec_present") then $m2.manual_spec_present else true end);
+  def prefer_prose(k): ($m1[k] // $m2[k] // null);
+  def union_arr(k): (($m1[k] // []) + ($m2[k] // []));
+  {
+    requires_human_review: or_bool("requires_human_review"),
+    requires_human_review_reason: prefer_prose("requires_human_review_reason"),
+    uncertain_observations: union_arr("uncertain_observations"),
+    prompt_injection_detected: or_bool("prompt_injection_detected"),
+    reviewer_self_modification: or_bool("reviewer_self_modification"),
+    build_unavailable: or_bool("build_unavailable"),
+    manual_spec_present: and_present,
+    spec_compliance: prefer_prose("spec_compliance"),
+    spec_sources: ($m1.spec_sources // $m2.spec_sources // null)
+  }
 JQEOF
-# Top-level guard: coerce non-object meta to {} before binding $m1/$m2 so
-# the helpers in meta-merge.jq can index uniformly without per-call type
-# guards. Without this, an agent that writes `[]` (a valid JSON array
-# that passes is_valid_json) crashes the merge on jq 1.7+ with
-# "Cannot index array with string".
-NORM_META1=$(jq 'if type == "object" then . else {} end' <<<"$META1")
-NORM_META2=$(jq 'if type == "object" then . else {} end' <<<"$META2")
 CORE_META=$(jq -n \
-  --argjson m1 "$NORM_META1" \
-  --argjson m2 "$NORM_META2" \
+  --argjson m1 "$META1" \
+  --argjson m2 "$META2" \
   -f /tmp/meta-merge.jq)
 
 CORE_COUNT=$(jq 'length' /tmp/merged-core.json)

--- a/scripts/build-review.sh
+++ b/scripts/build-review.sh
@@ -139,6 +139,11 @@ if [ -f /tmp/core-meta.json ] && ! is_valid_json /tmp/core-meta.json; then
   preserve_invalid /tmp/core-meta.json
   echo '{}' > /tmp/core-meta.json
 fi
+if [ -f /tmp/core-meta-2.json ] && ! is_valid_json /tmp/core-meta-2.json; then
+  echo "::warning::Core reviewer pass-2 meta is not valid JSON — falling back to {}."
+  preserve_invalid /tmp/core-meta-2.json
+  echo '{}' > /tmp/core-meta-2.json
+fi
 if [ -f /tmp/functional-meta.json ] && ! is_valid_json /tmp/functional-meta.json; then
   echo "::warning::Functional tester meta is not valid JSON — falling back to {}."
   preserve_invalid /tmp/functional-meta.json
@@ -298,7 +303,23 @@ echo '[]' > /tmp/merged-gap.json
 [ "$SWEEP2_HAS_OUTPUT" = "true" ] && cp /tmp/sweep-findings-2.json /tmp/merged-sweep2.json
 [ "$GAP_HAS_OUTPUT" = "true" ] && cp /tmp/gap-findings.json /tmp/merged-gap.json
 CORE_META='{}'
-[ -f /tmp/core-meta.json ] && CORE_META=$(cat /tmp/core-meta.json)
+# Pass-1 meta is preferred. Pass-2 meta is the equal-trust fallback when
+# pass-1 didn't write one — required to keep the verdict gates honest
+# under the boost. CORE_ANY_OUTPUT lets pass-2 substitute for pass-1's
+# *findings*, so the same substitution must apply to pass-2's *meta*
+# (manual_spec_present, requires_human_review, spec_compliance,
+# spec_sources, prompt_injection_detected, build_unavailable). Without
+# this, a pass-1 crash + pass-2 success would leave CORE_META='{}',
+# default `manual_spec_present` to true, default `requires_human_review`
+# to false, and silently bypass the spec-presence and human-review gates
+# introduced by 50cc139 — exactly the regression the PR self-review
+# (3 bots converged) flagged.
+if [ -f /tmp/core-meta.json ]; then
+  CORE_META=$(cat /tmp/core-meta.json)
+elif [ -f /tmp/core-meta-2.json ]; then
+  CORE_META=$(cat /tmp/core-meta-2.json)
+  echo "Pass-1 core meta absent; using pass-2 meta for verdict gates."
+fi
 
 CORE_COUNT=$(jq 'length' /tmp/merged-core.json)
 SWEEP_COUNT=$(jq 'length' /tmp/merged-sweep.json)

--- a/scripts/build-review.sh
+++ b/scripts/build-review.sh
@@ -21,6 +21,9 @@ set -euo pipefail
 #   /tmp/functional-findings.json — functional tester findings (optional)
 #   /tmp/functional-meta.json     — functional tester metadata (optional)
 #   /tmp/core-meta.json           — core reviewer metadata (optional)
+#   /tmp/core-findings-2.json     — first-review boost: core pass-2 findings (optional)
+#   /tmp/sweep-findings-2.json    — first-review boost: sweep pass-2 findings (optional)
+#   /tmp/gap-findings.json        — first-review boost: gap-finder critic findings (optional)
 #
 # Output files:
 #   review-result.json            — full review result
@@ -84,6 +87,52 @@ if [ -f /tmp/functional-findings.json ]; then
     preserve_invalid /tmp/functional-findings.json
   fi
 fi
+
+# First-review boost inputs. These files are only present when pr-review.yml
+# detects IS_FIRST_REVIEW=true and runs the second pass of core/sweep plus the
+# gap-finder critic. On re-reviews they are absent and the flags stay false —
+# all downstream merge logic treats absence as "no findings from this source".
+CORE2_HAS_OUTPUT=false; SWEEP2_HAS_OUTPUT=false; GAP_HAS_OUTPUT=false
+if [ -f /tmp/core-findings-2.json ]; then
+  if is_valid_findings /tmp/core-findings-2.json; then
+    CORE2_HAS_OUTPUT=true
+  else
+    echo "::warning::Core reviewer pass-2 findings are not a valid JSON array — treating as failed."
+    preserve_invalid /tmp/core-findings-2.json
+  fi
+fi
+if [ -f /tmp/sweep-findings-2.json ]; then
+  if is_valid_findings /tmp/sweep-findings-2.json; then
+    SWEEP2_HAS_OUTPUT=true
+  else
+    echo "::warning::Sweep reviewer pass-2 findings are not a valid JSON array — treating as failed."
+    preserve_invalid /tmp/sweep-findings-2.json
+  fi
+fi
+if [ -f /tmp/gap-findings.json ]; then
+  if is_valid_findings /tmp/gap-findings.json; then
+    GAP_HAS_OUTPUT=true
+  else
+    echo "::warning::Gap-finder critic findings are not a valid JSON array — treating as failed."
+    preserve_invalid /tmp/gap-findings.json
+  fi
+fi
+
+# Aggregate flags: pass-2 substitutes for pass-1 if pass-1 failed but pass-2
+# succeeded. Used for the failure gate, the warnings below, and the verdict
+# downgrade logic — any successful pass means we have those findings and can
+# trust the review on that axis.
+if [ "$CORE_HAS_OUTPUT" = "true" ] || [ "$CORE2_HAS_OUTPUT" = "true" ]; then
+  CORE_ANY_OUTPUT=true
+else
+  CORE_ANY_OUTPUT=false
+fi
+if [ "$SWEEP_HAS_OUTPUT" = "true" ] || [ "$SWEEP2_HAS_OUTPUT" = "true" ]; then
+  SWEEP_ANY_OUTPUT=true
+else
+  SWEEP_ANY_OUTPUT=false
+fi
+
 # Meta files are also agent-written JSON — fall back to empty if malformed.
 if [ -f /tmp/core-meta.json ] && ! is_valid_json /tmp/core-meta.json; then
   echo "::warning::Core reviewer meta is not valid JSON — falling back to {}."
@@ -96,16 +145,16 @@ if [ -f /tmp/functional-meta.json ] && ! is_valid_json /tmp/functional-meta.json
   echo '{}' > /tmp/functional-meta.json
 fi
 
-if [ "$CORE_HAS_OUTPUT" = "false" ] && [ "$SWEEP_HAS_OUTPUT" = "false" ]; then
-  echo "::error::Both code reviewers failed to produce output — cannot generate a verdict."
+if [ "$CORE_ANY_OUTPUT" = "false" ] && [ "$SWEEP_ANY_OUTPUT" = "false" ]; then
+  echo "::error::All code reviewers failed to produce output (core+sweep, both passes if boost ran) — cannot generate a verdict."
   echo "::error::Check rate limits and OAuth token."
   exit 1
 fi
 
-if [ "$CORE_HAS_OUTPUT" = "false" ]; then
+if [ "$CORE_ANY_OUTPUT" = "false" ]; then
   echo "::warning::Core reviewer (Opus) failed — proceeding with sweep-only findings. Correctness/spec review may be incomplete."
 fi
-if [ "$SWEEP_HAS_OUTPUT" = "false" ]; then
+if [ "$SWEEP_ANY_OUTPUT" = "false" ]; then
   echo "::warning::Sweep reviewer (Sonnet) failed — proceeding with core-only findings. Consistency/performance review may be incomplete."
 fi
 if [ "$FUNCTIONAL_HAS_OUTPUT" = "false" ]; then
@@ -238,10 +287,16 @@ echo '[]' > /tmp/merged-core.json
 echo '[]' > /tmp/merged-sweep.json
 echo '[]' > /tmp/merged-spec.json
 echo '[]' > /tmp/merged-functional.json
+echo '[]' > /tmp/merged-core2.json
+echo '[]' > /tmp/merged-sweep2.json
+echo '[]' > /tmp/merged-gap.json
 [ "$CORE_HAS_OUTPUT" = "true" ] && cp /tmp/core-findings.json /tmp/merged-core.json
 [ "$SWEEP_HAS_OUTPUT" = "true" ] && cp /tmp/sweep-findings.json /tmp/merged-sweep.json
 [ "$SPEC_HAS_OUTPUT" = "true" ] && cp /tmp/spec-findings.json /tmp/merged-spec.json
 [ "$FUNCTIONAL_HAS_OUTPUT" = "true" ] && cp /tmp/functional-findings.json /tmp/merged-functional.json
+[ "$CORE2_HAS_OUTPUT" = "true" ] && cp /tmp/core-findings-2.json /tmp/merged-core2.json
+[ "$SWEEP2_HAS_OUTPUT" = "true" ] && cp /tmp/sweep-findings-2.json /tmp/merged-sweep2.json
+[ "$GAP_HAS_OUTPUT" = "true" ] && cp /tmp/gap-findings.json /tmp/merged-gap.json
 CORE_META='{}'
 [ -f /tmp/core-meta.json ] && CORE_META=$(cat /tmp/core-meta.json)
 
@@ -249,7 +304,10 @@ CORE_COUNT=$(jq 'length' /tmp/merged-core.json)
 SWEEP_COUNT=$(jq 'length' /tmp/merged-sweep.json)
 SPEC_COUNT=$(jq 'length' /tmp/merged-spec.json)
 FUNCTIONAL_COUNT=$(jq 'length' /tmp/merged-functional.json)
-echo "Core: $CORE_COUNT, Sweep: $SWEEP_COUNT, Spec: $SPEC_COUNT, Functional: $FUNCTIONAL_COUNT findings"
+CORE2_COUNT=$(jq 'length' /tmp/merged-core2.json)
+SWEEP2_COUNT=$(jq 'length' /tmp/merged-sweep2.json)
+GAP_COUNT=$(jq 'length' /tmp/merged-gap.json)
+echo "Core: $CORE_COUNT, Sweep: $SWEEP_COUNT, Spec: $SPEC_COUNT, Functional: $FUNCTIONAL_COUNT, Core(2): $CORE2_COUNT, Sweep(2): $SWEEP2_COUNT, Gap: $GAP_COUNT findings"
 
 # ── Deduplication ──
 # Pass 1 (line-based): collapse findings at the same path+line_start.
@@ -271,7 +329,7 @@ def pick_best:
   then $best + {screenshot: $shot_donor.screenshot}
   else $best end;
 
-($c[0] + $s[0] + $p[0] + $f[0])
+($c[0] + $s[0] + $p[0] + $f[0] + $c2[0] + $s2[0] + $g[0])
 | group_by(.path + ":" + (.line_start | tostring))
 | map(pick_best)
 | group_by(.path + "|" + norm_title)
@@ -282,9 +340,12 @@ ALL_FINDINGS=$(jq -n \
   --slurpfile s /tmp/merged-sweep.json \
   --slurpfile p /tmp/merged-spec.json \
   --slurpfile f /tmp/merged-functional.json \
+  --slurpfile c2 /tmp/merged-core2.json \
+  --slurpfile s2 /tmp/merged-sweep2.json \
+  --slurpfile g /tmp/merged-gap.json \
   -f /tmp/dedup.jq)
 DEDUPED_COUNT=$(echo "$ALL_FINDINGS" | jq 'length')
-TOTAL=$((CORE_COUNT + SWEEP_COUNT + SPEC_COUNT + FUNCTIONAL_COUNT))
+TOTAL=$((CORE_COUNT + SWEEP_COUNT + SPEC_COUNT + FUNCTIONAL_COUNT + CORE2_COUNT + SWEEP2_COUNT + GAP_COUNT))
 if [ "$DEDUPED_COUNT" -lt "$TOTAL" ]; then
   echo "Within-run dedup (path+line then path+normalized-title, highest severity wins): $TOTAL -> $DEDUPED_COUNT (removed $((TOTAL - DEDUPED_COUNT)))"
 fi
@@ -356,8 +417,10 @@ if [ "$HAS_BLOCKING" = "true" ]; then
   VERDICT="REQUEST_CHANGES"
 elif [ "$HUMAN_REVIEW" = "true" ]; then
   VERDICT="COMMENT"
-elif [ "$CORE_HAS_OUTPUT" = "false" ]; then
-  # Core reviewer (bugs/spec) failed — can't confidently approve without it
+elif [ "$CORE_ANY_OUTPUT" = "false" ]; then
+  # Core reviewer (bugs/spec) failed — can't confidently approve without it.
+  # On first reviews this means BOTH core passes failed; on re-reviews this is
+  # the single core run.
   VERDICT="COMMENT"
   echo "::warning::Core reviewer failed — downgrading from APPROVE to COMMENT (cannot verify correctness)"
 elif [ "$MANUAL_SPEC_PRESENT" = "false" ]; then
@@ -485,11 +548,11 @@ EXTERNAL=$(jq -r '.spec_sources.external_issue // empty' review-result.json)
     echo "> :gear: **Build verification was unavailable.**"
     echo ""
   fi
-  if [ "$CORE_HAS_OUTPUT" = "false" ]; then
+  if [ "$CORE_ANY_OUTPUT" = "false" ]; then
     echo "> :warning: **Core reviewer (Opus) failed** — correctness and spec compliance review may be incomplete."
     echo ""
   fi
-  if [ "$SWEEP_HAS_OUTPUT" = "false" ]; then
+  if [ "$SWEEP_ANY_OUTPUT" = "false" ]; then
     echo "> :warning: **Sweep reviewer (Sonnet) failed** — consistency and performance review may be incomplete."
     echo ""
   fi

--- a/scripts/build-review.sh
+++ b/scripts/build-review.sh
@@ -302,24 +302,53 @@ echo '[]' > /tmp/merged-gap.json
 [ "$CORE2_HAS_OUTPUT" = "true" ] && cp /tmp/core-findings-2.json /tmp/merged-core2.json
 [ "$SWEEP2_HAS_OUTPUT" = "true" ] && cp /tmp/sweep-findings-2.json /tmp/merged-sweep2.json
 [ "$GAP_HAS_OUTPUT" = "true" ] && cp /tmp/gap-findings.json /tmp/merged-gap.json
-CORE_META='{}'
-# Pass-1 meta is preferred. Pass-2 meta is the equal-trust fallback when
-# pass-1 didn't write one — required to keep the verdict gates honest
-# under the boost. CORE_ANY_OUTPUT lets pass-2 substitute for pass-1's
-# *findings*, so the same substitution must apply to pass-2's *meta*
-# (manual_spec_present, requires_human_review, spec_compliance,
-# spec_sources, prompt_injection_detected, build_unavailable). Without
-# this, a pass-1 crash + pass-2 success would leave CORE_META='{}',
-# default `manual_spec_present` to true, default `requires_human_review`
-# to false, and silently bypass the spec-presence and human-review gates
-# introduced by 50cc139 — exactly the regression the PR self-review
-# (3 bots converged) flagged.
-if [ -f /tmp/core-meta.json ]; then
-  CORE_META=$(cat /tmp/core-meta.json)
-elif [ -f /tmp/core-meta-2.json ]; then
-  CORE_META=$(cat /tmp/core-meta-2.json)
-  echo "Pass-1 core meta absent; using pass-2 meta for verdict gates."
-fi
+# Merge pass-1 and pass-2 core meta into a single CORE_META that drives the
+# verdict gates. Naming the merge convention so future readers can audit it:
+#
+#   - **OR-merge** on safety-critical booleans (`requires_human_review`,
+#     `prompt_injection_detected`, `reviewer_self_modification`,
+#     `build_unavailable`). If EITHER pass detected the issue, surface it.
+#     Losing an escalation is strictly worse than redundant escalation.
+#   - **AND-merge** on `manual_spec_present`. If EITHER pass says no spec is
+#     available, treat as no spec (block APPROVE via the spec-presence gate
+#     from 50cc139). Losing the gate is strictly worse than spurious downgrade.
+#   - **Pass-1-prefer with pass-2 fallback** on prose / structured fields
+#     (`spec_compliance`, `spec_sources`, `requires_human_review_reason`).
+#     Pass-1 is canonical when present; pass-2 fills in when pass-1 didn't
+#     write the field (or wasn't run at all).
+#   - **Union** on `uncertain_observations` arrays.
+#
+# Without this, CORE_ANY_OUTPUT lets pass-2's *findings* substitute for a
+# missing pass-1 — but pass-2's *meta* would be silently dropped, and the
+# spec-presence / human-review / prompt-injection gates would default to
+# permissive. The PR self-review (3 bots converged) flagged exactly this.
+META1='{}'
+META2='{}'
+[ -f /tmp/core-meta.json ] && META1=$(cat /tmp/core-meta.json)
+[ -f /tmp/core-meta-2.json ] && META2=$(cat /tmp/core-meta-2.json)
+CORE_META=$(jq -n --argjson m1 "$META1" --argjson m2 "$META2" '
+  def or_bool(k): (($m1[k] // false) or ($m2[k] // false));
+  # has() is required because manual_spec_present absence must default to
+  # true (legacy behavior preserved for re-reviews where only pass-1 ran).
+  # `// true` would also fire on explicit false — wrong direction.
+  def and_present:
+    (if ($m1 | type == "object" and has("manual_spec_present")) then $m1.manual_spec_present else true end)
+    and
+    (if ($m2 | type == "object" and has("manual_spec_present")) then $m2.manual_spec_present else true end);
+  def prefer_prose(k): ($m1[k] // $m2[k] // null);
+  def union_arr(k): (($m1[k] // []) + ($m2[k] // []));
+  {
+    requires_human_review: or_bool("requires_human_review"),
+    requires_human_review_reason: prefer_prose("requires_human_review_reason"),
+    uncertain_observations: union_arr("uncertain_observations"),
+    prompt_injection_detected: or_bool("prompt_injection_detected"),
+    reviewer_self_modification: or_bool("reviewer_self_modification"),
+    build_unavailable: or_bool("build_unavailable"),
+    manual_spec_present: and_present,
+    spec_compliance: prefer_prose("spec_compliance"),
+    spec_sources: ($m1.spec_sources // $m2.spec_sources // null)
+  }
+')
 
 CORE_COUNT=$(jq 'length' /tmp/merged-core.json)
 SWEEP_COUNT=$(jq 'length' /tmp/merged-sweep.json)

--- a/skills/review-gap-finder.md
+++ b/skills/review-gap-finder.md
@@ -1,0 +1,113 @@
+---
+name: review-gap-finder
+description: Gap-finder critic — third perspective that hunts for issues the core+sweep pairs missed. Reads context.md and /tmp/prior-pass-findings.json, writes /tmp/gap-findings.json. Runs only on first reviews, sequentially after the parallel reviewers.
+---
+
+# Gap-Finder Review (Net-New Issues Only)
+
+You are the **third perspective** on this PR. Two parallel reviewer pairs have already produced findings — one core (bugs/spec/security) + one sweep (consistency/tests/performance), each run twice for redundancy. Your job is to surface issues they MISSED. You will be measured by whether you find genuine net-new issues without re-flagging anything they already covered.
+
+## Efficiency
+
+Target: **≤10 turns**. Turn 1: Read inputs. Turns 2-7: hunt for gaps. Turn 8-9: Write output.
+
+Use only Read and Write. Everything is in context.md and the JSON inputs — do NOT use Bash, Glob, or Grep.
+
+## Turn 1: Read inputs
+
+1. Project-specific review standards from `bugbot.md` (if the project has one) are already embedded in the prompt above — do NOT re-read `bugbot.md` with the Read tool.
+2. Read `context.md` at the repo root — full diff, file contents, issue, conventions, build output, prior bot comments.
+3. Read `/tmp/prior-pass-findings.json` — the union of every finding the core+sweep pairs produced this run. **You must read this fully.** It is the load-bearing input for your dedup decisions.
+4. Read `/tmp/user-replies-on-ours.json` if present — human rebuttals to prior bot findings. Anything rebutted there is off-limits unless you have new counter-evidence.
+
+### Honor bugbot's acceptance sections
+
+Before flagging anything, scan the embedded `bugbot.md` for **acceptance/exemption** sections (e.g. `## Accepted supply-chain trade-offs`, `## Accepted trade-offs`, `## Do NOT flag`, `## Known exceptions`). Any finding that matches an item listed there MUST be dropped — not downgraded to `note`, not moved to `uncertain_observations`, **dropped entirely**. The project owner has explicitly declared those patterns accepted.
+
+## Your scope — finding types
+
+You inherit the **full union** of core + sweep types — your job is to find what either pair missed:
+
+| Type | Belongs to (originally) |
+|---|---|
+| `bug`, `spec-mismatch`, `security`, `wrong-impl` | core |
+| `consistency`, `weak-test`, `missing-test`, `performance`, `design-smell`, `overcomplicated` | sweep |
+
+Use the same definitions and per-type evidence requirements that core and sweep use (quoted siblings for consistency, specific N+1 loops for performance, etc.).
+
+## Out of scope for everyone
+
+Cosmetic/formatting (linter territory), speculative extensibility, docstrings on unchanged code.
+
+## Severity
+
+| Level | Meaning | Blocks merge? |
+|---|---|---|
+| `critical` | Security vulnerability, data loss, build failure on changed lines | Yes |
+| `major` | Logic bug, spec violation, race condition, severe consistency divergence | Yes |
+| `minor` | Wrong-impl, design smell, overcomplicated, weak/missing test | No |
+| `note` | Observation worth mentioning, not actionable | No |
+
+You are trusted equally with core and sweep. If you find a real `critical` they missed, mark it `critical` — the verdict gate will block the merge.
+
+## Where to look (gap-finding playbook)
+
+Prior reviewers run on a single pass each and have known blind spots. Bias your attention toward:
+
+1. **Files with thin coverage** — diff hunks where prior findings cluster sparsely or not at all, especially newly-added files.
+2. **Cross-file invariants** — a function's contract changed in one file but a caller in another file was not updated. Prior reviewers tend to read files in isolation.
+3. **Error/edge paths** — happy-path code is often well-reviewed; null/empty/timeout/concurrency paths less so.
+4. **Test gaps** — non-trivial new logic with no corresponding test file (`missing-test`), tests that mock the SUT (`weak-test`).
+5. **Nits and minor consistency** — small divergences from sibling-file patterns, low-severity items prior passes deprioritized. These are noise on re-reviews if not caught now, so be willing to flag genuine `minor` and `note` items here.
+6. **Spec coverage gaps** — acceptance criteria or PRD items not mentioned by any prior finding and not visibly satisfied by the diff.
+
+## False-positive self-check (MANDATORY)
+
+Before finalizing ANY finding, verify all five (mirrored from review-core):
+
+1. **Concrete evidence** — Can you point to exact lines that are wrong? Speculation → drop it.
+2. **Refutation test** — Could the author dismiss this in one sentence? If yes → too weak → drop it.
+3. **Senior-engineer test** — Would an experienced engineer agree this is objectively wrong — not just "could be different"?
+4. **Exact reference** — For spec-mismatch, quote the exact rule/criterion. For consistency, quote the sibling file + line. For bugs, show the failure path. "Generally bad practice" is not evidence.
+5. **Artifact exists** — If the finding references a specific library, component, or export, look in the `# Repo capabilities snapshot` section of context.md and confirm the artifact is actually exported/installed. If it isn't, drop the finding.
+
+## Dedup against prior passes (MANDATORY — do this before writing each finding)
+
+The whole point of this stage is **net-new findings only**. For each candidate finding, run both checks below in order. If either fires, **drop it**.
+
+**Check 1 — path + line proximity.** Iterate `/tmp/prior-pass-findings.json`. If any prior entry has the same `path` AND its `line_start` is within ±5 of your candidate's `line_start`, drop your candidate. The prior pair already covered that location.
+
+**Check 2 — path + normalized title.** Normalize titles by lowercasing and collapsing all non-alphanumeric runs to single spaces. If any prior entry on the same `path` has the same normalized title as your candidate, drop your candidate — even if the line numbers differ.
+
+**Check 3 — rebutted issues.** If `/tmp/user-replies-on-ours.json` exists and contains a human rebuttal addressing the same issue you're about to flag, drop it. Do not re-flag user-rebutted false positives.
+
+**A clean `[]` is the expected outcome on a thorough first pass.** False positives waste team time more than a missed minor issue. If after honest hunting you find no net-new issues, write `[]` and exit. That is a successful gap-finder run.
+
+The merge step (`scripts/build-review.sh`) also dedupes by path+line ±5 and path+normalized-title across all sources, so even if you slip, duplicates collapse there. But your dedup is the first line of defense — and if your output is full of duplicates, the merge will silently drop your work.
+
+## Output: Write ONE file
+
+**`/tmp/gap-findings.json`** — array, same schema as core/sweep:
+
+```json
+[
+  {
+    "id": "g1",
+    "title": "...",
+    "severity": "critical|major|minor|note",
+    "type": "bug|spec-mismatch|security|wrong-impl|consistency|weak-test|missing-test|performance|design-smell|overcomplicated",
+    "path": "...",
+    "line_start": 42,
+    "line_end": 47,
+    "evidence": "2-6 lines",
+    "reasoning": "Why wrong + spec/sibling quote + why prior reviewers likely missed it",
+    "expected": "Fix — keep line_start..line_end ≤10 lines; if the issue spans more, point at the key line only"
+  }
+]
+```
+
+Use `id` prefix `g1, g2, …` to distinguish from core (`c*`) and sweep (`s*`).
+
+Do NOT write a meta file. Pass-1 `core-meta.json` remains the source of truth for verdict gates.
+
+Write `[]` for empty findings. ALWAYS write the file.


### PR DESCRIPTION
## Summary

- On the **first review of a PR**, run a second independent pass of `core` + `sweep` in parallel and a sequential **gap-finder critic** (Opus) afterwards. Re-reviews are unchanged.
- First-review detection: zero prior bot reviews/comments on the PR (queried via `gh api`, fail-closed on error). Distinguishes `synchronize` (re-review) from `opened`/`reopened`/`ready_for_review`, and treats `workflow_dispatch` re-runs against an already-reviewed PR as re-reviews.
- Critic findings flow through the same severity / merge / dedup / verdict pipeline with **equal trust** — a critic-flagged `critical` blocks merge.

## Why

Devs reported that re-reviews kept surfacing new comments on unchanged code (LLM non-determinism) and nits the first reviewer didn't bother with. Investing in round-one recall removes the churn at its source rather than masking it later.

Cost: roughly **+2.5×** on the code-review portion of a *first* review only. Re-reviews unchanged. Amortized ~+0.4× per PR if each PR sees ~4 pushes.

## Files

- `skills/review-gap-finder.md` (NEW) — critic prompt: scope union of core+sweep types, mirrored 5-gate false-positive guardrails, mandatory dedup against `/tmp/prior-pass-findings.json` (path+line ±5 then path+normalized-title).
- `scripts/build-review.sh` — validates `core-findings-2.json` / `sweep-findings-2.json` / `gap-findings.json`; pass-2 substitutes for pass-1 in the failure gate via `CORE_ANY_OUTPUT` / `SWEEP_ANY_OUTPUT`; dedup union extended.
- `.github/workflows/pr-review.yml` — `Detect first review` step, conditional pass-2 launches, gap-finder sequential block, extended `reap_on_exit` trap + waits + log groups + artifact uploads.

## Self-review hardening (commit 2)

Two parallel reviewers (`code-reviewer` + `silent-failure-hunter`) independently flagged the same top issues. All four addressed in 412ac65:

1. **Pass-2 could clobber pass-1's `core-meta.json`** — the override fought the embedded skill text. Now we sed-rewrite the embedded skill so pass-2's agent never sees the default paths. Protects the spec-presence and human-review verdict gates from #15.
2. **Gap-finder's `jq -s 'add'` collapsed to `[]` on any malformed input**, blinding its dedup contract. Replaced with per-file validation + per-file `::warning::`.
3. **Detect-first-review's gh api calls only warned on full failure** and the jq couldn't handle paginated multi-page responses (multi-line counts → silent `[ -eq 0 ]` crash). Now tracks each call's success independently and uses `jq -s 'add'` to merge pages.
4. **Synthesized `[]` for `gap-findings.json` was indistinguishable from a clean run**. Now emits a `::warning::` when the fallback fires.

## Test plan

- [x] **Unit fixture for `build-review.sh`**: hand-crafted 7 findings across all 7 sources with deliberate path:line and path+title overlap → 7 raw → 5 deduped, severity-wins on cross-pass overlap (`minor` + `critical` → `critical`), normalized-title collapse across different lines, `REQUEST_CHANGES` verdict.
- [x] **Re-review path**: pass-2 + gap files absent → 1 finding, `COMMENT`, no errors, no spurious "Core failed" warning.
- [x] **Pass-1 fail / pass-2 ok edge case**: pass-1 core absent, pass-2 produces critical → `REQUEST_CHANGES` from pass-2, `CORE_ANY_OUTPUT=true`, no false "Core reviewer failed" warning.
- [x] **Per-file gap-finder concat fallback**: 4 inputs (1 valid, 1 truncated, 1 missing, 1 valid) → 2 findings preserved, `::warning::` emitted for the truncated file. Old code would have produced `[]`.
- [x] **Paginated jq fix**: 2-page simulated `gh api` response under old code produces multi-line `'0\n1'` (would crash `[ -eq 0 ]` silently); new `jq -s 'add'` produces single integer `'1'`. Empty and single-page cases also verified.
- [x] **YAML / shellcheck**: `actionlint` clean except one pre-existing `SC2001` style nag.
- [ ] **End-to-end on a fresh PR in this repo** (dogfood) — best done after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the CI review workflow control flow, adds extra LLM runs, and alters verdict gating/dedup inputs; mistakes could increase cost, skip the boost, or affect approve/comment outcomes.
> 
> **Overview**
> On a PR’s *first* automated review, the workflow now detects whether the bot has previously reviewed/commented (via `gh api`, fail-closed) and, only when true, runs a second independent `core` + `sweep` pass in parallel plus a sequential `gap-finder` critic after the other agents finish.
> 
> The merge step (`scripts/build-review.sh`) is extended to validate, merge, and dedupe the new pass-2 and gap-finder findings, treat pass-2 as a fallback when pass-1 fails, and **merge core meta across passes** so verdict gates (e.g. spec-presence / human-review flags) remain safe. Artifacts/log grouping and the composite action skill set are updated to include the new `review-gap-finder` skill and the additional output files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 231722f55905a44ad606b16fb24e1b2f1a2322da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->