### PR TITLE
feat(pr-review): OAuth token pool with proactive rate-limit probe

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -49,7 +49,14 @@ on:
         default: 120
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
-        required: true
+        # No longer strictly required: callers can supply CLAUDE_CODE_OAUTH_TOKENS
+        # (a newline-separated pool) instead. The picker step accepts either —
+        # at least one MUST be set, which the picker enforces with a clear error.
+        required: false
+        description: "Single Claude OAuth token (legacy/simple setup). Either this or CLAUDE_CODE_OAUTH_TOKENS is required."
+      CLAUDE_CODE_OAUTH_TOKENS:
+        required: false
+        description: "Optional. Newline-separated pool of Claude OAuth tokens. The picker step probes each at job start (cheap Haiku call), filters to tokens whose 5-hour subscription window still allows calls, and randomly picks one. Use when a single token's 5-hour ceiling is the bottleneck — multiple Claude.ai subscriptions spread the load."
       CLAUDE_REVIEW_APP_CLIENT_ID:
         required: false
       CLAUDE_REVIEW_APP_PRIVATE_KEY:
@@ -76,27 +83,6 @@ jobs:
       packages: read  # needed for fetching from private registries when the consumer repo uses them
 
     steps:
-      - name: Check OAuth token is configured
-        shell: bash
-        env:
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-        run: |
-          if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
-            echo "::error::CLAUDE_CODE_OAUTH_TOKEN secret is not configured."
-            echo "Run 'claude setup-token' locally against a Claude subscription"
-            echo "and add the output as a repo secret named CLAUDE_CODE_OAUTH_TOKEN."
-            exit 1
-          fi
-
-          # Log a stable fingerprint of the OAuth token so the user can tell
-          # which token (and by proxy, which Claude account's quota) is in use.
-          # SHA-256 first 12 hex chars: deterministic per token, leaks nothing.
-          # When you rotate via `claude setup-token`, this fingerprint changes —
-          # cross-check it against the value printed when you last ran setup-token.
-          FINGERPRINT=$(printf '%s' "$CLAUDE_CODE_OAUTH_TOKEN" | shasum -a 256 | cut -c1-12)
-          echo "Claude OAuth token fingerprint: $FINGERPRINT"
-          echo "::notice title=Claude OAuth token::Token fingerprint $FINGERPRINT — if rate-limited, verify this matches the token."
-
       - name: Resolve PR head SHA
         # On `pull_request` events, github.event.pull_request.head.sha is set.
         # On `workflow_dispatch`, that field is empty and we'd otherwise fall
@@ -176,6 +162,40 @@ jobs:
       - name: Install review pipeline (downstream — at pipeline_ref)
         if: github.repository != 'panenco/claude-review'
         uses: ./__claude-review-pipeline
+
+      # The Claude CLI is normally installed implicitly when the
+      # `anthropics/claude-code-action` step runs (later in the job). The
+      # OAuth token picker below needs it earlier — to probe each candidate
+      # token before any review agent is launched. Re-running the official
+      # installer is idempotent: when the action subsequently fires and
+      # finds an existing binary, it leaves it in place.
+      - name: Install Claude CLI (for OAuth token picker)
+        shell: bash
+        run: |
+          if [ -x "$HOME/.local/bin/claude" ]; then
+            echo "Claude CLI already installed: $("$HOME/.local/bin/claude" --version)"
+          else
+            curl -fsSL https://claude.ai/install.sh | bash
+            "$HOME/.local/bin/claude" --version
+          fi
+
+      # OAuth token picker. Reads CLAUDE_CODE_OAUTH_TOKENS (newline-separated
+      # pool) and/or CLAUDE_CODE_OAUTH_TOKEN (single, legacy). When a pool is
+      # supplied, probes each candidate with a Haiku 1-turn call and inspects
+      # the `rate_limit_event` line in stream-json output — picks a token
+      # whose 5-hour window still has capacity. Single-token setups skip the
+      # probe entirely (zero overhead). Writes the chosen token to
+      # $GITHUB_ENV so downstream steps see it as `env.CLAUDE_CODE_OAUTH_TOKEN`.
+      # When every candidate is exhausted, this step exits 1 with a per-token
+      # status table — surfacing the diagnosis up-front instead of letting
+      # the context-builder hit rate_limit on its first call.
+      - name: Pick Claude OAuth token
+        id: token_picker
+        shell: bash
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          CLAUDE_CODE_OAUTH_TOKENS: ${{ secrets.CLAUDE_CODE_OAUTH_TOKENS }}
+        run: .review-scripts/pick-oauth-token.sh
 
       # Validate review-config.md sections (warn on missing recommended sections)
       # and sanity-check that file paths it references actually exist in the repo.
@@ -877,7 +897,11 @@ jobs:
           # last review" section in context.md. Empty/unset on round 1.
           PRIOR_HEAD_SHA: ${{ steps.prior_state.outputs.prior_head_sha }}
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Picked by the `Pick Claude OAuth token` step earlier in the job
+          # (env.CLAUDE_CODE_OAUTH_TOKEN, NOT secrets.…). When a pool is
+          # configured the chosen token has been probe-confirmed to have
+          # 5-hour-window capacity; single-token setups pass through unchanged.
+          claude_code_oauth_token: ${{ env.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.review_identity.outputs.token }}
           prompt: |
             Read ${{ env.CLAUDE_REVIEW_PIPELINE_DIR }}/skills/review-context-builder.md and follow it exactly. PR number: ${{ github.event.pull_request.number || inputs.pr_number }}. When done, context.md AND test-plan.md must exist at the repo root. Write both BEFORE running out of turns — partial output beats no output.
@@ -1028,7 +1052,9 @@ jobs:
         id: claude_run
         shell: bash
         env:
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Picked by the `Pick Claude OAuth token` step earlier in the job —
+          # see comment on `claude_code_oauth_token:` above for rationale.
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ env.CLAUDE_CODE_OAUTH_TOKEN }}
           GH_TOKEN: ${{ steps.review_identity.outputs.token }}
           # Separate token for writing to the review-assets branch: the custom
           # GitHub App token may lack `contents: write`, but the job's

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,5 +25,8 @@ jobs:
       - name: Run dev_env_secrets_test.sh
         run: bash tests/dev_env_secrets_test.sh
 
+      - name: Run pick_oauth_token_test.sh
+        run: bash tests/pick_oauth_token_test.sh
+
       - name: Shellcheck scripts (error-level only)
         run: shellcheck --severity=error scripts/*.sh tests/*.sh

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Add `CLAUDE_CODE_OAUTH_TOKEN` as a repo or org secret. Generate it with:
 claude setup-token
 ```
 
+Optional — when one Claude.ai subscription's 5-hour rate-limit window keeps blocking reviews, run `claude setup-token` against multiple subscriptions and put all tokens (one per line) in a single secret named `CLAUDE_CODE_OAUTH_TOKENS` instead. The pipeline probes each at job start and randomly picks one with capacity available.
+
 Optional: for a custom review bot identity, also set `CLAUDE_REVIEW_APP_CLIENT_ID`, `CLAUDE_REVIEW_APP_PRIVATE_KEY`, and `CLAUDE_REVIEW_APP_SLUG`.
 
 ### 3. (Optional) Add project config

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ runs:
           ls -la "$PIPELINE_DIR/skills/" 2>&1 || true
           exit 1
         fi
-        for s in build-review.sh verdict-gate.sh post-review.sh setup-dev-env.sh generate-functional-prompt.sh phase-timing.sh; do
+        for s in build-review.sh verdict-gate.sh post-review.sh setup-dev-env.sh generate-functional-prompt.sh phase-timing.sh pick-oauth-token.sh; do
           if [ ! -f "$PIPELINE_DIR/scripts/${s}" ]; then
             echo "::error::panenco/claude-review install is incomplete — missing script: ${s}"
             exit 1

--- a/prompts/setup-review.md
+++ b/prompts/setup-review.md
@@ -93,6 +93,10 @@ read-only `GITHUB_TOKEN` scope (see inline comment above).
 ```yaml
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      # Optional pool — see Step 6. Either CLAUDE_CODE_OAUTH_TOKEN or
+      # CLAUDE_CODE_OAUTH_TOKENS must be set; the explicit form requires
+      # listing every secret you want forwarded.
+      CLAUDE_CODE_OAUTH_TOKENS: ${{ secrets.CLAUDE_CODE_OAUTH_TOKENS }}
       CLAUDE_REVIEW_APP_CLIENT_ID: ${{ secrets.CLAUDE_REVIEW_APP_CLIENT_ID }}
       CLAUDE_REVIEW_APP_PRIVATE_KEY: ${{ secrets.CLAUDE_REVIEW_APP_PRIVATE_KEY }}
       CLAUDE_REVIEW_APP_SLUG: ${{ secrets.CLAUDE_REVIEW_APP_SLUG }}
@@ -366,7 +370,10 @@ The OAuth token is required for every repo; the App-token path is how reviews ge
 
 ### Track A — Repos inside the Panenco org (short path)
 
-1. `CLAUDE_CODE_OAUTH_TOKEN` (required) — generate with `claude setup-token` and add as a repo or org secret. Without it the workflow fails at the first step with `::error::CLAUDE_CODE_OAUTH_TOKEN secret is not configured.`
+1. **One of these two secrets is required** — without either, the workflow's `Pick Claude OAuth token` step fails with `::error::No Claude OAuth token configured.`
+
+   - `CLAUDE_CODE_OAUTH_TOKEN` — single token. Generate with `claude setup-token` and add as a repo or org secret. The simple/default setup.
+   - `CLAUDE_CODE_OAUTH_TOKENS` — newline-separated pool. Use when one Claude.ai subscription's 5-hour rate-limit window keeps blocking reviews: run `claude setup-token` against each of several accounts and put the resulting tokens (one per line) in a single multi-line secret. The picker probes each at job start with a cheap Haiku call, filters to tokens whose 5-hour window still has capacity, and randomly picks one. The pool wins when both secrets are set.
 
 2. `CLAUDE_REVIEW_APP_CLIENT_ID`, `CLAUDE_REVIEW_APP_PRIVATE_KEY`, `CLAUDE_REVIEW_APP_SLUG` (recommended) — these are typically already set as **Panenco org secrets** with "All repositories" visibility, so `secrets: inherit` picks them up automatically for any new repo. If they're not, ask a Panenco org owner to add them once, org-wide.
 
@@ -406,7 +413,7 @@ Create, then on the App's settings page:
 
 **Step B2 — Set the four secrets on the target repo (or external org).**
 
-- `CLAUDE_CODE_OAUTH_TOKEN` — generate with `claude setup-token`.
+- `CLAUDE_CODE_OAUTH_TOKEN` — generate with `claude setup-token`. (Or set `CLAUDE_CODE_OAUTH_TOKENS` instead — newline-separated pool of tokens, one per Claude.ai subscription. See Track A's note for when to prefer the pool form.)
 - `CLAUDE_REVIEW_APP_CLIENT_ID`, `CLAUDE_REVIEW_APP_PRIVATE_KEY`, `CLAUDE_REVIEW_APP_SLUG` — from Step B1.
 
 **Step B3 — Install your App on the target repo.**
@@ -424,7 +431,8 @@ It is common to fix one and miss the other on a first setup; the installation pa
 
 | Missing / misconfigured | Failure mode |
 |---|---|
-| `CLAUDE_CODE_OAUTH_TOKEN` | First step fails: `::error::CLAUDE_CODE_OAUTH_TOKEN secret is not configured.` |
+| `CLAUDE_CODE_OAUTH_TOKEN` (and no `CLAUDE_CODE_OAUTH_TOKENS`) | `Pick Claude OAuth token` step fails: `::error::No Claude OAuth token configured.` |
+| `CLAUDE_CODE_OAUTH_TOKENS` set but every token exhausted | `Pick Claude OAuth token` step fails with a per-token status table (`status=blocked` / `status=warning` / `status=invalid` plus `resetsAt`). Wait for a window to reset, or rotate one of the tokens with `claude setup-token` against a different Claude.ai account. |
 | `CLAUDE_REVIEW_APP_*` secrets | "Create GitHub App token" step is **skipped** → `github-actions[bot]` posts the review. Functionally OK, just the wrong identity. |
 | `CLAUDE_REVIEW_APP_*` secrets set, App not installed on repo | "Create GitHub App token" step **fails** with `RequestError [HttpError]: Not Found` / `Failed to create token for "<repo>": Not Found`. Fix: add the repo under the installation's Repository access. |
 | App installed but with "No repositories" | Same `Not Found` as above. Installation record exists but is empty. |

--- a/scripts/pick-oauth-token.sh
+++ b/scripts/pick-oauth-token.sh
@@ -91,12 +91,19 @@ probe_token() {
   printf '%s|%s\n' "$status" "$resets"
 }
 
-# Strip whitespace-only lines and trim each line. Used by both the pool
-# and single-token paths so a trailing newline on a single-token secret
-# (a common foot-gun when pasting into the GitHub UI) doesn't get split
-# into a valid candidate plus an empty one.
+# Trim each line, drop empties, and dedupe (preserving first-occurrence
+# order). Used by both the pool and single-token paths so a trailing
+# newline on a single-token secret (a common foot-gun when pasting into
+# the GitHub UI) doesn't get split into a valid candidate plus an empty
+# one, AND a token pasted twice into the pool doesn't probe twice
+# (wasted Haiku call + inflated pool_size in the operator log).
 trim_lines() {
-  printf '%s\n' "$1" | awk '{ gsub(/^[ \t\r]+|[ \t\r]+$/, "", $0); if (length) print }'
+  printf '%s\n' "$1" | awk '
+    {
+      gsub(/^[ \t\r]+|[ \t\r]+$/, "", $0)
+      if (length && !seen[$0]++) print
+    }
+  '
 }
 
 # Build candidate list. CLAUDE_CODE_OAUTH_TOKENS wins when it has any

--- a/scripts/pick-oauth-token.sh
+++ b/scripts/pick-oauth-token.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# pick-oauth-token.sh — Choose a Claude OAuth token from a pool of one or
+# more candidates, preferring tokens whose 5-hour subscription rate-limit
+# window still allows a call. Backwards-compat with single-token setups
+# (just CLAUDE_CODE_OAUTH_TOKEN set).
+#
+# Why probe? Claude.ai subscription tokens hit a rolling 5-hour ceiling
+# that the headless `/usage` slash command does NOT expose (it returns a
+# static string with no API call). The only proactive signal available is
+# the `rate_limit_event` line emitted by `--output-format stream-json`
+# during a real call — its `rate_limit_info.status` field is "allowed"
+# when the window still has capacity, anything else when it doesn't. So
+# we issue a tiny Haiku probe per candidate, parse the event, and pick a
+# token that's actually usable. Pool of one skips the probe entirely.
+#
+# Inputs (env):
+#   CLAUDE_CODE_OAUTH_TOKENS — optional. Newline-separated pool of tokens.
+#   CLAUDE_CODE_OAUTH_TOKEN  — optional. Single token; used when _TOKENS is
+#                              unset or empty. Also the canonical name the
+#                              CLI and claude-code-action read.
+#   GITHUB_ENV               — set by GitHub Actions; path to write env exports
+#   GITHUB_OUTPUT            — set by GitHub Actions; path to write step outputs
+#   CLAUDE_BIN               — optional override for the claude CLI path
+#                              (default: $HOME/.local/bin/claude)
+#   CLAUDE_PROBE_CMD         — TEST-ONLY override. When set, replaces the real
+#                              CLI probe. Receives the candidate token via
+#                              CLAUDE_CODE_OAUTH_TOKEN in its env and must
+#                              echo a JSON line shaped like the CLI's
+#                              `rate_limit_event` (with rate_limit_info.status
+#                              and rate_limit_info.resetsAt).
+#
+# Outputs:
+#   $GITHUB_ENV    — appends `CLAUDE_CODE_OAUTH_TOKEN=<chosen>`
+#   $GITHUB_OUTPUT — appends `fingerprint=<sha256:12>`, `pool_size=<N>`,
+#                    `healthy_count=<M>`
+#
+# Exit:
+#   0 — picked a token (single-token mode is always 0)
+#   1 — no candidates supplied OR every candidate is exhausted/invalid
+
+set -uo pipefail
+
+# Stable, leak-free fingerprint of a token (first 12 hex of sha256).
+fingerprint() { printf '%s' "$1" | shasum -a 256 | cut -c1-12; }
+
+# Format epoch seconds as UTC ISO-8601 "YYYY-MM-DDTHH:MMZ", or echo back
+# the raw value if neither BSD nor GNU `date` accepts it. Used purely for
+# operator-readable log lines — empty input returns "-".
+format_resets() {
+  local resets="$1"
+  [ -z "$resets" ] && { printf -- '-'; return 0; }
+  date -u -r "$resets" '+%Y-%m-%dT%H:%MZ' 2>/dev/null \
+    || date -u -d "@$resets" '+%Y-%m-%dT%H:%MZ' 2>/dev/null \
+    || printf '%s' "$resets"
+}
+
+# Probe one token. Echoes a single line: "<status>|<resetsAt>".
+# `status` is "allowed" / "blocked" / "warning" (whatever the API returns),
+# OR "invalid" when the probe failed to produce a rate_limit_event line at
+# all (network error, expired token, malformed output). `resetsAt` is the
+# unix epoch seconds, or empty when unavailable.
+probe_token() {
+  local token="$1"
+  local out rle status resets
+  if [ -n "${CLAUDE_PROBE_CMD:-}" ]; then
+    out=$(CLAUDE_CODE_OAUTH_TOKEN="$token" bash -c "$CLAUDE_PROBE_CMD" 2>&1) || true
+  else
+    # Haiku is the cheapest model; the rate limit is account-wide so a
+    # Haiku probe correctly reflects whether subsequent Opus/Sonnet calls
+    # would also be allowed. timeout 30 prevents a hung TLS handshake from
+    # stalling the whole job. --max-turns 1 + "ok" guarantees a single
+    # tool-free assistant turn.
+    out=$(CLAUDE_CODE_OAUTH_TOKEN="$token" timeout 30 \
+      "${CLAUDE_BIN:-$HOME/.local/bin/claude}" -p "ok" \
+        --model claude-haiku-4-5 \
+        --max-turns 1 \
+        --output-format stream-json \
+        --verbose \
+        --setting-sources user \
+        --permission-mode dontAsk \
+      2>&1) || true
+  fi
+
+  rle=$(printf '%s\n' "$out" | grep -m1 '"type":"rate_limit_event"' || true)
+  if [ -z "$rle" ]; then
+    printf 'invalid|\n'
+    return 0
+  fi
+  status=$(printf '%s' "$rle" | jq -r '.rate_limit_info.status // "invalid"' 2>/dev/null || echo invalid)
+  resets=$(printf '%s' "$rle" | jq -r '.rate_limit_info.resetsAt // ""' 2>/dev/null || echo "")
+  printf '%s|%s\n' "$status" "$resets"
+}
+
+# Strip whitespace-only lines and trim each line. Used by both the pool
+# and single-token paths so a trailing newline on a single-token secret
+# (a common foot-gun when pasting into the GitHub UI) doesn't get split
+# into a valid candidate plus an empty one.
+trim_lines() {
+  printf '%s\n' "$1" | awk '{ gsub(/^[ \t\r]+|[ \t\r]+$/, "", $0); if (length) print }'
+}
+
+# Build candidate list. CLAUDE_CODE_OAUTH_TOKENS wins when it has any
+# non-whitespace content; otherwise we fall back to single-token compat.
+# Plain `${X:-Y}` is wrong here — it only falls through when X is unset or
+# the empty string, not when X is "\n   \n" (a real shape when a user
+# saves an empty-looking secret).
+build_candidates() {
+  local out
+  out=$(trim_lines "${CLAUDE_CODE_OAUTH_TOKENS:-}")
+  [ -n "$out" ] || out=$(trim_lines "${CLAUDE_CODE_OAUTH_TOKEN:-}")
+  [ -n "$out" ] && printf '%s\n' "$out"
+  return 0
+}
+
+main() {
+  local CANDIDATES=()
+  while IFS= read -r line; do
+    CANDIDATES+=("$line")
+  done < <(build_candidates)
+  local pool_size=${#CANDIDATES[@]}
+
+  if [ "$pool_size" -eq 0 ]; then
+    echo "::error::No Claude OAuth token configured. Set either CLAUDE_CODE_OAUTH_TOKEN (single) or CLAUDE_CODE_OAUTH_TOKENS (newline-separated pool) as a repo secret."
+    echo "::error::Run 'claude setup-token' locally against a Claude subscription to generate one."
+    exit 1
+  fi
+
+  # Single-token fast path: no decision to make, so skip the probe.
+  if [ "$pool_size" -eq 1 ]; then
+    local fp
+    fp=$(fingerprint "${CANDIDATES[0]}")
+    echo "::notice title=Claude OAuth token::Single token configured (fingerprint $fp). No pool — skipping probe."
+    [ -n "${GITHUB_ENV:-}" ] && printf 'CLAUDE_CODE_OAUTH_TOKEN=%s\n' "${CANDIDATES[0]}" >> "$GITHUB_ENV"
+    if [ -n "${GITHUB_OUTPUT:-}" ]; then
+      printf 'fingerprint=%s\npool_size=1\nhealthy_count=1\n' "$fp" >> "$GITHUB_OUTPUT"
+    fi
+    exit 0
+  fi
+
+  # Multi-token: probe each, build a status table, pick a healthy one.
+  echo "::group::Probing $pool_size OAuth tokens"
+  local i fp result status resets human_resets
+  local STATUSES=() RESETS=() FPS=() ALLOWED_IDX=()
+  for i in "${!CANDIDATES[@]}"; do
+    fp=$(fingerprint "${CANDIDATES[i]}")
+    FPS[i]="$fp"
+    result=$(probe_token "${CANDIDATES[i]}")
+    status="${result%%|*}"
+    resets="${result#*|}"
+    STATUSES[i]="$status"
+    RESETS[i]="$resets"
+    human_resets=$(format_resets "$resets")
+    printf 'token #%d %s — status=%s resetsAt=%s\n' "$i" "$fp" "$status" "$human_resets"
+    [ "$status" = "allowed" ] && ALLOWED_IDX+=("$i")
+  done
+  echo "::endgroup::"
+
+  if [ "${#ALLOWED_IDX[@]}" -eq 0 ]; then
+    echo "::error::All $pool_size OAuth tokens are exhausted or invalid — review cannot run."
+    for i in "${!CANDIDATES[@]}"; do
+      echo "::error::  ${FPS[i]} — status=${STATUSES[i]} resetsAt=$(format_resets "${RESETS[i]}")"
+    done
+    echo "::error::Wait for a token's 5-hour window to reset, or rotate one of the secrets."
+    exit 1
+  fi
+
+  # Random pick spreads load across healthy tokens. Not crypto, just balancing.
+  local pick="${ALLOWED_IDX[$((RANDOM % ${#ALLOWED_IDX[@]}))]}"
+  local chosen="${CANDIDATES[pick]}"
+  local chosen_fp="${FPS[pick]}"
+  echo "::notice title=Claude OAuth token::Picked token #$pick (fingerprint $chosen_fp) from pool of $pool_size — ${#ALLOWED_IDX[@]} healthy."
+
+  [ -n "${GITHUB_ENV:-}" ] && printf 'CLAUDE_CODE_OAUTH_TOKEN=%s\n' "$chosen" >> "$GITHUB_ENV"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf 'fingerprint=%s\npool_size=%s\nhealthy_count=%s\n' \
+      "$chosen_fp" "$pool_size" "${#ALLOWED_IDX[@]}" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+main "$@"

--- a/tests/pick_oauth_token_test.sh
+++ b/tests/pick_oauth_token_test.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# pick_oauth_token_test.sh — exercises scripts/pick-oauth-token.sh end-to-end.
+# Uses CLAUDE_PROBE_CMD to stub out the real Haiku probe so the test runs
+# offline and deterministically. The stub maps token CONTENT to a status
+# (e.g. "allowed-1" → status=allowed, "blocked-1" → status=blocked) so each
+# case can stage the desired pool shape.
+
+cd "$(dirname "$0")/.."
+
+PICKER="scripts/pick-oauth-token.sh"
+[ -x "$PICKER" ] || { echo "FAIL: $PICKER not executable"; exit 1; }
+
+fail=0
+assert_eq() {
+  local label="$1" want="$2" got="$3"
+  if [ "$want" != "$got" ]; then
+    echo "FAIL: $label — want '$want', got '$got'"
+    fail=$((fail + 1))
+  else
+    echo "OK:   $label"
+  fi
+}
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "OK:   $label"
+  else
+    echo "FAIL: $label — expected to find '$needle' in: $haystack"
+    fail=$((fail + 1))
+  fi
+}
+
+# Stub probe. Token content drives the simulated status:
+#   prefix "allowed-" → status=allowed (with future resetsAt)
+#   prefix "blocked-" → status=blocked
+#   prefix "warning-" → status=warning
+#   prefix "noevent-" → emit nothing → picker classifies as invalid
+#   anything else     → status=invalid (no rate_limit_event line)
+PROBE_STUB='
+case "$CLAUDE_CODE_OAUTH_TOKEN" in
+  allowed-*) printf "%s\n" "{\"type\":\"rate_limit_event\",\"rate_limit_info\":{\"status\":\"allowed\",\"resetsAt\":1778065800,\"rateLimitType\":\"five_hour\"}}" ;;
+  blocked-*) printf "%s\n" "{\"type\":\"rate_limit_event\",\"rate_limit_info\":{\"status\":\"blocked\",\"resetsAt\":1778100000,\"rateLimitType\":\"five_hour\"}}" ;;
+  warning-*) printf "%s\n" "{\"type\":\"rate_limit_event\",\"rate_limit_info\":{\"status\":\"warning\",\"resetsAt\":1778099999,\"rateLimitType\":\"five_hour\"}}" ;;
+  noevent-*) printf "%s\n" "{\"type\":\"result\",\"is_error\":true}" ;;
+  *) printf "" ;;
+esac
+'
+export CLAUDE_PROBE_CMD="$PROBE_STUB"
+
+# Per-case GITHUB_ENV / GITHUB_OUTPUT files so we can inspect what the
+# picker tried to export. The picker also exits 0/1, which we capture.
+run_picker() {
+  local tmp env_file out_file
+  tmp=$(mktemp -d)
+  env_file="$tmp/env"
+  out_file="$tmp/out"
+  : > "$env_file"
+  : > "$out_file"
+  GITHUB_ENV="$env_file" GITHUB_OUTPUT="$out_file" \
+    bash "$PICKER" > "$tmp/stdout" 2> "$tmp/stderr"
+  local rc=$?
+  printf 'rc=%s\n' "$rc"
+  printf 'env=%s\n' "$(cat "$env_file")"
+  printf 'out=%s\n' "$(cat "$out_file")"
+  printf 'stdout=%s\n' "$(cat "$tmp/stdout")"
+  printf 'stderr=%s\n' "$(cat "$tmp/stderr")"
+  rm -rf "$tmp"
+}
+
+# --- 1. No tokens at all → exits 1 with a clear error -----------------------
+RESULT=$(unset CLAUDE_CODE_OAUTH_TOKEN CLAUDE_CODE_OAUTH_TOKENS; run_picker)
+assert_eq "No tokens → exits 1" "rc=1" "$(echo "$RESULT" | grep '^rc=')"
+assert_contains "No tokens → error mentions setup-token" "claude setup-token" "$RESULT"
+
+# --- 2. Single CLAUDE_CODE_OAUTH_TOKEN → fast-path, no probe, exit 0 --------
+RESULT=$(unset CLAUDE_CODE_OAUTH_TOKENS
+  CLAUDE_CODE_OAUTH_TOKEN=anything-goes-here run_picker)
+assert_eq "Single token → exits 0" "rc=0" "$(echo "$RESULT" | grep '^rc=')"
+assert_contains "Single token → writes chosen to GITHUB_ENV" \
+  "CLAUDE_CODE_OAUTH_TOKEN=anything-goes-here" "$RESULT"
+assert_contains "Single token → emits pool_size=1" "pool_size=1" "$RESULT"
+assert_contains "Single token → log says 'skipping probe'" "skipping probe" "$RESULT"
+
+# --- 3. Pool of 1 in CLAUDE_CODE_OAUTH_TOKENS → still single-token fast path ---
+RESULT=$(unset CLAUDE_CODE_OAUTH_TOKEN
+  CLAUDE_CODE_OAUTH_TOKENS="allowed-solo" run_picker)
+assert_eq "Pool of 1 → exits 0" "rc=0" "$(echo "$RESULT" | grep '^rc=')"
+assert_contains "Pool of 1 → writes the only token to GITHUB_ENV" \
+  "CLAUDE_CODE_OAUTH_TOKEN=allowed-solo" "$RESULT"
+
+# --- 4. Pool of 3, all allowed → picks one, healthy_count=3 -----------------
+INPUT=$'allowed-1\nallowed-2\nallowed-3'
+RESULT=$(unset CLAUDE_CODE_OAUTH_TOKEN
+  CLAUDE_CODE_OAUTH_TOKENS="$INPUT" run_picker)
+assert_eq "Pool of 3 allowed → exits 0" "rc=0" "$(echo "$RESULT" | grep '^rc=')"
+assert_contains "Pool of 3 allowed → pool_size=3" "pool_size=3" "$RESULT"
+assert_contains "Pool of 3 allowed → healthy_count=3" "healthy_count=3" "$RESULT"
+PICKED=$(echo "$RESULT" | grep -oE 'CLAUDE_CODE_OAUTH_TOKEN=allowed-[123]' | head -1)
+case "$PICKED" in
+  CLAUDE_CODE_OAUTH_TOKEN=allowed-1|CLAUDE_CODE_OAUTH_TOKEN=allowed-2|CLAUDE_CODE_OAUTH_TOKEN=allowed-3)
+    echo "OK:   Pool of 3 allowed → picked one of the three ($PICKED)"
+    ;;
+  *)
+    echo "FAIL: Pool of 3 allowed → did not pick a valid candidate ($PICKED)"
+    fail=$((fail + 1))
+    ;;
+esac
+
+# --- 5. Mixed pool: 1 allowed + 2 blocked → picks the allowed one -----------
+INPUT=$'blocked-1\nallowed-only\nblocked-2'
+RESULT=$(unset CLAUDE_CODE_OAUTH_TOKEN
+  CLAUDE_CODE_OAUTH_TOKENS="$INPUT" run_picker)
+assert_eq "Mixed pool → exits 0" "rc=0" "$(echo "$RESULT" | grep '^rc=')"
+assert_contains "Mixed pool → picks the allowed candidate" \
+  "CLAUDE_CODE_OAUTH_TOKEN=allowed-only" "$RESULT"
+assert_contains "Mixed pool → healthy_count=1" "healthy_count=1" "$RESULT"
+assert_contains "Mixed pool → pool_size=3" "pool_size=3" "$RESULT"
+
+# --- 6. All exhausted (blocked + warning + invalid) → exits 1 with table ----
+INPUT=$'blocked-1\nwarning-2\nnoevent-3'
+RESULT=$(unset CLAUDE_CODE_OAUTH_TOKEN
+  CLAUDE_CODE_OAUTH_TOKENS="$INPUT" run_picker)
+assert_eq "All exhausted → exits 1" "rc=1" "$(echo "$RESULT" | grep '^rc=')"
+assert_contains "All exhausted → error names blocked status" "status=blocked" "$RESULT"
+assert_contains "All exhausted → error names warning status" "status=warning" "$RESULT"
+assert_contains "All exhausted → error names invalid status" "status=invalid" "$RESULT"
+assert_contains "All exhausted → suggests waiting or rotating" \
+  "Wait for a token's 5-hour window" "$RESULT"
+# When all probes fail, we MUST NOT write any token to GITHUB_ENV — a
+# downstream step running with whatever was already in env would silently
+# burn the (also exhausted) token without surfacing the diagnosis.
+ENV_LINE=$(echo "$RESULT" | grep -oE 'env=CLAUDE_CODE_OAUTH_TOKEN=[^ ]+' || true)
+assert_eq "All exhausted → does not export a token to GITHUB_ENV" "" "$ENV_LINE"
+
+# --- 7. Pool with empty/whitespace lines → ignored, doesn't inflate count ---
+INPUT=$'\n  \nallowed-1\n\n  allowed-2  \n'
+RESULT=$(unset CLAUDE_CODE_OAUTH_TOKEN
+  CLAUDE_CODE_OAUTH_TOKENS="$INPUT" run_picker)
+assert_eq "Whitespace-only lines stripped → exits 0" "rc=0" "$(echo "$RESULT" | grep '^rc=')"
+assert_contains "Whitespace-only lines stripped → pool_size=2" "pool_size=2" "$RESULT"
+
+# --- 8. CLAUDE_CODE_OAUTH_TOKENS wins over CLAUDE_CODE_OAUTH_TOKEN ----------
+RESULT=$(CLAUDE_CODE_OAUTH_TOKEN=should-be-ignored \
+  CLAUDE_CODE_OAUTH_TOKENS="allowed-from-pool" run_picker)
+assert_eq "Pool wins over single → exits 0" "rc=0" "$(echo "$RESULT" | grep '^rc=')"
+assert_contains "Pool wins over single → uses pool token" \
+  "CLAUDE_CODE_OAUTH_TOKEN=allowed-from-pool" "$RESULT"
+
+# --- 9. CLAUDE_CODE_OAUTH_TOKENS empty/whitespace falls back to single -----
+RESULT=$(CLAUDE_CODE_OAUTH_TOKEN=allowed-fallback \
+  CLAUDE_CODE_OAUTH_TOKENS=$'\n  \n  \n' run_picker)
+assert_eq "Empty pool → falls back to single → exits 0" \
+  "rc=0" "$(echo "$RESULT" | grep '^rc=')"
+assert_contains "Empty pool → uses single token" \
+  "CLAUDE_CODE_OAUTH_TOKEN=allowed-fallback" "$RESULT"
+assert_contains "Empty pool → fast path (pool_size=1)" "pool_size=1" "$RESULT"
+
+# --- 10. Single token with trailing newline still single (no spurious 2nd) --
+# A common foot-gun: a user pastes a token followed by ENTER into the GitHub
+# secret form, leaving a trailing \n. Without trimming, build_candidates would
+# emit ["token", ""] and the picker would route to the multi-token branch
+# with one guaranteed-failing probe. Trim ensures it stays single-token.
+RESULT=$(unset CLAUDE_CODE_OAUTH_TOKENS
+  CLAUDE_CODE_OAUTH_TOKEN=$'tok-with-trailing-newline\n' run_picker)
+assert_eq "Trailing newline on single → exits 0" "rc=0" "$(echo "$RESULT" | grep '^rc=')"
+assert_contains "Trailing newline on single → pool_size=1 (no probe)" \
+  "pool_size=1" "$RESULT"
+assert_contains "Trailing newline on single → token written without the newline" \
+  "CLAUDE_CODE_OAUTH_TOKEN=tok-with-trailing-newline" "$RESULT"
+
+if [ "$fail" -gt 0 ]; then
+  echo ""
+  echo "FAILED: $fail assertion(s)"
+  exit 1
+fi
+echo ""
+echo "PASSED: all assertions"

--- a/tests/pick_oauth_token_test.sh
+++ b/tests/pick_oauth_token_test.sh
@@ -135,11 +135,18 @@ ENV_LINE=$(echo "$RESULT" | grep -oE 'env=CLAUDE_CODE_OAUTH_TOKEN=[^ ]+' || true
 assert_eq "All exhausted → does not export a token to GITHUB_ENV" "" "$ENV_LINE"
 
 # --- 7. Pool with empty/whitespace lines → ignored, doesn't inflate count ---
+# `  allowed-2  ` exercises inline trimming: if leading/trailing spaces
+# leak through, the stub's `allowed-*` arm misses, the probe returns
+# empty, and the picker classifies it as `invalid`. Asserting BOTH
+# pool_size AND healthy_count is what makes the trim coverage real —
+# pool_size alone passes whether or not trimming worked, since allowed-1
+# is a healthy candidate either way.
 INPUT=$'\n  \nallowed-1\n\n  allowed-2  \n'
 RESULT=$(unset CLAUDE_CODE_OAUTH_TOKEN
   CLAUDE_CODE_OAUTH_TOKENS="$INPUT" run_picker)
 assert_eq "Whitespace-only lines stripped → exits 0" "rc=0" "$(echo "$RESULT" | grep '^rc=')"
 assert_contains "Whitespace-only lines stripped → pool_size=2" "pool_size=2" "$RESULT"
+assert_contains "Inline whitespace trimmed → healthy_count=2" "healthy_count=2" "$RESULT"
 
 # --- 8. CLAUDE_CODE_OAUTH_TOKENS wins over CLAUDE_CODE_OAUTH_TOKEN ----------
 RESULT=$(CLAUDE_CODE_OAUTH_TOKEN=should-be-ignored \
@@ -156,6 +163,19 @@ assert_eq "Empty pool → falls back to single → exits 0" \
 assert_contains "Empty pool → uses single token" \
   "CLAUDE_CODE_OAUTH_TOKEN=allowed-fallback" "$RESULT"
 assert_contains "Empty pool → fast path (pool_size=1)" "pool_size=1" "$RESULT"
+
+# --- 9b. Duplicate tokens in pool → deduped, probed once, counted once ----
+# A user pasting the same token twice into the secret form would otherwise
+# burn an extra Haiku probe and inflate pool_size in operator-visible logs.
+# Trim/dedup runs first; equivalent forms (with vs without surrounding
+# whitespace) collapse to the same entry.
+INPUT=$'allowed-dup\nallowed-dup\n  allowed-dup  \nallowed-other'
+RESULT=$(unset CLAUDE_CODE_OAUTH_TOKEN
+  CLAUDE_CODE_OAUTH_TOKENS="$INPUT" run_picker)
+assert_eq "Duplicates deduped → exits 0" "rc=0" "$(echo "$RESULT" | grep '^rc=')"
+assert_contains "Duplicates deduped → pool_size=2 (3 dup-of-1 + 1 unique)" \
+  "pool_size=2" "$RESULT"
+assert_contains "Duplicates deduped → healthy_count=2" "healthy_count=2" "$RESULT"
 
 # --- 10. Single token with trailing newline still single (no spurious 2nd) --
 # A common foot-gun: a user pastes a token followed by ENTER into the GitHub


### PR DESCRIPTION
## Summary

- Add optional `CLAUDE_CODE_OAUTH_TOKENS` secret (newline-separated pool) alongside the existing single-token `CLAUDE_CODE_OAUTH_TOKEN`. Either is now sufficient to satisfy the workflow's auth requirement.
- New `Pick Claude OAuth token` step probes each candidate with a Haiku 1-turn call, parses the `rate_limit_event` line in stream-json output, and picks a random token whose 5-hour subscription window still has capacity. Single-token setups skip the probe entirely (zero overhead) — fully backwards compatible.
- All-tokens-exhausted produces a per-token status table at the picker step and exits 1, surfacing the diagnosis up-front instead of letting the context-builder hit `rate_limit` on its first call.

## Why

When one Claude.ai subscription's 5-hour ceiling keeps blocking reviews, a pool of tokens (one per subscription) lets the workflow keep running.

The headless `/usage` slash command does NOT expose usage data — it returns a static string with no API call. The only proactive signal available is the `rate_limit_event` line emitted by `--output-format stream-json`:

```json
{"type":"rate_limit_event","rate_limit_info":{"status":"allowed","resetsAt":1778065800,"rateLimitType":"five_hour",...}}
```

`status="allowed"` means the token has capacity; anything else (`blocked` / `warning`) means it'll fail soon. The probe lets us pick proactively instead of failing mid-review.

## Architecture

1. **`scripts/pick-oauth-token.sh`** — picker. Trims and dedupes the candidate list, single-token fast-path skips probing entirely, multi-token mode runs `claude -p "ok" --model claude-haiku-4-5 --max-turns 1 --output-format stream-json --verbose` per candidate. The `CLAUDE_PROBE_CMD` env var injects a stub for offline tests.
2. **Workflow changes** (`.github/workflows/pr-review.yml`):
   - `secrets:` block — both `CLAUDE_CODE_OAUTH_TOKEN` and `CLAUDE_CODE_OAUTH_TOKENS` are optional; the picker enforces "at least one".
   - New `Install Claude CLI (for OAuth token picker)` step — installs the CLI before the picker via the official `claude.ai/install.sh`. Idempotent: when `anthropics/claude-code-action@v1` later runs and finds the binary, it's left in place.
   - New `Pick Claude OAuth token` step — runs the picker, writes the chosen token to `$GITHUB_ENV`.
   - The two consumer references (`claude_code_oauth_token:` input on context-builder, `CLAUDE_CODE_OAUTH_TOKEN` env on the analyze step) read `env.CLAUDE_CODE_OAUTH_TOKEN` instead of `secrets.CLAUDE_CODE_OAUTH_TOKEN`, picking up the chosen token.
3. **Consumer-facing docs** updated per the setup-prompt-parity rule:
   - `prompts/setup-review.md` — pool documented in 4 places (secrets fallback, Track A primary, Track B Step B2, symptom table).
   - `README.md` — pool documented in Quick Start.
4. **`action.yml`** — `pick-oauth-token.sh` added to install-time validation list.
5. **`tests/pick_oauth_token_test.sh`** — 32 assertions across 10 cases. Stub probe via `CLAUDE_PROBE_CMD` so the test runs offline and deterministically. Wired into `tests.yml` CI.

## Behaviour contract

- Single token (today's setup): no behaviour change beyond the small CLI-install-step overhead happening earlier in the job.
- Pool of N tokens: ~2-10s of probe overhead per token at job start (Haiku, single turn), then the chosen token runs the entire review (per-job pick, agreed scope).
- All tokens exhausted: fail-fast at the picker step with a per-token table (status + `resetsAt`), before any agent runs.
- Mid-job rate-limit on the chosen token: existing `verdict-gate.sh` detection remains the safety net (no mid-job retry — would require restructuring the entire pipeline to be re-runnable).

## Trade-offs / known limitations

- **Sequential probing.** ~2-10s per token, scales linearly. Acceptable for typical 2-5 token pools; if pools grow large, parallelizing is a follow-up.
- **`claude.ai/install.sh` is unpinned.** Same supply-chain risk as `npm install -g @anthropic-ai/claude-code` and equivalent to what `anthropics/claude-code-action@v1` already does internally.
- **`status="warning"` is treated as not-pickable.** Conservative: better than picking a token that fails a few minutes into the review.
- **Concurrent PR runs can race on the same "allowed" token.** Random pick statistically helps; reactive verdict-gate detection catches the rest.

## Test plan

- [x] `tests/pick_oauth_token_test.sh` — 32 assertions, all passing
- [x] `tests/dedup_test.sh`, `tests/dev_env_secrets_test.sh`, `tests/round2_inherit_test.sh` — no regressions
- [x] `shellcheck --severity=error scripts/*.sh tests/*.sh` — clean
- [x] YAML syntax check on all 4 workflow/action files — pass
- [x] Real-CLI smoke test — `rate_limit_event.status=allowed` parses correctly with the `jq` logic
- [x] Fake-binary smoke test — picker correctly classifies `status=invalid` and exits 1 with the per-token table
- [x] End-to-end run of both single-token and multi-token paths against the picker locally
- [ ] First in-CI run on this PR will dogfood the picker (single-token mode for this repo)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how OAuth credentials are selected and injected into the review workflow and adds a new early CLI install + probe call that can fail fast and block runs if misconfigured.
> 
> **Overview**
> Adds support for an optional `CLAUDE_CODE_OAUTH_TOKENS` secret (newline-separated pool) and a new early workflow step that probes tokens for 5-hour rate-limit capacity, picks a healthy one, and exports it as `CLAUDE_CODE_OAUTH_TOKEN` for downstream review steps.
> 
> Updates the reusable workflow to install the Claude CLI earlier for probing, switches claude steps to consume `env.CLAUDE_CODE_OAUTH_TOKEN` (instead of `secrets`), and fails fast with clearer diagnostics when no usable token exists.
> 
> Includes a new `scripts/pick-oauth-token.sh`, CI coverage via `tests/pick_oauth_token_test.sh`, action install-time validation updates, and documentation changes in `README.md` and `prompts/setup-review.md` to describe the pool setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68cf2d55accb17803663ef1f367899540383412a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->