### PR TITLE
feat(dev-env): forward DEV_ENV_SECRETS to dev-start.sh

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -59,6 +59,9 @@ on:
       TRACKER_SECRETS:
         required: false
         description: "Optional. Newline-separated KEY=VALUE pairs exposed as env vars to .github/claude-review/fetch-issue.sh. Populated from the caller repo's secret of the same name via `secrets: inherit`."
+      DEV_ENV_SECRETS:
+        required: false
+        description: "Optional. Newline-separated KEY=VALUE pairs exposed as env vars to .github/claude-review/dev-start.sh (and the legacy review-config.md bash blocks + Auth eval). Populated from the caller repo's secret of the same name via `secrets: inherit`."
 
 jobs:
   review:
@@ -795,6 +798,7 @@ jobs:
         shell: bash
         env:
           PKG_MANAGER: ${{ steps.pkg.outputs.manager }}
+          DEV_ENV_SECRETS: ${{ secrets.DEV_ENV_SECRETS }}
         run: |
           set -uo pipefail
           mkdir -p /tmp/dev-env
@@ -918,6 +922,7 @@ jobs:
         env:
           PKG_MANAGER: ${{ steps.pkg.outputs.manager }}
           DEV_ENV_TIMEOUT_SECONDS: ${{ inputs.dev_env_timeout_seconds }}
+          DEV_ENV_SECRETS: ${{ secrets.DEV_ENV_SECRETS }}
         run: |
           set -uo pipefail
           source .review-scripts/phase-timing.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,5 +22,8 @@ jobs:
       - name: Run dedup_test.sh
         run: bash tests/dedup_test.sh
 
+      - name: Run dev_env_secrets_test.sh
+        run: bash tests/dev_env_secrets_test.sh
+
       - name: Shellcheck scripts (error-level only)
         run: shellcheck --severity=error scripts/*.sh tests/*.sh

--- a/README.md
+++ b/README.md
@@ -248,6 +248,19 @@ Rules:
 
 If the project has nothing to start (pure-docs, lib-only), do **not** create this file. Its absence is the signal for degraded mode (core + sweep reviewers run; no functional tester). An empty-but-present `dev-start.sh` will fail the step.
 
+##### Passing secrets to `dev-start.sh`
+
+If bring-up needs credentials (private registry token, S3 keys for seeding, third-party API key), put them in a repo secret named `DEV_ENV_SECRETS` as `KEY=VALUE` lines. The pipeline exports each line as an env var before running the script. Blank lines and `# comments` are skipped; everything after the first `=` is preserved verbatim so tokens containing `=` survive.
+
+```
+NPM_TOKEN=npm_xxxxx
+AWS_ACCESS_KEY_ID=AKIA...
+AWS_SECRET_ACCESS_KEY=...
+# values are exposed verbatim — do not wrap in quotes
+```
+
+Same wiring as `TRACKER_SECRETS` for `fetch-issue.sh`: the caller's `secrets: inherit` forwards it, and the env vars are visible to `dev-start.sh`, the legacy `## Functional validation` bash blocks, and the `### Auth` eval. Pick any names that make sense for your stack.
+
 #### `### Auth`
 
 Authentication for functional testing:

--- a/prompts/setup-review.md
+++ b/prompts/setup-review.md
@@ -238,6 +238,21 @@ Rules:
 
 If the project has no services to start (pure-docs repo, lib-only package), do **not** create this file. Its absence triggers degraded mode (core + sweep reviewers run; no functional tester). An empty-but-present `dev-start.sh` will fail the step — either commit a real one or don't commit one at all.
 
+### Secrets for dev-start.sh
+
+If bring-up needs credentials that aren't checked-in defaults (private registry token, S3 keys for seeding, third-party API key the dev server requires at boot), do not hardcode them. Instead emit a to-do for the user:
+
+> "**Add a repo secret named `DEV_ENV_SECRETS`** with newline-separated `KEY=VALUE` pairs. The pipeline exports each line as an env var to `dev-start.sh` (and to the legacy `## Functional validation` bash blocks + `### Auth` eval). Pick names that match what your script reads. Example:
+> ```
+> NPM_TOKEN=npm_xxxxx
+> AWS_ACCESS_KEY_ID=AKIA...
+> AWS_SECRET_ACCESS_KEY=...
+> # values are exposed verbatim — do not wrap in quotes
+> ```
+> Without this, lines in `dev-start.sh` that reference these env vars will see them as empty and the script will fail at the first command that needs them — same fail-hard semantics as any other dev-start error."
+
+Detect this need passively: grep the `dev-start.sh` you just drafted for `$VAR` references that aren't shell built-ins or values you already set inside the script. If any look like they should come from outside (registry creds, cloud SDK keys, anything ending in `_TOKEN` / `_KEY` / `_SECRET`), surface the to-do. If `dev-start.sh` is self-contained (compose-defined creds, no external API), skip this step.
+
 ## Step 4.6: External issue tracker (optional)
 
 The default spec sources are the linked GitHub issue and any `docs/prds/*.md` referenced from it. Repos that track specs in Linear / Jira / Monday / Notion / etc. can opt into an extra hook that fetches the external spec and includes it in the reviewer's context. The pipeline ships **no provider-specific code** — the consumer owns the script and the API call.
@@ -420,6 +435,10 @@ It is common to fix one and miss the other on a first setup; the installation pa
 ### `TRACKER_SECRETS` (optional, for Step 4.6 opt-in)
 
 Single multiline secret with newline-separated `KEY=VALUE` pairs that your `fetch-issue.sh` reads as env vars. Without it, the hook runs but every referenced env var is empty — the Actions log will show a `::warning::` from `fetch-issue.sh`, and the review completes without external-spec context.
+
+### `DEV_ENV_SECRETS` (optional, for Step 4.5 when dev-start.sh needs creds)
+
+Single multiline secret with newline-separated `KEY=VALUE` pairs exposed as env vars to `.github/claude-review/dev-start.sh` (and to the legacy `## Functional validation` bash blocks + `### Auth` eval). Use it for registry tokens, cloud SDK keys, or third-party API creds your bring-up needs at boot. Without it, references in `dev-start.sh` to these env vars are empty — the script will fail hard at the first command that depends on them, and the whole review stops (same fail-hard semantics as any other `dev-start.sh` error). Skip if your bring-up is self-contained.
 
 ## Step 7: Test
 

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -27,6 +27,14 @@ set -uo pipefail
 # Required env vars:
 #   GITHUB_OUTPUT   — path to GitHub Actions output file
 #
+# Optional env vars:
+#   DEV_ENV_SECRETS — newline-separated KEY=VALUE pairs forwarded as env vars
+#                     to dev-start.sh (and to legacy review-config.md bash
+#                     blocks + Auth eval). Mirrors TRACKER_SECRETS for the
+#                     fetch-issue.sh hook. Blank lines and `# comments` are
+#                     skipped; everything after the first `=` is preserved
+#                     verbatim so tokens containing `=` survive.
+#
 # Outputs (written to $GITHUB_OUTPUT):
 #   api_ready   — true/false
 #   api_url     — URL of the running API (possibly adjusted via health-path fallback)
@@ -38,6 +46,20 @@ DEV_SCRIPT=".github/claude-review/dev-start.sh"
 CONFIG=".github/review-config.md"
 HAS_CONFIG=false
 [ -f "$CONFIG" ] && HAS_CONFIG=true
+
+# Expose each KEY=VALUE line of DEV_ENV_SECRETS as an env var. Done once
+# at script scope so dev-start.sh, the legacy review-config.md bash blocks,
+# and the Auth eval all see the same names. The parser mirrors the
+# TRACKER_SECRETS handler in pr-review.yml verbatim.
+export_dev_env_secrets() {
+  [ -z "${DEV_ENV_SECRETS:-}" ] && return 0
+  while IFS= read -r line; do
+    case "$line" in ''|'#'*) continue ;; esac
+    [[ "$line" != *=* ]] && continue
+    export "${line%%=*}=${line#*=}"
+  done <<< "$DEV_ENV_SECRETS"
+}
+export_dev_env_secrets
 
 # Extract bash blocks from a section of review-config.md, heading-level-aware.
 # ## matches a level-2 section and includes its ### subsections; ### stops at

--- a/tests/dev_env_secrets_test.sh
+++ b/tests/dev_env_secrets_test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# dev_env_secrets_test.sh — covers export_dev_env_secrets in
+# scripts/setup-dev-env.sh. Mirrors the TRACKER_SECRETS parser in
+# pr-review.yml; consumers rely on identical semantics across the two.
+
+cd "$(dirname "$0")/.."
+
+fail=0
+assert_eq() {
+  local label="$1" want="$2" got="$3"
+  if [ "$want" != "$got" ]; then
+    echo "FAIL: $label — want '$want', got '$got'"
+    fail=$((fail + 1))
+  else
+    echo "OK:   $label"
+  fi
+}
+
+# Extract just the function (between `export_dev_env_secrets() {` and its
+# matching `}`) — sourcing the whole script would run phase 1, which has
+# real side effects (curl, file IO, GITHUB_OUTPUT writes).
+FN_SRC=$(awk '/^export_dev_env_secrets\(\) \{$/,/^\}$/' scripts/setup-dev-env.sh)
+if [ -z "$FN_SRC" ]; then
+  echo "FAIL: could not extract export_dev_env_secrets from scripts/setup-dev-env.sh"
+  exit 1
+fi
+eval "$FN_SRC"
+
+run_parser() {
+  # Subshell so each case starts with a clean env. stdout = `name=value`
+  # lines for every var we care about, sorted; stderr = swallowed.
+  local input="$1" probe="$2"
+  (
+    unset DEV_ENV_SECRETS
+    DEV_ENV_SECRETS="$input"
+    export_dev_env_secrets
+    eval "$probe"
+  )
+}
+
+# 1. Unset / empty input is a no-op (no error, no exports).
+RESULT=$(run_parser "" 'echo "rc=$?"')
+assert_eq "Empty input is a no-op" "rc=0" "$RESULT"
+
+# 2. Single KEY=VALUE pair exports correctly.
+RESULT=$(run_parser "FOO=bar" 'echo "FOO=$FOO"')
+assert_eq "Single KEY=VALUE export" "FOO=bar" "$RESULT"
+
+# 3. Multiple lines, including blank lines and comments, all parsed.
+INPUT=$'FOO=bar\n\n# comment line\nBAZ=qux\n'
+RESULT=$(run_parser "$INPUT" 'echo "FOO=$FOO"; echo "BAZ=$BAZ"')
+assert_eq "Multi-line parse (FOO)" "FOO=bar" "$(echo "$RESULT" | grep '^FOO=')"
+assert_eq "Multi-line parse (BAZ)" "BAZ=qux" "$(echo "$RESULT" | grep '^BAZ=')"
+
+# 4. Values containing `=` are preserved verbatim (only the FIRST `=` is
+#    the separator). Tokens like JWTs and base64 padding need this.
+RESULT=$(run_parser "TOKEN=abc=def==" 'echo "TOKEN=$TOKEN"')
+assert_eq "Value with embedded =" "TOKEN=abc=def==" "$RESULT"
+
+# 5. Lines without `=` are skipped silently (mirrors TRACKER_SECRETS).
+INPUT=$'JUST_A_KEY\nGOOD=ok'
+RESULT=$(run_parser "$INPUT" 'echo "GOOD=$GOOD"; echo "MISSING=${JUST_A_KEY:-unset}"')
+assert_eq "Line without = is skipped (good var still set)" "GOOD=ok" "$(echo "$RESULT" | grep '^GOOD=')"
+assert_eq "Line without = is skipped (no spurious export)" "MISSING=unset" "$(echo "$RESULT" | grep '^MISSING=')"
+
+# 6. Comment lines are skipped; a `=` inside a comment never leaks.
+INPUT=$'# SECRET=should-not-export\nREAL=visible'
+RESULT=$(run_parser "$INPUT" 'echo "REAL=$REAL"; echo "SECRET=${SECRET:-unset}"')
+assert_eq "Comment with = does not leak" "SECRET=unset" "$(echo "$RESULT" | grep '^SECRET=')"
+assert_eq "Real var after comment exports" "REAL=visible" "$(echo "$RESULT" | grep '^REAL=')"
+
+# 7. Empty value is allowed (KEY=).
+RESULT=$(run_parser "EMPTY=" 'echo "EMPTY=[$EMPTY]"')
+assert_eq "Empty value" "EMPTY=[]" "$RESULT"
+
+if [ "$fail" -gt 0 ]; then
+  echo ""
+  echo "FAILED: $fail assertion(s)"
+  exit 1
+fi
+echo ""
+echo "PASSED: all assertions"


### PR DESCRIPTION
## Summary
- Adds an optional `DEV_ENV_SECRETS` repo secret that mirrors `TRACKER_SECRETS`. Each `KEY=VALUE` line is exposed as an env var to `.github/claude-review/dev-start.sh`, the legacy `## Functional validation` bash blocks, and the `### Auth` eval.
- Parsing lives in `scripts/setup-dev-env.sh::export_dev_env_secrets`, so both invocation paths in the reusable workflow (background launcher + synchronous fallback) pick it up with one change.
- Documents the mechanism under the `dev-start.sh` contract in the README; backed by a parser test (`tests/dev_env_secrets_test.sh`) wired into the existing `tests` workflow.

Closes the gap where consumer repos couldn't supply registry tokens, S3 keys, or third-party API creds to dev-env bring-up without forking the workflow.

## Test plan
- [x] `bash tests/dev_env_secrets_test.sh` — 10/10 assertions pass (empty input, single + multi-line, comments, lines without `=`, embedded `=` in value, empty value).
- [x] `bash tests/dedup_test.sh` — existing tests still pass.
- [x] `actionlint -shellcheck=` clean on both workflow files (pre-existing SC2086/SC2001 noise on unrelated lines unchanged).
- [x] `shellcheck --severity=error` clean on `setup-dev-env.sh` + the new test.
- [ ] Smoke a consumer repo that sets `DEV_ENV_SECRETS` (e.g., a private-registry `NPM_TOKEN`) once this lands on `@v1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow/env-plumbing and a small shell parser change; risk is mainly mis-parsed secrets causing dev-env bring-up failures, mitigated by the added unit test.
> 
> **Overview**
> Adds a new optional repo secret, `DEV_ENV_SECRETS`, to the reusable `pr-review.yml` workflow and forwards it into both dev-env startup paths (background pre-start and the wait/synchronous fallback).
> 
> Implements `DEV_ENV_SECRETS` parsing/export in `scripts/setup-dev-env.sh` (skipping blanks/comments, preserving values containing `=`) so `dev-start.sh`, legacy `review-config.md` bash blocks, and `### Auth` eval can consume the same env vars. Updates docs (`README.md`, `prompts/setup-review.md`) and adds a regression test (`tests/dev_env_secrets_test.sh`) wired into `tests.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4204740f237d48a6e9af98fb2abda6c63d077d26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->