### PR TITLE
fix(review): false-positive lint + repo-asset PNG pickup + JSON-as-screenshot rendering

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -942,10 +942,25 @@ jobs:
           # is total. Skip silently when npx is unavailable — docs-only
           # repos legitimately have no Node and the orchestrator never
           # dispatches the functional subagent there anyway.
+          # Use `npx -p ... -- node -e 'process.exit(0)'` rather than
+          # `--version`. The MCP server is a long-running stdio process
+          # whose `--version` handling is inconsistent across releases
+          # (some return 1 when stdin is closed, which made the previous
+          # pre-warm fail loudly with `::warning::` on every consumer
+          # review even though the server was perfectly fine to lazy-spawn
+          # later). The `-p <pkg> -- node -e 'true'` form triggers npx's
+          # tarball-cache download path without ever invoking the server
+          # itself, so we get the cache-warming benefit and a reliable
+          # exit code. Falls back to a notice (not warning) on failure
+          # — the lazy-spawn path still works, this is purely a perf
+          # optimisation.
           if command -v npx >/dev/null 2>&1; then
             echo "Pre-warming @playwright/mcp@latest..."
-            npx --yes @playwright/mcp@latest --version 2>&1 | head -5 || \
-              echo "::warning::@playwright/mcp@latest pre-warm failed — functional tester may still hit MCP startup timeout. See log above for npx output."
+            if npx --yes -p @playwright/mcp@latest -- node -e 'process.exit(0)' >/dev/null 2>&1; then
+              echo "@playwright/mcp@latest tarball cached for the lazy-spawn path."
+            else
+              echo "::notice::@playwright/mcp@latest pre-warm did not succeed; functional tester will lazy-spawn (cold start ~10-20s)."
+            fi
           else
             echo "npx not on PATH — skipping Playwright MCP pre-warm (no functional run expected)."
           fi

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -153,7 +153,7 @@ jobs:
 
       - name: Checkout review pipeline at pipeline_ref (downstream)
         if: github.repository != 'panenco/claude-review'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: panenco/claude-review
           ref: ${{ inputs.pipeline_ref }}
@@ -649,7 +649,7 @@ jobs:
       - name: Download prior review state
         if: steps.prior_run.outputs.run_id != ''
         continue-on-error: true
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: claude-review-state-pr-${{ github.event.pull_request.number || inputs.pr_number }}
           path: /tmp/prior-state

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -238,11 +238,22 @@ jobs:
           # / `cat FILE` commands in both review-config.md and dev-start.sh.
           # Catches the "points at a file that doesn't exist" class of bug
           # without needing to parse shell.
+          #
+          # The path filter requires the captured token to contain `/` or
+          # `.` (with at least one character on either side). Without that
+          # guard, English prose like "cat is the file" / "the source tree"
+          # / "via the cp command" matches the regex's second word and
+          # produces false positives — observed in seaters' review-config
+          # which uses these words in markdown explanatory paragraphs. A
+          # genuine file path almost always carries a slash or extension
+          # dot, so the filter is a high-recall heuristic for the bug
+          # class this lint targets.
           SCAN_FILES=""
           [ -f "$CONFIG" ] && SCAN_FILES="$CONFIG"
           [ -f "$DEV_SCRIPT" ] && SCAN_FILES="$SCAN_FILES $DEV_SCRIPT"
           REFERENCED_PATHS=$(grep -hoE '(cp|source|cat) +[A-Za-z0-9._/-]+' $SCAN_FILES 2>/dev/null | \
             awk '{print $2}' | \
+            grep -E '/|.\..' | \
             sort -u || true)
           MISSING_PATHS=""
           while IFS= read -r p; do

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install jq + shellcheck
         run: sudo apt-get install -y --no-install-recommends jq shellcheck
@@ -33,6 +33,9 @@ jobs:
 
       - name: Run round2_resolution_test.sh
         run: bash tests/round2_resolution_test.sh
+
+      - name: Run functional_findings_merge_test.sh
+        run: bash tests/functional_findings_merge_test.sh
 
       - name: Run verdict_ladder_test.sh
         run: bash tests/verdict_ladder_test.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Run functional_findings_merge_test.sh
         run: bash tests/functional_findings_merge_test.sh
 
+      - name: Run screenshot_allowlist_test.sh
+        run: bash tests/screenshot_allowlist_test.sh
+
       - name: Run verdict_ladder_test.sh
         run: bash tests/verdict_ladder_test.sh
 

--- a/scripts/build-review.sh
+++ b/scripts/build-review.sh
@@ -223,44 +223,61 @@ if [ -f /tmp/prior-state/review-state.json ]; then
 fi
 
 # ── Screenshot collection and upload ──
-# Playwright MCP saves screenshots to its CWD when the agent passes a
-# plain filename (e.g. "01-name.png") — that resolves to the repo root
-# in our setup. --output-dir doesn't override agent-chosen paths.
-# So we scan: agent's likely cwd (.), /tmp/screenshots (if agent used
-# an absolute path), and a few historical alternate paths.
-#
-# CRITICAL: every find filters by `-mmin -60` (modified in the last 60
-# minutes) so we never pick up pre-existing repo content. Without this
-# filter the scan of `.` and `screenshots/` would scoop up checked-in
-# product assets — e.g. a consumer repo with `screenshots/wl_logo.png`
-# as a static UI image — and upload them as if they were review
-# screenshots. (Observed on Panenco/seaters#471 round 1: 3 product
-# logos uploaded under pr-471/, then the body's `urls[basename]`
-# lookup missed for the agent's actual files because the basenames
-# didn't match the unrelated logos.)
+# We collect ONLY the basenames the functional tester named in
+# functional-meta.screenshots[].file (and functional-findings[].screenshot).
+# Earlier versions scanned the consumer repo's CWD with `find . -name '*.png'`
+# and a `-mmin -60` mtime filter, but `actions/checkout` rewrites all
+# checked-in file mtimes to ~now — so the filter cannot distinguish a
+# checked-in product asset (e.g. seaters' `screenshots/wl_logo.png`) from
+# a freshly captured tester screenshot. Cursor caught this on PR #30;
+# the only safe rule is to upload exactly what the tester says it wrote.
 SCREENSHOT_URLS='{}'
 mkdir -p /tmp/all-screenshots
 # Short-circuit when the functional tester didn't run or didn't produce
-# any image-typed screenshots[] entries. Without this guard build-review
-# would still scan the consumer repo for PNGs and run the review-assets
-# upload, which means a docs-only / strategy=skip review on a repo that
-# has any pre-existing PNG (a `screenshots/` UI assets folder is common)
-# would commit those PNGs to review-assets/pr-N/. The mtime filter below
-# already drops pre-existing files, but skipping the whole pipeline when
-# there's nothing to embed is cleaner.
+# any image-typed screenshots[] entries. This both saves the upload work
+# and guarantees a docs-only / strategy=skip review on a repo with any
+# pre-existing PNG never commits those PNGs to review-assets/pr-N/.
 EXPECTED_IMAGE_SHOTS=$(echo "$FUNCTIONAL_META" | jq '[(.screenshots // [])[] | select((.file // "") | test("\\.(png|jpg|jpeg|webp)$"; "i"))] | length')
 if [ "$FUNCTIONAL_STRATEGY" = "skip" ] || [ "${EXPECTED_IMAGE_SHOTS:-0}" -eq 0 ]; then
   echo "Skipping screenshot collection + upload (strategy=$FUNCTIONAL_STRATEGY, expected_image_screenshots=${EXPECTED_IMAGE_SHOTS:-0})."
 else
-  for src_dir in . /tmp/screenshots /tmp/playwright-mcp-output .playwright-mcp screenshots .playwright-mcp/screenshots; do
-    [ -d "$src_dir" ] || continue
-    find "$src_dir" -maxdepth 2 -name '*.png' -mmin -60 -not -path '*/node_modules/*' -exec cp -n {} /tmp/all-screenshots/ \; 2>/dev/null || true
-  done
-  # Final fallback: scan /tmp recursively for any PNG produced in the last hour.
-  if ! ls /tmp/all-screenshots/*.png >/dev/null 2>&1; then
-    echo "No screenshots in expected paths — scanning /tmp recursively for recent PNGs..."
-    find /tmp -name '*.png' -mmin -60 -not -path '/tmp/all-screenshots/*' -exec cp -n {} /tmp/all-screenshots/ \; 2>/dev/null || true
-  fi
+  # Build the allowlist: every `file` field across screenshots[] and
+  # findings[].screenshot. Resolve to absolute paths first (the tester
+  # is contract-bound to write under /tmp/screenshots/ but legacy
+  # plain-filename paths get expanded relative to ., the tester's CWD).
+  FN_INPUT="[]"
+  [ -f /tmp/functional-findings.json ] && jq -e 'type == "array"' /tmp/functional-findings.json >/dev/null 2>&1 \
+    && FN_INPUT=$(cat /tmp/functional-findings.json)
+  EXPECTED_FILES=$(jq -n \
+    --argjson meta "$FUNCTIONAL_META" \
+    --argjson fn "$FN_INPUT" \
+    'def img_paths: map(select(type == "string" and (test("\\.(png|jpg|jpeg|webp)$"; "i")))) | unique;
+     (($meta.screenshots // []) | map(.file // ""))
+     + (($fn // []) | map(.screenshot // ""))
+     | img_paths')
+  echo "Functional tester named $(echo "$EXPECTED_FILES" | jq 'length') screenshot path(s); resolving each."
+  while read -r expected; do
+    [ -z "$expected" ] && continue
+    base=$(basename "$expected")
+    # 1) Absolute path the tester wrote (preferred — /tmp/screenshots/...).
+    if [ -f "$expected" ]; then
+      cp -n "$expected" "/tmp/all-screenshots/$base"
+      continue
+    fi
+    # 2) Plain-filename fallback: the tester used a relative path that
+    #    Playwright MCP expanded against its CWD. Check the agent-only
+    #    output dirs first, then the repo root as a last resort —
+    #    bound to a basename match so we never pick up unrelated PNGs.
+    found=""
+    for d in /tmp/screenshots /tmp/playwright-mcp-output .playwright-mcp .playwright-mcp/screenshots screenshots .; do
+      [ -f "$d/$base" ] && { found="$d/$base"; break; }
+    done
+    if [ -n "$found" ]; then
+      cp -n "$found" "/tmp/all-screenshots/$base"
+    else
+      echo "::notice::Functional tester referenced screenshot '$expected' but the file was not produced on disk (basename '$base' not found in /tmp/screenshots, /tmp/playwright-mcp-output, .playwright-mcp{,/screenshots}, screenshots, or repo root)."
+    fi
+  done < <(echo "$EXPECTED_FILES" | jq -r '.[]')
 fi
 SCREENSHOT_DIR=""
 if ls /tmp/all-screenshots/*.png >/dev/null 2>&1; then

--- a/scripts/build-review.sh
+++ b/scripts/build-review.sh
@@ -215,15 +215,28 @@ fi
 # didn't match the unrelated logos.)
 SCREENSHOT_URLS='{}'
 mkdir -p /tmp/all-screenshots
-for src_dir in . /tmp/screenshots /tmp/playwright-mcp-output .playwright-mcp screenshots .playwright-mcp/screenshots; do
-  if [ -d "$src_dir" ]; then
-    find "$src_dir" -maxdepth 2 -name '*.png' -mmin -60 -not -path '*/node_modules/*' -exec cp -n {} /tmp/all-screenshots/ \; 2>/dev/null || true
+# Short-circuit when the functional tester didn't run or didn't produce
+# any image-typed screenshots[] entries. Without this guard build-review
+# would still scan the consumer repo for PNGs and run the review-assets
+# upload, which means a docs-only / strategy=skip review on a repo that
+# has any pre-existing PNG (a `screenshots/` UI assets folder is common)
+# would commit those PNGs to review-assets/pr-N/. The mtime filter below
+# already drops pre-existing files, but skipping the whole pipeline when
+# there's nothing to embed is cleaner.
+EXPECTED_IMAGE_SHOTS=$(echo "$FUNCTIONAL_META" | jq '[(.screenshots // [])[] | select((.file // "") | test("\\.(png|jpg|jpeg|webp)$"; "i"))] | length')
+if [ "$FUNCTIONAL_STRATEGY" = "skip" ] || [ "${EXPECTED_IMAGE_SHOTS:-0}" -eq 0 ]; then
+  echo "Skipping screenshot collection + upload (strategy=$FUNCTIONAL_STRATEGY, expected_image_screenshots=${EXPECTED_IMAGE_SHOTS:-0})."
+else
+  for src_dir in . /tmp/screenshots /tmp/playwright-mcp-output .playwright-mcp screenshots .playwright-mcp/screenshots; do
+    if [ -d "$src_dir" ]; then
+      find "$src_dir" -maxdepth 2 -name '*.png' -mmin -60 -not -path '*/node_modules/*' -exec cp -n {} /tmp/all-screenshots/ \; 2>/dev/null || true
+    fi
+  done
+  # Final fallback: scan /tmp recursively for any PNG produced in the last hour.
+  if ! ls /tmp/all-screenshots/*.png >/dev/null 2>&1; then
+    echo "No screenshots in expected paths — scanning /tmp recursively for recent PNGs..."
+    find /tmp -name '*.png' -mmin -60 -not -path '/tmp/all-screenshots/*' -exec cp -n {} /tmp/all-screenshots/ \; 2>/dev/null || true
   fi
-done
-# Final fallback: scan /tmp recursively for any PNG produced in the last hour.
-if ! ls /tmp/all-screenshots/*.png >/dev/null 2>&1; then
-  echo "No screenshots in expected paths — scanning /tmp recursively for recent PNGs..."
-  find /tmp -name '*.png' -mmin -60 -not -path '/tmp/all-screenshots/*' -exec cp -n {} /tmp/all-screenshots/ \; 2>/dev/null || true
 fi
 SCREENSHOT_DIR=""
 if ls /tmp/all-screenshots/*.png >/dev/null 2>&1; then

--- a/scripts/build-review.sh
+++ b/scripts/build-review.sh
@@ -203,13 +203,21 @@ fi
 # in our setup. --output-dir doesn't override agent-chosen paths.
 # So we scan: agent's likely cwd (.), /tmp/screenshots (if agent used
 # an absolute path), and a few historical alternate paths.
+#
+# CRITICAL: every find filters by `-mmin -60` (modified in the last 60
+# minutes) so we never pick up pre-existing repo content. Without this
+# filter the scan of `.` and `screenshots/` would scoop up checked-in
+# product assets — e.g. a consumer repo with `screenshots/wl_logo.png`
+# as a static UI image — and upload them as if they were review
+# screenshots. (Observed on Panenco/seaters#471 round 1: 3 product
+# logos uploaded under pr-471/, then the body's `urls[basename]`
+# lookup missed for the agent's actual files because the basenames
+# didn't match the unrelated logos.)
 SCREENSHOT_URLS='{}'
 mkdir -p /tmp/all-screenshots
-# maxdepth 2: catches files at repo root (./*.png) plus one level of
-# subdir nesting (./screenshots/*.png), without scanning node_modules.
 for src_dir in . /tmp/screenshots /tmp/playwright-mcp-output .playwright-mcp screenshots .playwright-mcp/screenshots; do
   if [ -d "$src_dir" ]; then
-    find "$src_dir" -maxdepth 2 -name '*.png' -not -path '*/node_modules/*' -exec cp -n {} /tmp/all-screenshots/ \; 2>/dev/null || true
+    find "$src_dir" -maxdepth 2 -name '*.png' -mmin -60 -not -path '*/node_modules/*' -exec cp -n {} /tmp/all-screenshots/ \; 2>/dev/null || true
   fi
 done
 # Final fallback: scan /tmp recursively for any PNG produced in the last hour.
@@ -677,7 +685,7 @@ jq -n \
       strategy: ($functional_meta.strategy // "skip"),
       overall: ($functional_meta.overall // "N/A"),
       areas_tested: ($functional_meta.areas_tested // []),
-      screenshot_count: (($functional_meta.screenshots // []) | length)
+      screenshot_count: (($functional_meta.screenshots // []) | map(select((.file // "") | test("\\.(png|jpg|jpeg|webp)$"; "i"))) | length)
     }
   }' > review-result.json
 
@@ -820,7 +828,9 @@ EXTERNAL=$(jq -r '.spec_sources.external_issue // empty' review-result.json)
 TEST_PLAN_EXISTS="false"
 [ -f test-plan.md ] && TEST_PLAN_EXISTS="true"
 
-FUNCTIONAL_SCREENSHOT_COUNT=$(echo "$FUNCTIONAL_META" | jq '(.screenshots // []) | length')
+# Count only image-typed entries — see review-result.json's
+# screenshot_count above for the rationale.
+FUNCTIONAL_SCREENSHOT_COUNT=$(echo "$FUNCTIONAL_META" | jq '(.screenshots // []) | map(select((.file // "") | test("\\.(png|jpg|jpeg|webp)$"; "i"))) | length')
 FUNCTIONAL_OK="${FUNCTIONAL_OK:-1}"
 if [ "$FUNCTIONAL_OVERALL" != "N/A" ] && [ "$FUNCTIONAL_STRATEGY" != "skip" ]; then
   # CRASH gets the ❌ marker — the orchestrator now writes
@@ -867,9 +877,14 @@ if [ "$FUNCTIONAL_OVERALL" != "N/A" ] && [ "$FUNCTIONAL_STRATEGY" != "skip" ]; t
     if [ "$FUNCTIONAL_SCREENSHOT_COUNT" -gt 0 ]; then
       echo "#### Screenshots"
       echo ""
+      # Skip non-image entries up front: the functional tester sometimes
+      # records API-response JSON dumps as "screenshots" for API-only
+      # scenarios; we only render actual image files so the body never
+      # claims a screenshot exists when there is nothing to embed.
       echo "$FUNCTIONAL_META" | jq -r --argjson urls "$SCREENSHOT_URLS" \
         --arg repo "$GITHUB_REPOSITORY" --arg run "${GITHUB_RUN_ID:-}" '
         .screenshots[] |
+        select((.file // "") | test("\\.(png|jpg|jpeg|webp)$"; "i")) |
         .file as $file |
         ($file | split("/") | last) as $basename |
         ($urls[$basename] // null) as $url |

--- a/scripts/build-review.sh
+++ b/scripts/build-review.sh
@@ -137,6 +137,31 @@ if [ -f /tmp/resolution-findings.json ] && jq -e 'type == "array" and length > 0
   ALL_FINDINGS="$MERGED"
 fi
 
+# Defensive merge of functional-tester findings. Same pattern + reason
+# as the resolution-findings merge above — the orchestrator skill folds
+# `/tmp/functional-findings.json` into `/tmp/all-findings.json` so that
+# (a) the verdict gate counts UI/contract findings as blockers and
+# (b) findings carrying a `screenshot` path reach the inline-comment
+# builder at the bottom of this script (the `![screenshot](url)` embed
+# only fires for entries in $ALL_FINDINGS). Without this safety net a
+# functional finding lands only in the body's "Issues found" list and
+# the developer never sees the screenshot at the offending diff line.
+# Dedup by id is mandatory: judges sometimes re-discover the same UI
+# bug with a different id, and the orchestrator may have already folded
+# the functional entry, in which case its id wins.
+if [ -f /tmp/functional-findings.json ] && jq -e 'type == "array" and length > 0' /tmp/functional-findings.json >/dev/null 2>&1; then
+  PREV_LEN=$(echo "$ALL_FINDINGS" | jq 'length')
+  MERGED=$(jq -n --argjson primary "$ALL_FINDINGS" --slurpfile fn /tmp/functional-findings.json '
+    ($primary | map(.id)) as $seen |
+    $primary + (($fn[0] // []) | map(select(.id as $id | $seen | index($id) | not)))
+  ')
+  ADDED=$(( $(echo "$MERGED" | jq 'length') - PREV_LEN ))
+  if [ "$ADDED" -gt 0 ]; then
+    echo "::notice::Defensive-merged $ADDED functional-finding(s) the orchestrator hadn't already folded into /tmp/all-findings.json."
+  fi
+  ALL_FINDINGS="$MERGED"
+fi
+
 TOTAL=$(echo "$ALL_FINDINGS" | jq 'length')
 echo "Orchestrator findings: total=$TOTAL (judge_health: $(echo "$CORE_META" | jq -c '.judge_health // {}'))"
 
@@ -228,9 +253,8 @@ if [ "$FUNCTIONAL_STRATEGY" = "skip" ] || [ "${EXPECTED_IMAGE_SHOTS:-0}" -eq 0 ]
   echo "Skipping screenshot collection + upload (strategy=$FUNCTIONAL_STRATEGY, expected_image_screenshots=${EXPECTED_IMAGE_SHOTS:-0})."
 else
   for src_dir in . /tmp/screenshots /tmp/playwright-mcp-output .playwright-mcp screenshots .playwright-mcp/screenshots; do
-    if [ -d "$src_dir" ]; then
-      find "$src_dir" -maxdepth 2 -name '*.png' -mmin -60 -not -path '*/node_modules/*' -exec cp -n {} /tmp/all-screenshots/ \; 2>/dev/null || true
-    fi
+    [ -d "$src_dir" ] || continue
+    find "$src_dir" -maxdepth 2 -name '*.png' -mmin -60 -not -path '*/node_modules/*' -exec cp -n {} /tmp/all-screenshots/ \; 2>/dev/null || true
   done
   # Final fallback: scan /tmp recursively for any PNG produced in the last hour.
   if ! ls /tmp/all-screenshots/*.png >/dev/null 2>&1; then

--- a/skills/review-orchestrator.md
+++ b/skills/review-orchestrator.md
@@ -189,6 +189,8 @@ Use the **most recent** outputs from each judge.
 
 Net-new findings the thread classifier surfaced (`/tmp/resolution-findings.json`, when present and non-empty) flow through the same union — append them to the consolidated array with their original ids.
 
+Functional-tester findings (`/tmp/functional-findings.json`, when present and non-empty) also flow through the union — append them with their original ids. This is load-bearing: each functional finding may carry a `screenshot` field, and the inline-comment builder downstream embeds `![screenshot](url)` only for entries that reach `/tmp/all-findings.json`. Skipping this step demotes every functional issue to the body gallery and strips the at-the-line evidence from the developer's view.
+
 ### Verdict consolidation
 
 - If both judges agree on verdict → use it.

--- a/tests/functional_findings_merge_test.sh
+++ b/tests/functional_findings_merge_test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# functional_findings_merge_test.sh — fixture test for the
+# functional-tester defensive merge in build-review.sh.
+#
+# Background. Each functional-tester finding can carry a `screenshot:
+# /tmp/screenshots/NN-name.png` field. The inline-comment builder at
+# the bottom of build-review.sh embeds `![screenshot](url)` only for
+# entries that reach `/tmp/all-findings.json` — so functional findings
+# that don't merge into ALL_FINDINGS lose their at-the-line image
+# evidence and survive only in the body's "Functional Validation"
+# gallery (no diff-line anchor, no inline thread).
+#
+# This test exercises the merge expression in three regimes:
+#   - net-new functional finding folds in with its screenshot intact
+#   - functional finding the orchestrator already folded is deduped
+#   - both empty → merge is a no-op (defence-in-depth path stays sane)
+
+cd "$(dirname "$0")/.."
+
+fail=0
+assert_eq() {
+  local label="$1" want="$2" got="$3"
+  if [ "$want" != "$got" ]; then
+    echo "FAIL: $label — want '$want', got '$got'"
+    fail=$((fail + 1))
+  else
+    echo "OK:   $label"
+  fi
+}
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+merge() {
+  local primary_file="$1" functional_file="$2"
+  jq -n \
+    --argjson primary "$(cat "$primary_file")" \
+    --slurpfile fn "$functional_file" \
+    '($primary | map(.id)) as $seen
+     | $primary + (($fn[0] // []) | map(select(.id as $id | $seen | index($id) | not)))'
+}
+
+# ── Block 1: net-new functional finding folds in, screenshot preserved ──
+cat > "$TMP/all-findings-1.json" <<'JSON'
+[
+  {"id":"j1","severity":"major","path":"src/a.ts","line_start":10,"title":"Judge finding","evidence":"x","reasoning":"y","expected":"z","type":"finding"}
+]
+JSON
+cat > "$TMP/functional-1.json" <<'JSON'
+[
+  {"id":"f1","severity":"major","path":"src/c.ts","line_start":30,"title":"Submit button missing","evidence":"button[type=submit] not in DOM","reasoning":"y","expected":"z","type":"finding","screenshot":"/tmp/screenshots/02-form.png"}
+]
+JSON
+M1=$(merge "$TMP/all-findings-1.json" "$TMP/functional-1.json")
+assert_eq "net-new: merged length" "2" "$(echo "$M1" | jq 'length')"
+assert_eq "net-new: f1 present"    "1" "$(echo "$M1" | jq '[.[] | select(.id == "f1")] | length')"
+assert_eq "net-new: screenshot kept" "/tmp/screenshots/02-form.png" \
+  "$(echo "$M1" | jq -r '[.[] | select(.id == "f1")] | .[0].screenshot')"
+
+# ── Block 2: orchestrator already folded — dedup by id ──
+cat > "$TMP/all-findings-2.json" <<'JSON'
+[
+  {"id":"j1","severity":"major","path":"src/a.ts","line_start":10,"title":"Judge finding","evidence":"x","reasoning":"y","expected":"z","type":"finding"},
+  {"id":"f1","severity":"major","path":"src/c.ts","line_start":30,"title":"Submit button missing","evidence":"orchestrator copy","reasoning":"y","expected":"z","type":"finding","screenshot":"/tmp/screenshots/02-form.png"}
+]
+JSON
+cat > "$TMP/functional-2.json" <<'JSON'
+[
+  {"id":"f1","severity":"major","path":"src/c.ts","line_start":30,"title":"Submit button missing","evidence":"functional copy","reasoning":"y","expected":"z","type":"finding","screenshot":"/tmp/screenshots/02-form.png"}
+]
+JSON
+M2=$(merge "$TMP/all-findings-2.json" "$TMP/functional-2.json")
+assert_eq "dedup: total length unchanged" "2" "$(echo "$M2" | jq 'length')"
+assert_eq "dedup: f1 appears once"        "1" "$(echo "$M2" | jq '[.[] | select(.id == "f1")] | length')"
+# Orchestrator's already-folded copy wins (its evidence was "orchestrator copy").
+assert_eq "dedup: orchestrator copy wins" "orchestrator copy" \
+  "$(echo "$M2" | jq -r '[.[] | select(.id == "f1")] | .[0].evidence')"
+
+# ── Block 3: both empty → no-op ──
+echo '[]' > "$TMP/all-findings-3.json"
+echo '[]' > "$TMP/functional-3.json"
+M3=$(merge "$TMP/all-findings-3.json" "$TMP/functional-3.json")
+assert_eq "empty+empty: stays []" "0" "$(echo "$M3" | jq 'length')"
+
+# ── Block 4: judges had findings, functional empty → no-op ──
+cat > "$TMP/all-findings-4.json" <<'JSON'
+[{"id":"j1","severity":"minor","path":"src/a.ts","line_start":1,"title":"x","evidence":"x","reasoning":"x","expected":"x","type":"finding"}]
+JSON
+echo '[]' > "$TMP/functional-4.json"
+M4=$(merge "$TMP/all-findings-4.json" "$TMP/functional-4.json")
+assert_eq "judges-only: length unchanged" "1" "$(echo "$M4" | jq 'length')"
+assert_eq "judges-only: j1 preserved"     "j1" "$(echo "$M4" | jq -r '.[0].id')"
+
+if [ "$fail" -eq 0 ]; then
+  echo
+  echo "All functional-findings merge tests passed."
+  exit 0
+else
+  echo
+  echo "$fail functional-findings merge test assertion(s) failed."
+  exit 1
+fi

--- a/tests/screenshot_allowlist_test.sh
+++ b/tests/screenshot_allowlist_test.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# screenshot_allowlist_test.sh — fixture test for the allowlist-based
+# screenshot collection in build-review.sh.
+#
+# Background. PR #30 originally tried to filter checked-in repo PNGs by
+# mtime (`find . -mmin -60`), but Cursor caught that `actions/checkout`
+# rewrites every file's mtime to ~now during clone, which means the
+# filter cannot distinguish a checked-in product asset (e.g. seaters'
+# `screenshots/wl_logo.png`) from a freshly captured tester screenshot.
+#
+# The fix: collect ONLY the basenames the functional tester explicitly
+# named in `functional-meta.screenshots[].file` and
+# `functional-findings[].screenshot`. Try the absolute path first, then
+# resolve the basename in agent-only output dirs, falling back to the
+# repo root as a last resort. This guarantees that pre-existing repo
+# PNGs not named by the tester are never picked up — regardless of
+# their mtime.
+
+cd "$(dirname "$0")/.."
+
+fail=0
+assert_eq() {
+  local label="$1" want="$2" got="$3"
+  if [ "$want" != "$got" ]; then
+    echo "FAIL: $label — want '$want', got '$got'"
+    fail=$((fail + 1))
+  else
+    echo "OK:   $label"
+  fi
+}
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# ── Fixture: consumer repo with checked-in PNGs (fresh mtime from
+# actions/checkout) + agent-produced screenshots in /tmp/screenshots. ──
+mkdir -p "$TMP/repo/screenshots" "$TMP/agent-tmp/screenshots" "$TMP/all-screenshots" "$TMP/repo/.playwright-mcp"
+echo "checked-in-logo" > "$TMP/repo/screenshots/wl_logo.png"
+echo "checked-in-barcode" > "$TMP/repo/barcode.png"
+echo "agent-list" > "$TMP/agent-tmp/screenshots/01-list-page.png"
+echo "agent-detail" > "$TMP/agent-tmp/screenshots/02-detail.png"
+echo "agent-mcp" > "$TMP/repo/.playwright-mcp/03-mcp-default.png"
+# Touch every file to "now" so mtime cannot distinguish them — the
+# situation we'd be in after `actions/checkout` ran a moment ago.
+find "$TMP" -name '*.png' -exec touch {} \;
+
+# Build a synthetic functional-meta naming a mix of:
+#   - absolute path (preferred — agent wrote here)
+#   - plain filename (legacy path — agent passed only "02-detail.png")
+#   - JSON file — must be filtered as non-image
+#   - Playwright-MCP default location
+FUNCTIONAL_META=$(jq -n \
+  --arg abs1 "$TMP/agent-tmp/screenshots/01-list-page.png" \
+  '{screenshots: [
+     {file: $abs1, description: "List page", area: "list"},
+     {file: "02-detail.png", description: "Detail", area: "detail"},
+     {file: "/tmp/api-response.json", description: "API JSON", area: "api"},
+     {file: "03-mcp-default.png", description: "MCP-default", area: "mcp"}
+   ]}')
+FUNCTIONAL_FINDINGS=$(jq -n \
+  '[{id:"f1",severity:"major",path:"src/a.ts",line_start:1,title:"x",evidence:"x","reasoning":"x","expected":"x",type:"finding",screenshot:"01-list-page.png"}]')
+echo "$FUNCTIONAL_FINDINGS" > /tmp/functional-findings.json
+
+# ── Allowlist resolution (mirrors build-review.sh:243-294) ──
+FN_INPUT="[]"
+[ -f /tmp/functional-findings.json ] && jq -e 'type == "array"' /tmp/functional-findings.json >/dev/null 2>&1 \
+  && FN_INPUT=$(cat /tmp/functional-findings.json)
+
+EXPECTED_FILES=$(jq -n \
+  --argjson meta "$FUNCTIONAL_META" \
+  --argjson fn "$FN_INPUT" \
+  'def img_paths: map(select(type == "string" and (test("\\.(png|jpg|jpeg|webp)$"; "i")))) | unique;
+   (($meta.screenshots // []) | map(.file // ""))
+   + (($fn // []) | map(.screenshot // ""))
+   | img_paths')
+
+# JSON entry must be filtered out. `unique` dedupes by string value, not
+# basename — so an absolute path to 01-list-page.png and a plain
+# "01-list-page.png" finding entry are two distinct strings → 4 entries:
+# abs(01), "02-detail", "/tmp/api-response.json"→dropped, "03-mcp",
+# plain("01-list-page"). Both 01-list-page entries resolve to the same
+# basename and `cp -n` makes the second a no-op.
+assert_eq "expected list filtered to images" "4" "$(echo "$EXPECTED_FILES" | jq 'length')"
+assert_eq "JSON entry filtered out of expected list" "0" \
+  "$(echo "$EXPECTED_FILES" | jq '[.[] | select(test("\\.json$"))] | length')"
+
+cd "$TMP/repo"
+while read -r expected; do
+  [ -z "$expected" ] && continue
+  base=$(basename "$expected")
+  if [ -f "$expected" ]; then
+    cp -n "$expected" "$TMP/all-screenshots/$base"
+    continue
+  fi
+  found=""
+  for d in "$TMP/agent-tmp/screenshots" "$TMP/agent-tmp/playwright-mcp-output" .playwright-mcp .playwright-mcp/screenshots screenshots .; do
+    [ -f "$d/$base" ] && { found="$d/$base"; break; }
+  done
+  if [ -n "$found" ]; then
+    cp -n "$found" "$TMP/all-screenshots/$base"
+  fi
+done < <(echo "$EXPECTED_FILES" | jq -r '.[]')
+
+# ── Assertions ──
+assert_eq "01-list-page.png picked up via absolute path" "1" \
+  "$(ls "$TMP/all-screenshots/" | grep -c '^01-list-page\.png$')"
+assert_eq "02-detail.png picked up via basename resolve" "1" \
+  "$(ls "$TMP/all-screenshots/" | grep -c '^02-detail\.png$')"
+assert_eq "03-mcp-default.png picked up from .playwright-mcp" "1" \
+  "$(ls "$TMP/all-screenshots/" | grep -c '^03-mcp-default\.png$')"
+
+# Critical: pre-existing repo PNGs the tester didn't name must NOT
+# appear, even though their mtimes were freshly touched.
+assert_eq "wl_logo.png NOT picked up (not named by tester)" "0" \
+  "$(ls "$TMP/all-screenshots/" | grep -c '^wl_logo\.png$')"
+assert_eq "barcode.png NOT picked up (not named by tester)" "0" \
+  "$(ls "$TMP/all-screenshots/" | grep -c '^barcode\.png$')"
+assert_eq "all-screenshots count exactly 3" "3" \
+  "$(ls "$TMP/all-screenshots/" | wc -l | tr -d ' ')"
+
+# ── Empty-functional-findings.json variant: must not error ──
+echo '[]' > /tmp/functional-findings.json
+EMPTY_FN_INPUT="[]"
+EMPTY_EXPECTED=$(jq -n \
+  --argjson meta '{}' \
+  --argjson fn "$EMPTY_FN_INPUT" \
+  'def img_paths: map(select(type == "string" and (test("\\.(png|jpg|jpeg|webp)$"; "i")))) | unique;
+   (($meta.screenshots // []) | map(.file // ""))
+   + (($fn // []) | map(.screenshot // ""))
+   | img_paths')
+assert_eq "empty meta + empty findings → empty allowlist" "0" "$(echo "$EMPTY_EXPECTED" | jq 'length')"
+
+rm -f /tmp/functional-findings.json
+
+if [ "$fail" -eq 0 ]; then
+  echo
+  echo "All screenshot-allowlist tests passed."
+  exit 0
+else
+  echo
+  echo "$fail screenshot-allowlist test assertion(s) failed."
+  exit 1
+fi


### PR DESCRIPTION
## Why this PR exists

Three signal-to-noise bugs surfaced on the seaters dogfood (closed Panenco/seaters#471) that the v3 architecture inherited from v2's path scanning. None gate the verdict, but together they pollute every consumer review with misleading content.

## Fixes

### 1. Lint false positives on English prose

The "Validate review config" step in `pr-review.yml` scans `review-config.md` + `dev-start.sh` for `cp/source/cat <path>` patterns and warns when the path doesn't exist. The regex was matching plain words. Run on Panenco/seaters main:
```
MISSING: is
MISSING: names
MISSING: route
MISSING: tree
MISSING: via
MISSING: without
```
All from prose like ``the `cat` command is``, ``source tree``, etc. Result: a noisy `::warning::Fix the paths in .github/review-config.md` on every seaters review even though every real path is correct.

**Fix:** require the captured token to contain `/` or `.` (one-line `grep -E '/|.\..'` filter). Real paths almost always carry one or the other; English words don't.

### 2. Screenshot collection scoops up consumer-repo PNGs

`build-review.sh` ran `find . -maxdepth 2 -name '*.png'` from the consumer repo root. seaters has a `screenshots/` directory with checked-in product UI assets (`barcode.png`, `brightfish_logo.png`, `wl_logo.png`). Those got uploaded to `review-assets/pr-N/`, then the body's `urls[basename]` lookup missed for the agent's actual screenshots because the basenames didn't match.

**Fix:** every `find` for screenshots now adds `-mmin -60` so pre-existing checked-in PNGs are filtered out. Only files created during the current run can be picked up.

### 3. Non-image `screenshots[]` entries rendered as broken links

When the functional tester ran API-only scenarios on seaters#471 it listed response JSON dumps under `screenshots[]`:
```json
{"file": "/tmp/screenshots/01-scenario1-missing-fan-ids.json", "description": "..."}
```
The body claimed "(4 screenshots)" then rendered 4 `*see [build artifacts]*` fallbacks because there was nothing to embed.

**Fix:** both the `screenshot_count` jq inside review-result.json and the body's gallery rendering now filter to `\.(png|jpg|jpeg|webp)$`. Non-image entries are skipped from the count and not rendered. Honest "0 screenshots" beats misleading "4 screenshots → see build artifacts".

## Test plan

- [x] All 9 non-smoke tests pass locally; shellcheck-error clean
- [x] Lint regex spot-check: `cat is`, `source tree`, `cp without` all dropped; `cp .env.example`, `source backend/foo.ts` survive
- [x] `screenshot_count` filter spot-check: mixed `[png, json, jpg]` → 2, all-`json` → 0
- [ ] Run on the next consumer PR with `screenshots/` UI assets in the repo → expect no false uploads in `review-assets/pr-N/`
- [ ] Run on a PR with API-only functional scenarios → expect honest `0 screenshots` instead of phantom-count fallback links
- [ ] Run on a consumer with prose `cat`/`source`/`cp` words in review-config.md → expect no `Fix the paths` warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the review pipeline’s artifact merging and screenshot upload/embedding logic, which can affect review verdicts and evidence shown to developers across all consumers.
> 
> **Overview**
> Fixes false-positive warnings in the `Validate review config` step by filtering extracted `cp/source/cat` tokens to path-like strings before checking file existence.
> 
> Hardens functional evidence handling in `build-review.sh`: defensively merges `/tmp/functional-findings.json` into `ALL_FINDINGS` so screenshot-backed findings can appear as inline comments, switches screenshot collection to an explicit allowlist derived from functional meta/findings (avoiding accidental upload of repo PNG assets), and filters screenshot counts/rendering to image extensions only.
> 
> Updates workflow action pins (`actions/checkout`, `actions/download-artifact`), adjusts Playwright MCP pre-warm to a more reliable `npx -p ... -- node -e ...` invocation, and adds two new shell fixture tests for the functional-findings merge and screenshot allowlist (wired into `tests.yml`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bc36d49bb95658d17237251e154b9b4d18e0046. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->