### PR TITLE
fix(pr-review): detect lockfiles in apps/*, packages/* for monorepos

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -265,16 +265,51 @@ jobs:
             echo "Pure docs PR — skipping build setup."
           fi
 
-      # Detect package manager from lockfile.
+      # Detect package manager from lockfile. Looks at the repo root first
+      # (preserves single-app behavior), then falls back to common monorepo
+      # locations (`apps/*`, `packages/*`). Emits `dir` and `lockfile`
+      # outputs so downstream steps can install in the right place and
+      # point setup-node's cache at the correct lockfile. Prefers pnpm >
+      # yarn > npm; first hit wins.
       - name: Detect package manager
         id: pkg
         if: steps.code_check.outputs.needs_build == 'true'
         shell: bash
         run: |
-          if [ -f pnpm-lock.yaml ]; then echo "manager=pnpm" >> "$GITHUB_OUTPUT"
-          elif [ -f yarn.lock ]; then echo "manager=yarn" >> "$GITHUB_OUTPUT"
-          elif [ -f package-lock.json ]; then echo "manager=npm" >> "$GITHUB_OUTPUT"
-          else echo "manager=none" >> "$GITHUB_OUTPUT"; fi
+          set -uo pipefail
+          MANAGER=none
+          DIR=""
+          LOCK=""
+          # Build the candidate list: root first (so single-app repos behave
+          # exactly as before), then alphabetically-sorted apps/* and
+          # packages/* entries. Each candidate dir is checked for any of
+          # the three lockfile names in the pnpm > yarn > npm preference.
+          CANDIDATE_DIRS=(".")
+          while IFS= read -r d; do CANDIDATE_DIRS+=("$d"); done < <(
+            find apps packages -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort
+          )
+          for d in "${CANDIDATE_DIRS[@]}"; do
+            for f in pnpm-lock.yaml yarn.lock package-lock.json; do
+              if [ -f "$d/$f" ]; then
+                DIR="$d"
+                LOCK="$d/$f"
+                case "$f" in
+                  pnpm-lock.yaml)    MANAGER=pnpm ;;
+                  yarn.lock)         MANAGER=yarn ;;
+                  package-lock.json) MANAGER=npm ;;
+                esac
+                break 2
+              fi
+            done
+          done
+          if [ "$MANAGER" = "none" ]; then
+            echo "No JS lockfile found at root or in apps/*, packages/* — JS install + analyzers will be skipped."
+          else
+            echo "Detected $MANAGER lockfile at $LOCK"
+          fi
+          echo "manager=$MANAGER" >> "$GITHUB_OUTPUT"
+          echo "dir=$DIR" >> "$GITHUB_OUTPUT"
+          echo "lockfile=$LOCK" >> "$GITHUB_OUTPUT"
 
       - name: Set up pnpm
         if: steps.pkg.outputs.manager == 'pnpm'
@@ -296,12 +331,24 @@ jobs:
           node-version-file: ${{ steps.node_version.outputs.file || '' }}
           node-version: ${{ steps.node_version.outputs.file == '' && 'lts/*' || '' }}
           cache: ${{ steps.pkg.outputs.manager }}
+          # Point the cache at the actual lockfile so monorepo layouts
+          # (lockfile under apps/*/ or packages/*/) cache correctly. When
+          # the lockfile is at root the path resolves to ./pnpm-lock.yaml
+          # which matches setup-node's default behavior.
+          cache-dependency-path: ${{ steps.pkg.outputs.lockfile }}
 
       # Soft-fail: degraded review is better than no review.
+      # `working-directory` cd's into the lockfile's dir (`.` for single-app
+      # repos, `apps/<name>` or `packages/<name>` for monorepos). Downstream
+      # analyzers that exec `pnpm/yarn/npm` are responsible for finding
+      # node_modules — the Playwright browser-install step already auto-
+      # discovers its dir, and the context-builder agent runs commands at
+      # repo root and uses relative paths.
       - name: Install dependencies
         id: install
         if: steps.code_check.outputs.needs_build == 'true' && steps.pkg.outputs.manager != 'none'
         shell: bash
+        working-directory: ${{ steps.pkg.outputs.dir }}
         env:
           PKG_MANAGER: ${{ steps.pkg.outputs.manager }}
         run: |


### PR DESCRIPTION
## Summary

`Detect package manager` previously only looked at the repo root for `pnpm-lock.yaml` / `yarn.lock` / `package-lock.json`. In monorepos that keep their JS app under `apps/<name>/` (e.g. QIT: `apps/web/pnpm-lock.yaml`), the root has no lockfile, so `manager` was set to `none` and the entire JS branch of the pipeline was skipped:

1. `Install dependencies` skipped (gated on `manager != 'none'`)
2. `install_ok` output never written
3. `Pre-start dev environment (background)` skipped (gated on `install_ok == 'true'`)
4. The functional tester never ran; `dev-start.sh` was never executed

This PR makes detection monorepo-aware while preserving exact single-app behavior:

- Prefer the **repo root** lockfile when present (root-first priority is unchanged).
- Otherwise scan `apps/*` and `packages/*` (single-level, alphabetically sorted) for the first lockfile, with `pnpm > yarn > npm` preference.
- `pkg` step now emits two new outputs: `dir` (working dir for `Install dependencies`) and `lockfile` (passed to `setup-node` as `cache-dependency-path` so the package-manager cache hits in monorepos).
- `Install dependencies` runs with `working-directory: ${{ steps.pkg.outputs.dir }}` — for single-app repos this is `.` and behavior is identical to before.

Other steps were already monorepo-safe and don't need changes:
- `Install Playwright browsers` auto-discovers its dir via `find . -name 'playwright.config.*'`.
- The `npx --yes @playwright/mcp@latest` pre-warm doesn't need `node_modules`.

## Test plan
- [ ] Push to a single-app repo (lockfile at root): pkg detects same as before, `dir=.`, install runs at root — behavior unchanged.
- [ ] Push to QIT (lockfile at `apps/web/pnpm-lock.yaml`): `Detected pnpm lockfile at apps/web/pnpm-lock.yaml`, install runs in `apps/web`, `install_ok=true`, `Pre-start dev environment` executes `.github/claude-review/dev-start.sh`.
- [ ] Push to a docs-only PR: `needs_build=false`, pkg step is skipped (gate unchanged) — no regression.
- [ ] Push to a repo with no JS at all (`manager=none`): still emits the helpful "No JS lockfile found…" log line; install + Pre-start still skipped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes GitHub Actions workflow logic for dependency install location and Node cache keying, which could break builds in repos with unusual layouts or multiple lockfiles.
> 
> **Overview**
> Fixes the PR review workflow’s JS setup for monorepos by expanding lockfile detection beyond repo root to also scan `apps/*` and `packages/*` (root-first, `pnpm` > `yarn` > `npm`).
> 
> The workflow now emits `dir` and `lockfile` from the detection step, uses `cache-dependency-path` so `setup-node` caches against the correct lockfile, and runs `Install dependencies` in the detected subdirectory via `working-directory`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c53da1bb49f7234003f285e086593743e17921c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->