### PR TITLE
fix(pr-review): split Playwright cache restore + save to silence post-step hashFiles failure

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -323,9 +323,19 @@ jobs:
       # parameter; this is purely for ~/.cache/ms-playwright so we don't
       # re-download chromium every run. Key on lock-file hash so a PR that
       # bumps @playwright/test invalidates the cache.
-      - name: Cache Playwright browsers
+      #
+      # Split into restore + save (instead of the unified `actions/cache`)
+      # so the post-step doesn't re-evaluate `hashFiles(...)`. The unified
+      # action's post step recomputes the key, and `hashFiles()` fails when
+      # the workspace has been cleaned by an earlier post step in the same
+      # job — surfacing as a noisy red `Post Cache Playwright browsers`:
+      # "Fail to hash files under directory '/home/runner/work/<repo>'".
+      # The split form captures the primary key once at restore time and
+      # reuses it on save, so post-step hashFiles is never called.
+      - name: Cache Playwright browsers (restore)
+        id: pw_cache
         if: steps.code_check.outputs.needs_build == 'true' && steps.install.outputs.install_ok == 'true'
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-ms-playwright-${{ hashFiles('**/package-lock.json', '**/pnpm-lock.yaml', '**/yarn.lock') }}
@@ -333,7 +343,7 @@ jobs:
             ${{ runner.os }}-ms-playwright-
 
       # Install Playwright browser for smoke tests (browser-based validation).
-      # Becomes a no-op restore on cache hit.
+      # Becomes a no-op when the cache restored a complete browser tree.
       - name: Install Playwright browsers
         if: steps.code_check.outputs.needs_build == 'true' && steps.install.outputs.install_ok == 'true'
         shell: bash
@@ -350,6 +360,17 @@ jobs:
           else
             echo "No Playwright config found — skipping browser install"
           fi
+
+      # Save the Playwright cache only on a miss (cache-hit != 'true').
+      # Reuses cache-primary-key from the restore step so post-step
+      # hashFiles is never called. `if: always()` so we still save even
+      # when a downstream step (smoke-test) fails on a fresh-cache run.
+      - name: Cache Playwright browsers (save)
+        if: always() && steps.pw_cache.outputs.cache-hit != 'true' && steps.pw_cache.outputs.cache-primary-key != ''
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ steps.pw_cache.outputs.cache-primary-key }}
 
       # Optional: GitHub App token for a custom review identity.
       # Requires all three secrets: APP_CLIENT_ID + APP_PRIVATE_KEY + APP_SLUG.


### PR DESCRIPTION
## Two failures, both make consumer runs look red on the GitHub UI when the underlying review actually completed.

### 1. Post Cache Playwright browsers — \`hashFiles\` failed

Every consumer run logs a red \`Post Cache Playwright browsers\` step with:

\`\`\`
##[error]The template is not valid. panenco/claude-review/.github/workflows/pr-review.yml@v2 (Line: 331, Col: 16): hashFiles('**/package-lock.json, **/pnpm-lock.yaml, **/yarn.lock') failed. Fail to hash files under directory '/home/runner/work/<repo>/<repo>'
\`\`\`

The actual review pipeline has already finished and posted its verdict by then, but the failed post turns the whole job red on the GitHub UI. Reported on Panenco/seaters#412 (run 25149333603).

**Cause**: the unified \`actions/cache\` re-evaluates its \`key:\` expression in its post step. By that point in the post chain another step has cleared the workspace, so \`hashFiles(...)\` returns no matches.

**Fix**: split into \`actions/cache/restore\` (with \`id: pw_cache\`) plus a separate \`actions/cache/save\` that reuses \`steps.pw_cache.outputs.cache-primary-key\` captured at restore time. Cache semantics unchanged.

### 2. Verdict APPROVE silently dropped under \`github-actions[bot]\`

Discovered on Curewiki/curewiki#58 — a v2 migration PR where the workflow_call input was renamed (\`CLAUDE_REVIEW_APP_ID\` → \`CLAUDE_REVIEW_APP_CLIENT_ID\`) but the user's repo-level secret is still under the old name. Result:

\`\`\`
HAS_APP: false
Review identity: github-actions[bot]
Posting APPROVE review with 0 inline comments
{"message":"Unprocessable Entity","errors":["GitHub Actions is not permitted to approve pull requests."],"status":"422"}
##[warning]Claude review posting failed (POST failed after 1 retry) — verdict is APPROVE but no PR review comment was created.
\`\`\`

The pipeline produced APPROVE on merit, GitHub blocked it with a policy 422, the retry hit the same 422, and the final \`::warning::\` is easy to miss. The PR sees zero visible reviews.

**Fix**: detect the combo before POSTing. When verdict=APPROVE AND BOT_USER=\`github-actions[bot]\`, downgrade to COMMENT and prepend a banner explaining:
- why the verdict was attenuated (GitHub policy, not pipeline judgment)
- how to restore APPROVE capability (configure the App secrets + install App on the repo)

Recorded in \`review-result.json\` as \`posting_downgrade\` so downstream consumers see the same signal.

## Test plan

- [ ] In-PR dogfood reaches verdict-gate without a red \`Post Cache Playwright browsers\` step.
- [ ] On a repo without the App secrets configured, verdict APPROVE is posted as COMMENT with the banner — no 422 in the log.
- [ ] On a repo WITH the App secrets configured, behavior is unchanged (APPROVE still posts as APPROVE).

## Release plan

After merge, tag \`v2.0.2\` and force-move the floating \`v2\` to the merge commit:

\`\`\`bash
MERGE_SHA=\$(git rev-parse origin/main)
git tag v2.0.2 \"\$MERGE_SHA\"
git tag -f v2 \"\$MERGE_SHA\"
git push origin v2.0.2
git push origin v2 --force
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)