### PR TITLE
feat(round-2): rescope functional plan to since-last + inherit prior smoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ The pipeline persists a small state artifact (`/tmp/review-state.json`) on every
 
 Round-1 is otherwise identical to the legacy single-pass review with the recall boost (double-pass + critic) layered on. If the prior state artifact is missing (retention expired, prior run failed before upload), round 2 degrades to a clean full re-review with a `::notice::` explaining why.
 
+On round 2 the test planner also rescopes the functional run: scenarios are planned against `/tmp/since-last.diff` rather than the full PR diff, and **zero scenarios is a valid outcome**. A small follow-up commit drops to `quick` (one scenario over the touched area) when since-last has user-observable surface, or `skip` (no scenarios) when since-last is comments / log strings / type-only / internal-helper / docs / config / dev-tooling — anything a user wouldn't notice. The smoke gate inherits the prior round's `functional_overall` for technical-change PRs, so a `skip` on round 2 doesn't drop APPROVE → COMMENT (inheritance kicks in only for prior PASS/WARN; a prior FAIL still blocks). Prior `critical`/`major` functional findings whose path is in since-last AND is plausibly the area being fixed get one targeted retest scenario; otherwise the resolution-checker + dedup re-evaluate them independently.
+
 ---
 
 ## Per-Project Configuration

--- a/scripts/build-review.sh
+++ b/scripts/build-review.sh
@@ -509,6 +509,22 @@ if [ -f test-plan.md ] && grep -qiE '^## *Technical change: *true *$' test-plan.
   TECHNICAL_CHANGE=true
 fi
 
+# Planner's intended strategy, read directly from test-plan.md so the
+# inheritance branch below can distinguish "planner deliberately chose
+# skip" (round-2 since-last is non-user-observable) from "planner wanted a
+# smoke but the workflow couldn't launch one" (degraded mode: no
+# dev-start.sh, web not ready, no functional-prompt). Both end up with
+# the same synthetic `{strategy:"skip",overall:"PASS"}` placeholder in
+# functional-meta.json, so FUNCTIONAL_STRATEGY alone can't tell them
+# apart. The same parser as in pr-review.yml's strategy resolution.
+PLANNED_STRATEGY=""
+if [ -f test-plan.md ]; then
+  PLANNED_STRATEGY=$(grep -m1 -iE '^## Strategy:' test-plan.md 2>/dev/null \
+    | sed -E 's/.*Strategy:[[:space:]]*//' \
+    | sed -E 's/[^a-zA-Z-]//g' \
+    | tr '[:upper:]' '[:lower:]' || true)
+fi
+
 # Did the smoke test actually pass? Three failure modes to disqualify:
 #
 #   1. Tester crashed (FUNCTIONAL_OK != 1).
@@ -529,19 +545,22 @@ fi
 # types / internal helpers), the prior round's PASS/WARN smoke result still
 # applies — observable behavior didn't change. We inherit it so a one-line
 # follow-up doesn't drop APPROVE → COMMENT just to re-prove the same flow.
-# Inheritance only kicks in on PASS/WARN: a prior FAIL or N/A leaves
-# SMOKE_OK=false and the gate fires as before.
+# Inheritance only kicks in when the PLANNER chose skip (PLANNED_STRATEGY
+# from test-plan.md), AND on prior PASS/WARN. Degraded-mode runs (planner
+# wanted functional, workflow couldn't launch) fall through to no inherit
+# even when prior is PASS/WARN — those have no current smoke evidence.
 SMOKE_OK=false
 SMOKE_INHERITED=false
 if [ "${FUNCTIONAL_OK:-1}" -ne 1 ]; then
   :  # tester crashed
 elif [ "$FUNCTIONAL_STRATEGY" = "skip" ]; then
-  if [ "$PRIOR_FUNCTIONAL_OVERALL" = "PASS" ] || [ "$PRIOR_FUNCTIONAL_OVERALL" = "WARN" ]; then
+  if [ "$PLANNED_STRATEGY" = "skip" ] && { [ "$PRIOR_FUNCTIONAL_OVERALL" = "PASS" ] || [ "$PRIOR_FUNCTIONAL_OVERALL" = "WARN" ]; }; then
     SMOKE_OK=true
     SMOKE_INHERITED=true
     echo "::notice::Smoke gate inherited from prior round (functional_overall=$PRIOR_FUNCTIONAL_OVERALL, strategy=$PRIOR_FUNCTIONAL_STRATEGY) — current planner chose strategy=skip because since-last has no user-observable surface."
   fi
-  # else: tester never launched (degraded mode) AND no prior to inherit — no smoke evidence
+  # else: tester never launched (degraded mode), planner wanted a smoke but couldn't get one,
+  # OR no prior to inherit — no smoke evidence either way.
 elif [ "$FUNCTIONAL_OVERALL" = "PASS" ] || [ "$FUNCTIONAL_OVERALL" = "WARN" ]; then
   SMOKE_OK=true
 fi
@@ -1025,16 +1044,27 @@ fi
 NEXT_ROUND=$((PRIOR_ROUND + 1))
 [ -z "$PRIOR_HEAD_SHA_FROM_STATE" ] && NEXT_ROUND=1
 
-# When this round inherited the smoke result (planner picked skip on a
-# non-user-observable since-last), persist the inherited PASS/WARN so the
-# next round can keep inheriting until something user-observable forces a
-# fresh smoke run. Without this, a chain of internal-only follow-ups would
-# lose the smoke signal at round 3 and APPROVE would drop unnecessarily.
-PERSISTED_FUNCTIONAL_OVERALL="$FUNCTIONAL_OVERALL"
-PERSISTED_FUNCTIONAL_STRATEGY="$FUNCTIONAL_STRATEGY"
+# Decide what to persist for the NEXT round's inheritance check. Three cases:
+#
+#   1. SMOKE_INHERITED=true (planner picked skip + prior PASS/WARN inherited)
+#      → carry the inherited values forward so a chain of internal-only
+#        follow-ups keeps the smoke signal alive.
+#   2. Tester actually ran (FUNCTIONAL_OK=1 AND FUNCTIONAL_STRATEGY != "skip")
+#      → persist the real result.
+#   3. Anything else (crashed, degraded mode, planner-chose-skip with no prior)
+#      → persist empty so the next round CAN'T inherit. The synthetic
+#        `{strategy:"skip",overall:"PASS"}` placeholder used by the workflow
+#        when the tester didn't run would otherwise look like a legitimate
+#        pass to the next round's inheritance check (Cursor #26 + Aikido
+#        flagged this exact leak).
+PERSISTED_FUNCTIONAL_OVERALL=""
+PERSISTED_FUNCTIONAL_STRATEGY=""
 if [ "$SMOKE_INHERITED" = "true" ]; then
   PERSISTED_FUNCTIONAL_OVERALL="$PRIOR_FUNCTIONAL_OVERALL"
   PERSISTED_FUNCTIONAL_STRATEGY="$PRIOR_FUNCTIONAL_STRATEGY"
+elif [ "${FUNCTIONAL_OK:-1}" -eq 1 ] && [ "$FUNCTIONAL_STRATEGY" != "skip" ]; then
+  PERSISTED_FUNCTIONAL_OVERALL="$FUNCTIONAL_OVERALL"
+  PERSISTED_FUNCTIONAL_STRATEGY="$FUNCTIONAL_STRATEGY"
 fi
 
 jq -n \

--- a/scripts/build-review.sh
+++ b/scripts/build-review.sh
@@ -174,6 +174,19 @@ FUNCTIONAL_STRATEGY=$(echo "$FUNCTIONAL_META" | jq -r '.strategy // "skip"')
 FUNCTIONAL_OVERALL=$(echo "$FUNCTIONAL_META" | jq -r '.overall // "N/A"')
 echo "Functional tester: strategy=$FUNCTIONAL_STRATEGY, overall=$FUNCTIONAL_OVERALL"
 
+# Prior round's smoke result (round 2+ only). When the round-2 planner picks
+# strategy=skip because since-last has no user-observable surface, the
+# Technical-change smoke gate below inherits PRIOR_FUNCTIONAL_OVERALL so a
+# small follow-up commit doesn't drop APPROVE → COMMENT just because the
+# tester didn't re-run. Inheritance only kicks in for PASS/WARN — a prior
+# FAIL or N/A doesn't satisfy the gate.
+PRIOR_FUNCTIONAL_OVERALL=""
+PRIOR_FUNCTIONAL_STRATEGY=""
+if [ -f /tmp/prior-state/review-state.json ]; then
+  PRIOR_FUNCTIONAL_OVERALL=$(jq -r '.functional_overall // empty' /tmp/prior-state/review-state.json 2>/dev/null || echo "")
+  PRIOR_FUNCTIONAL_STRATEGY=$(jq -r '.functional_strategy // empty' /tmp/prior-state/review-state.json 2>/dev/null || echo "")
+fi
+
 # ── Screenshot collection and upload ──
 # Playwright MCP saves screenshots to its CWD when the agent passes a
 # plain filename (e.g. "01-name.png") — that resolves to the repo root
@@ -510,11 +523,25 @@ fi
 # Without (2), a technical PR in a repo without dev-start.sh would silently
 # bypass the gate via the synthetic PASS placeholder — exactly the case
 # Cursor flagged on the previous commit.
+#
+# Round-2 inheritance: when the planner deliberately picks strategy=skip
+# because since-last has no user-observable surface (comments / log strings /
+# types / internal helpers), the prior round's PASS/WARN smoke result still
+# applies — observable behavior didn't change. We inherit it so a one-line
+# follow-up doesn't drop APPROVE → COMMENT just to re-prove the same flow.
+# Inheritance only kicks in on PASS/WARN: a prior FAIL or N/A leaves
+# SMOKE_OK=false and the gate fires as before.
 SMOKE_OK=false
+SMOKE_INHERITED=false
 if [ "${FUNCTIONAL_OK:-1}" -ne 1 ]; then
   :  # tester crashed
 elif [ "$FUNCTIONAL_STRATEGY" = "skip" ]; then
-  :  # tester never launched (degraded mode) or planner skipped — no smoke evidence either way
+  if [ "$PRIOR_FUNCTIONAL_OVERALL" = "PASS" ] || [ "$PRIOR_FUNCTIONAL_OVERALL" = "WARN" ]; then
+    SMOKE_OK=true
+    SMOKE_INHERITED=true
+    echo "::notice::Smoke gate inherited from prior round (functional_overall=$PRIOR_FUNCTIONAL_OVERALL, strategy=$PRIOR_FUNCTIONAL_STRATEGY) — current planner chose strategy=skip because since-last has no user-observable surface."
+  fi
+  # else: tester never launched (degraded mode) AND no prior to inherit — no smoke evidence
 elif [ "$FUNCTIONAL_OVERALL" = "PASS" ] || [ "$FUNCTIONAL_OVERALL" = "WARN" ]; then
   SMOKE_OK=true
 fi
@@ -997,6 +1024,19 @@ if [ -f /tmp/prior-state/review-state.json ]; then
 fi
 NEXT_ROUND=$((PRIOR_ROUND + 1))
 [ -z "$PRIOR_HEAD_SHA_FROM_STATE" ] && NEXT_ROUND=1
+
+# When this round inherited the smoke result (planner picked skip on a
+# non-user-observable since-last), persist the inherited PASS/WARN so the
+# next round can keep inheriting until something user-observable forces a
+# fresh smoke run. Without this, a chain of internal-only follow-ups would
+# lose the smoke signal at round 3 and APPROVE would drop unnecessarily.
+PERSISTED_FUNCTIONAL_OVERALL="$FUNCTIONAL_OVERALL"
+PERSISTED_FUNCTIONAL_STRATEGY="$FUNCTIONAL_STRATEGY"
+if [ "$SMOKE_INHERITED" = "true" ]; then
+  PERSISTED_FUNCTIONAL_OVERALL="$PRIOR_FUNCTIONAL_OVERALL"
+  PERSISTED_FUNCTIONAL_STRATEGY="$PRIOR_FUNCTIONAL_STRATEGY"
+fi
+
 jq -n \
   --arg head "$CURRENT_HEAD_SHA" \
   --arg base "$CURRENT_BASE_SHA" \
@@ -1004,6 +1044,8 @@ jq -n \
   --argjson findings "$ALL_FINDINGS" \
   --arg verdict "$VERDICT" \
   --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg functional_overall "$PERSISTED_FUNCTIONAL_OVERALL" \
+  --arg functional_strategy "$PERSISTED_FUNCTIONAL_STRATEGY" \
   '{
     schema_version: 1,
     prior_head_sha: $head,
@@ -1011,7 +1053,11 @@ jq -n \
     round: $round,
     findings: $findings,
     verdict: $verdict,
+    functional_overall: $functional_overall,
+    functional_strategy: $functional_strategy,
     reviewed_at: $ts
   }' > /tmp/review-state.json
-echo "review-state.json: head=$CURRENT_HEAD_SHA round=$NEXT_ROUND findings=$(echo "$ALL_FINDINGS" | jq 'length')"
+INHERITED_TAG=""
+[ "$SMOKE_INHERITED" = "true" ] && INHERITED_TAG=" (inherited)"
+echo "review-state.json: head=$CURRENT_HEAD_SHA round=$NEXT_ROUND findings=$(echo "$ALL_FINDINGS" | jq 'length') functional=$PERSISTED_FUNCTIONAL_OVERALL/$PERSISTED_FUNCTIONAL_STRATEGY${INHERITED_TAG}"
 echo "::endgroup::"

--- a/skills/review-context-builder.md
+++ b/skills/review-context-builder.md
@@ -359,6 +359,24 @@ Choose one of:
 
 Document the strategy in test-plan.md so the agent knows what to do.
 
+### Round-2 scope reduction (REQUIRED when `/tmp/since-last.diff` exists and is non-empty)
+
+On a follow-up review the planner's input is **`/tmp/since-last.diff`** (per-file chunks at `/tmp/since-last-chunks/<file>.diff`), NOT the full PR diff. The first round already validated the rest of the feature; re-running the original plan against unchanged code burns turn budget without adding signal.
+
+**Zero scenarios is a valid round-2 outcome.** If since-last has no user-observable surface — comments, log strings, type-only edits, internal helpers, dev tooling, test/fixture-only changes, doc/config changes — pick `skip`. The smoke gate (`build-review.sh`) inherits the prior round's `functional_overall` for technical-change PRs, so you do NOT need to emit a placeholder `quick` to keep APPROVE alive. Pick `quick`/`functional` only when since-last actually changes something a user would notice.
+
+Apply the strategy table above to the since-last subset:
+
+- since-last empty, docs-only, config-only, comments-only, types-only, internal-only — anything not visible to a user → `skip` (zero scenarios).
+- since-last is a trivial single-area observable edit (<30 LoC) → `quick`, one scenario over the touched area.
+- since-last has real user-observable changes → `functional`, scenarios scoped to the changed files only.
+
+`## Technical change:` is derived from PR title/body and persists across rounds — keep emitting it whenever the original signal still holds, regardless of since-last size.
+
+**Retest rule (optional, judgement).** If `/tmp/prior-state/review-state.json` lists a prior `critical` or `major` *functional* finding (`type` ∈ `spec-mismatch | ui-regression | endpoint-failure | smoke-failure`) whose `path` is in `/tmp/since-last-chunks/` AND the since-last edit plausibly attempts to fix it (touches the same lines or the same function), add one scenario re-verifying that area. If since-last touches the file but in an unrelated area, skip the retest — the prior finding will be re-evaluated by the resolution checker via dedup.
+
+Do NOT include scenarios for files outside `/tmp/since-last-chunks/`. Round 1 covered them. The fallback case (`PRIOR_HEAD_SHA` outside the shallow clone, since-last absent) reverts to round-1 full-diff scoping — see "Diff since last review" above.
+
 ### Scenarios
 
 Write scenarios in test-plan.md following `.claude/skills/review-test-planner.md` format. For each scenario, state:
@@ -366,4 +384,4 @@ Write scenarios in test-plan.md following `.claude/skills/review-test-planner.md
 - Which acceptance criterion it maps to
 - Expected result (status code, UI state, screenshot)
 
-**Max 6 scenarios total** across both UI and API. The agent prefers UI when a page exists; API-only scenarios are for no-UI changes.
+**Max 6 scenarios total** across both UI and API. Round-2 plans typically need 0–2 scenarios — zero is fine when since-last has no user-observable surface (see "Round-2 scope reduction" above). The agent prefers UI when a page exists; API-only scenarios are for no-UI changes.

--- a/skills/review-test-planner.md
+++ b/skills/review-test-planner.md
@@ -29,13 +29,33 @@ Target: **≤6 turns**. Read files in parallel, think, write the plan. That's it
 
 ## Procedure
 
+### Step 0: Round-2 scope reduction (REQUIRED when `/tmp/since-last.diff` exists and is non-empty)
+
+On a follow-up review the planner's input is **`/tmp/since-last.diff`** + per-file chunks at `/tmp/since-last-chunks/<file>.diff`, NOT the full PR diff. Round 1 already validated the rest of the feature; re-running the original plan against unchanged code burns turn budget without adding signal.
+
+**Zero scenarios is a valid round-2 outcome.** If since-last has no user-observable surface — comments, log strings, type-only edits, internal helpers, dev tooling, test/fixture-only changes, doc/config changes — pick `skip`. The smoke gate (`build-review.sh`) inherits the prior round's `functional_overall` for technical-change PRs, so you do NOT need to emit a placeholder `quick` just to keep the gate alive. Pick `quick`/`functional` only when since-last actually changes something a user would notice.
+
+Treat the since-last subset as "what changed" for Step 1. Apply Step 1's strategy table to the since-last diff:
+
+- since-last empty, docs-only, config-only, comments-only, types-only, internal-only — anything not visible to a user → `skip` (zero scenarios).
+- since-last is a trivial single-area observable edit (<30 LoC) → `quick`, one scenario over the touched area.
+- since-last has real user-observable changes → `functional`, scenarios scoped to the changed files only.
+
+`## Technical change:` is derived from PR title/body and persists across rounds — emit it whenever the original signal still holds, regardless of since-last size.
+
+**Retest rule (optional, judgement).** If `/tmp/prior-state/review-state.json` lists a prior `critical` or `major` *functional* finding (`type` ∈ `spec-mismatch | ui-regression | endpoint-failure | smoke-failure`) whose `path` is in `/tmp/since-last-chunks/` AND the since-last edit plausibly attempts to fix it (touches the same lines or function), add one scenario re-verifying that area. If since-last touches the file but in an unrelated area, skip the retest — the resolution checker + dedup re-evaluate prior findings independently.
+
+Do NOT plan scenarios for files outside `/tmp/since-last-chunks/`. The fallback case (`PRIOR_HEAD_SHA` set but the prior commit is outside the shallow clone, so `/tmp/since-last.diff` is absent) reverts to round-1 full-diff scoping — see context.md's "Diff since last review" section for the fallback note.
+
+Round-2 plans typically need 0–2 scenarios, not the round-1 max of 6.
+
 ### Step 1: Classify the PR
 
 From context.md, determine:
 
-1. **What changed** — files, endpoints, pages, components
+1. **What changed** — files, endpoints, pages, components (round 2: from `/tmp/since-last-chunks/` only)
 2. **What the spec says** — acceptance criteria, issue description, PR body
-3. **Change magnitude** — additions + deletions, number of files
+3. **Change magnitude** — additions + deletions, number of files (round 2: of the since-last diff)
 
 Map to a strategy:
 

--- a/tests/round2_inherit_test.sh
+++ b/tests/round2_inherit_test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -uo pipefail
 
-# smoke_inherit_test.sh — fixture test for round-2 smoke-gate inheritance
+# round2_inherit_test.sh — fixture test for round-2 smoke-gate inheritance
 # in build-review.sh. Mirrors the inline SMOKE_OK + persistence logic with
 # the same shape, then asserts behavior across the cases Cursor + Aikido
 # flagged on PR #26:

--- a/tests/smoke_inherit_test.sh
+++ b/tests/smoke_inherit_test.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# smoke_inherit_test.sh — fixture test for round-2 smoke-gate inheritance
+# in build-review.sh. Mirrors the inline SMOKE_OK + persistence logic with
+# the same shape, then asserts behavior across the cases Cursor + Aikido
+# flagged on PR #26:
+#
+#   - planner deliberately chose skip + prior PASS  → inherit + persist
+#   - degraded mode (planner wanted functional, tester didn't run) + prior PASS  → DO NOT inherit
+#   - tester crashed (FUNCTIONAL_OK=0) + synthetic placeholder + prior PASS  → DO NOT inherit, DO NOT persist PASS
+#   - tester ran successfully  → no inherit needed, persist real result
+#   - fresh round 1 + tester ran  → persist real result, no inheritance possible
+#   - prior FAIL + planner chose skip  → DO NOT inherit
+#
+# No LLM key required.
+
+cd "$(dirname "$0")/.."
+
+fail=0
+
+assert_eq() {
+  local label="$1" want="$2" got="$3"
+  if [ "$want" != "$got" ]; then
+    echo "FAIL: $label — want '$want', got '$got'"
+    fail=$((fail + 1))
+  else
+    echo "OK:   $label"
+  fi
+}
+
+# decide_smoke <FUNCTIONAL_OK> <FUNCTIONAL_STRATEGY> <FUNCTIONAL_OVERALL> \
+#              <PLANNED_STRATEGY> <PRIOR_FUNCTIONAL_OVERALL>
+# Echoes "<SMOKE_OK> <SMOKE_INHERITED>". Mirrors build-review.sh:534-563.
+decide_smoke() {
+  local FUNCTIONAL_OK="$1"
+  local FUNCTIONAL_STRATEGY="$2"
+  local FUNCTIONAL_OVERALL="$3"
+  local PLANNED_STRATEGY="$4"
+  local PRIOR_FUNCTIONAL_OVERALL="$5"
+  local SMOKE_OK=false
+  local SMOKE_INHERITED=false
+  if [ "${FUNCTIONAL_OK:-1}" -ne 1 ]; then
+    :
+  elif [ "$FUNCTIONAL_STRATEGY" = "skip" ]; then
+    if [ "$PLANNED_STRATEGY" = "skip" ] && { [ "$PRIOR_FUNCTIONAL_OVERALL" = "PASS" ] || [ "$PRIOR_FUNCTIONAL_OVERALL" = "WARN" ]; }; then
+      SMOKE_OK=true
+      SMOKE_INHERITED=true
+    fi
+  elif [ "$FUNCTIONAL_OVERALL" = "PASS" ] || [ "$FUNCTIONAL_OVERALL" = "WARN" ]; then
+    SMOKE_OK=true
+  fi
+  echo "$SMOKE_OK $SMOKE_INHERITED"
+}
+
+# decide_persist <SMOKE_INHERITED> <FUNCTIONAL_OK> <FUNCTIONAL_STRATEGY> \
+#                <FUNCTIONAL_OVERALL> <PRIOR_FUNCTIONAL_STRATEGY> <PRIOR_FUNCTIONAL_OVERALL>
+# Echoes "<PERSISTED_OVERALL>|<PERSISTED_STRATEGY>". Mirrors build-review.sh:1041-1063.
+decide_persist() {
+  local SMOKE_INHERITED="$1"
+  local FUNCTIONAL_OK="$2"
+  local FUNCTIONAL_STRATEGY="$3"
+  local FUNCTIONAL_OVERALL="$4"
+  local PRIOR_FUNCTIONAL_STRATEGY="$5"
+  local PRIOR_FUNCTIONAL_OVERALL="$6"
+  local PERSISTED_OVERALL=""
+  local PERSISTED_STRATEGY=""
+  if [ "$SMOKE_INHERITED" = "true" ]; then
+    PERSISTED_OVERALL="$PRIOR_FUNCTIONAL_OVERALL"
+    PERSISTED_STRATEGY="$PRIOR_FUNCTIONAL_STRATEGY"
+  elif [ "${FUNCTIONAL_OK:-1}" -eq 1 ] && [ "$FUNCTIONAL_STRATEGY" != "skip" ]; then
+    PERSISTED_OVERALL="$FUNCTIONAL_OVERALL"
+    PERSISTED_STRATEGY="$FUNCTIONAL_STRATEGY"
+  fi
+  echo "${PERSISTED_OVERALL}|${PERSISTED_STRATEGY}"
+}
+
+echo "── Smoke gate decision ──"
+
+# Case A: round-2 planner chose skip + prior PASS → inherit
+assert_eq "A: planner-skip + prior PASS" \
+  "true true" \
+  "$(decide_smoke 1 skip PASS skip PASS)"
+
+# Case B: round-2 planner chose skip + prior WARN → inherit
+assert_eq "B: planner-skip + prior WARN" \
+  "true true" \
+  "$(decide_smoke 1 skip PASS skip WARN)"
+
+# Case C: degraded mode (planner wanted functional, tester didn't launch)
+#         + prior PASS → DO NOT inherit (Aikido finding)
+assert_eq "C: degraded-mode + prior PASS — must NOT inherit" \
+  "false false" \
+  "$(decide_smoke 1 skip PASS functional PASS)"
+
+# Case D: tester crashed (FUNCTIONAL_OK=0) + synthetic placeholder
+#         + prior PASS → first branch catches crash, no inherit
+assert_eq "D: tester-crashed + prior PASS — must NOT inherit" \
+  "false false" \
+  "$(decide_smoke 0 skip PASS functional PASS)"
+
+# Case E: planner-chose-skip + prior FAIL → no inherit (FAIL not in PASS/WARN)
+assert_eq "E: planner-skip + prior FAIL — must NOT inherit" \
+  "false false" \
+  "$(decide_smoke 1 skip PASS skip FAIL)"
+
+# Case F: planner-chose-skip + no prior (round 1 docs PR) → no inherit
+assert_eq "F: planner-skip + no prior — must NOT inherit" \
+  "false false" \
+  "$(decide_smoke 1 skip PASS skip "")"
+
+# Case G: tester ran successfully + functional PASS → SMOKE_OK without inherit
+assert_eq "G: functional PASS — pass without inheritance" \
+  "true false" \
+  "$(decide_smoke 1 functional PASS functional "")"
+
+# Case H: tester ran with WARN → also passes the gate
+assert_eq "H: functional WARN — pass without inheritance" \
+  "true false" \
+  "$(decide_smoke 1 functional WARN functional "")"
+
+# Case I: tester ran with FAIL → fail
+assert_eq "I: functional FAIL — gate fails" \
+  "false false" \
+  "$(decide_smoke 1 functional FAIL functional "")"
+
+# Case J: pipeline-self-test PASS → pass without inheritance
+assert_eq "J: pipeline-self-test PASS" \
+  "true false" \
+  "$(decide_smoke 1 pipeline-self-test PASS pipeline-self-test "")"
+
+echo
+echo "── Persistence decision ──"
+
+# Case K: real functional PASS → persist actual values
+assert_eq "K: real run — persist actual" \
+  "PASS|functional" \
+  "$(decide_persist false 1 functional PASS "" "")"
+
+# Case L: real functional FAIL → persist FAIL (next round won't inherit, but verdict gate uses it)
+assert_eq "L: real FAIL — persist FAIL" \
+  "FAIL|functional" \
+  "$(decide_persist false 1 functional FAIL "" "")"
+
+# Case M: tester crashed + synthetic placeholder → persist EMPTY (Cursor finding)
+assert_eq "M: crashed — must NOT persist synthetic PASS" \
+  "|" \
+  "$(decide_persist false 0 skip PASS "" "")"
+
+# Case N: degraded mode + synthetic placeholder → persist EMPTY (Cursor finding)
+assert_eq "N: degraded mode — must NOT persist synthetic PASS" \
+  "|" \
+  "$(decide_persist false 1 skip PASS "" "")"
+
+# Case O: planner deliberately chose skip + no inheritance → persist EMPTY
+#         (so the next round can't claim inherited evidence from a skip placeholder)
+assert_eq "O: planner-skip without inherit — persist EMPTY" \
+  "|" \
+  "$(decide_persist false 1 skip PASS "" "")"
+
+# Case P: SMOKE_INHERITED=true → carry inherited values forward (chain)
+assert_eq "P: inherited — carry prior forward" \
+  "PASS|functional" \
+  "$(decide_persist true 1 skip PASS functional PASS)"
+
+# Case Q: SMOKE_INHERITED=true with prior WARN → carry WARN forward
+assert_eq "Q: inherited WARN — carry WARN forward" \
+  "WARN|quick" \
+  "$(decide_persist true 1 skip PASS quick WARN)"
+
+# Case R: pipeline-self-test PASS → persist actual
+assert_eq "R: pipeline-self-test — persist actual" \
+  "PASS|pipeline-self-test" \
+  "$(decide_persist false 1 pipeline-self-test PASS "" "")"
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "PASSED: all assertions"
+  exit 0
+else
+  echo "FAILED: $fail assertion(s)"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Round-2 test planner now scopes scenarios to `/tmp/since-last.diff` instead of the full PR diff. Zero scenarios is a first-class outcome when since-last has no user-observable surface (comments, log strings, type-only edits, internal helpers, dev tooling, tests/fixtures).
- Smoke gate inherits the prior round's `functional_overall` so a small follow-up commit on a technical-change PR doesn't drop APPROVE → COMMENT. Inheritance only kicks in for prior `PASS`/`WARN`; a prior `FAIL` or `N/A` still blocks.
- `review-state.json` now persists `functional_overall` + `functional_strategy`, and inherits them through chains of internal-only follow-ups so the smoke signal isn't lost at round 3+.
- Retest rule for prior `critical`/`major` functional findings whose path is in since-last is now judgement-based (only when the since-last edit plausibly attempts the fix) — otherwise the resolution-checker + dedup re-evaluate independently.

## Why

Observed on [Panenco/seaters PR #434 round-2 run](https://github.com/Panenco/seaters/actions/runs/25314103501): round-2 detection works correctly (`Round-2 since-last.diff: 171 lines, 3 per-file chunks`, scoped per-file diff index, resolution-checker launched, verdict ladder fired), but the planner still emitted a full 6-scenario plan covering the entire original feature — including scenarios for files outside since-last (modal reopen, cache invalidation, API health). Functional tester then ran ~18 minutes against that full plan with no signal added beyond round 1.

Under the new rules the planner would drop to 1–2 scenarios scoped to the backend idempotency change in since-last (`TransactionService.java` + `ConstraintExceptionUtils.java`); `transaction.spec.ts` is test-only and contributes nothing on its own.

## What changed

| File | Change |
|------|--------|
| `skills/review-context-builder.md` Turn 6 | New "Round-2 scope reduction" subsection with strategy rules + retest rule. Scenario cap clarified ("0–2 typical"). |
| `skills/review-test-planner.md` | New `Step 0: Round-2 scope reduction` ahead of Step 1, plus inline round-2 notes. |
| `scripts/build-review.sh` | Load `PRIOR_FUNCTIONAL_OVERALL`/`_STRATEGY` from prior state. Inherit to `SMOKE_OK` when current strategy=skip + prior PASS/WARN. Persist `functional_overall` + `functional_strategy` (and inherited values) in `review-state.json`. |
| `README.md` | One-paragraph doc of the new round-2 functional scoping + inheritance behavior. |

## Test plan

- [ ] CI green (existing `tests/dedup_test.sh` still passes locally)
- [ ] Bash syntax check on `build-review.sh` clean
- [ ] On the next push to `Panenco/seaters#434`, observe the test plan drops below 6 scenarios and is scoped to since-last
- [ ] On a subsequent comment-only / type-only follow-up to a technical-change PR, observe `Smoke gate inherited from prior round` notice and APPROVE not blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes verdict-gating logic and what gets persisted in `review-state.json`, which can affect when PRs are auto-approved on follow-up pushes.
> 
> **Overview**
> **Round-2 functional planning is now explicitly scoped to `/tmp/since-last.diff`,** and docs clarify that *zero functional scenarios is valid* when follow-up commits are non-user-observable.
> 
> **The technical-change smoke gate now supports round-2 inheritance:** when the planner intentionally chose `Strategy: skip` and the prior round’s `functional_overall` was `PASS`/`WARN`, `build-review.sh` treats smoke as satisfied and persists the inherited smoke signal across subsequent rounds; it avoids inheriting when the tester didn’t run (degraded mode) or crashed (synthetic `skip/PASS` placeholder).
> 
> Adds a bash fixture test (`tests/round2_inherit_test.sh`) covering the inheritance and persistence decision matrix to prevent regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba1f60ecb6c2691d61684045a22b04ef36eeaae5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->