### PR TITLE
fix(review): Playwright MCP actually runs for the functional tester

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -998,59 +998,14 @@ jobs:
           MODEL_FUNCTIONAL: ${{ inputs.model_functional }}
           PIPELINE_DIR: ${{ env.CLAUDE_REVIEW_PIPELINE_DIR }}
         run: |
-          mkdir -p .claude/agents
-          # heredoc with substitution for env vars; the YAML frontmatter
-          # fields (`mcpServers`, `tools`, etc.) are spec-compliant per
-          # Claude Code's subagent docs. The body is a one-line redirect to
-          # the full skill file so we don't duplicate the rubric.
-          cat > .claude/agents/review-functional-tester.md <<EOF
-          ---
-          name: review-functional-tester
-          description: QA agent that validates PR functionality end-to-end with Playwright MCP. Spawned by the review orchestrator to test user flows, take targeted screenshots tied to findings, and write /tmp/functional-meta.json + /tmp/functional-findings.json.
-          model: ${MODEL_FUNCTIONAL}
-          tools:
-            - Bash
-            - Read
-            - Write
-            - Glob
-            - Grep
-            - ToolSearch
-            - mcp__playwright__browser_navigate
-            - mcp__playwright__browser_take_screenshot
-            - mcp__playwright__browser_snapshot
-            - mcp__playwright__browser_console_messages
-            - mcp__playwright__browser_click
-            - mcp__playwright__browser_fill_form
-            - mcp__playwright__browser_wait_for
-            - mcp__playwright__browser_close
-            - mcp__playwright__browser_select_option
-            - mcp__playwright__browser_press_key
-            - mcp__playwright__browser_type
-            - mcp__playwright__browser_hover
-            - mcp__playwright__browser_resize
-            - mcp__playwright__browser_tabs
-            - mcp__playwright__browser_navigate_back
-            - mcp__playwright__browser_evaluate
-          mcpServers:
-            playwright:
-              type: stdio
-              command: npx
-              args:
-                - "--yes"
-                - "@playwright/mcp@latest"
-                - "--headless"
-                - "--output-dir"
-                - "/tmp/screenshots"
-          ---
-
-          Read ${PIPELINE_DIR}/skills/review-functional-tester.md and follow it exactly. The orchestrator spawned you for PR ${PR_NUMBER}. test-plan.md and context.md are at the repo root. Your first turn MUST be the MCP smoke check described in the skill — do not silently fall back to curl/psql when MCP is unavailable.
-          EOF
-          echo "Functional-tester subagent installed:"
-          ls -la .claude/agents/
-          # Verify YAML parses (best-effort — pyyaml may not be available).
-          if command -v python3 >/dev/null 2>&1; then
-            python3 -c "import sys, re; t=open('.claude/agents/review-functional-tester.md').read(); fm=re.match(r'^---\n(.*?)\n---\n', t, re.S); assert fm, 'no frontmatter'; print('frontmatter bytes:', len(fm.group(1)))" || echo "::warning::frontmatter validation failed"
-          fi
+          # Helper writes .claude/agents/review-functional-tester.md to cwd
+          # (Claude Code's project-level subagent discovery path) and
+          # validates the frontmatter against Claude Code's subagent schema.
+          # The validator catches the dict-vs-list mcpServers regression
+          # the first iteration of this PR shipped — see the helper script
+          # for the full schema rationale and reference to the canonical
+          # docs at https://code.claude.com/docs/en/sub-agents.
+          bash "${CLAUDE_REVIEW_PIPELINE_DIR}/scripts/install-functional-tester-agent.sh"
 
       - name: 'Review: orchestrate'
         id: claude_run

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -918,64 +918,38 @@ jobs:
           echo "$PID" > /tmp/dev-env/pid
           echo "Background dev-env launched: PID=$PID (process group leader)"
 
-      - name: Setup Playwright MCP config
-        # Unconditional. The orchestrator step always passes --mcp-config to
-        # the claude CLI; the file must exist even for docs-only PRs (the
-        # MCP server spawns lazily — only when an mcp__playwright__ tool is
-        # called by a functional-tester subagent — so listing it on every
-        # run is free).
+      - name: Pre-warm Playwright MCP package cache
+        # Pre-warm the @playwright/mcp install before the functional-tester
+        # subagent spawns the MCP server. Without this, the first npx
+        # invocation downloads + extracts the package on the runner's hot
+        # path, and Claude Code's MCP-startup handshake can time out before
+        # tools register. Cache is per-runner so this is a once-per-cold
+        # cost (~10-20s); the failure mode it prevents (silent zero
+        # screenshots, every UI scenario untestable) is total. The MCP
+        # server itself is now defined in `.claude/agents/review-functional-tester.md`
+        # — no `--mcp-config` JSON file is written here anymore.
+        # Use `npx -p ... -- node -e 'process.exit(0)'` rather than
+        # `--version`. The MCP server is a long-running stdio process
+        # whose `--version` handling is inconsistent across releases
+        # (some return 1 when stdin is closed). The `-p <pkg> -- node -e 'true'`
+        # form triggers npx's tarball-cache download path without ever
+        # invoking the server itself.
         shell: bash
         run: |
           # Force --output-dir so screenshots land in a known location.
           # Without this, Playwright MCP defaults to os.tmpdir()/playwright-mcp-output/<sessionId>/...
           # which our upload step never finds.
           mkdir -p /tmp/screenshots
-
-          # Pre-warm the @playwright/mcp install before the Claude CLI
-          # spawns it (only when a functional run is plausible — i.e. the
-          # repo has Node + npx on PATH). Without this the first npx
-          # invocation downloads + extracts the package on the runner's
-          # hot path, and the Claude CLI's MCP-startup handshake times out
-          # before tools register. Cache is per-runner so this is a
-          # once-per-cold-runner cost (~10-20s); the failure mode it
-          # prevents (silently 0 screenshots, every UI scenario untestable)
-          # is total. Skip silently when npx is unavailable — docs-only
-          # repos legitimately have no Node and the orchestrator never
-          # dispatches the functional subagent there anyway.
-          # Use `npx -p ... -- node -e 'process.exit(0)'` rather than
-          # `--version`. The MCP server is a long-running stdio process
-          # whose `--version` handling is inconsistent across releases
-          # (some return 1 when stdin is closed, which made the previous
-          # pre-warm fail loudly with `::warning::` on every consumer
-          # review even though the server was perfectly fine to lazy-spawn
-          # later). The `-p <pkg> -- node -e 'true'` form triggers npx's
-          # tarball-cache download path without ever invoking the server
-          # itself, so we get the cache-warming benefit and a reliable
-          # exit code. Falls back to a notice (not warning) on failure
-          # — the lazy-spawn path still works, this is purely a perf
-          # optimisation.
           if command -v npx >/dev/null 2>&1; then
             echo "Pre-warming @playwright/mcp@latest..."
             if npx --yes -p @playwright/mcp@latest -- node -e 'process.exit(0)' >/dev/null 2>&1; then
-              echo "@playwright/mcp@latest tarball cached for the lazy-spawn path."
+              echo "@playwright/mcp@latest tarball cached for the subagent's spawn path."
             else
-              echo "::notice::@playwright/mcp@latest pre-warm did not succeed; functional tester will lazy-spawn (cold start ~10-20s)."
+              echo "::notice::@playwright/mcp@latest pre-warm did not succeed; functional tester will install on first call (cold start ~10-20s)."
             fi
           else
             echo "npx not on PATH — skipping Playwright MCP pre-warm (no functional run expected)."
           fi
-
-          cat > /tmp/mcp-playwright.json << 'MCPEOF'
-          {
-            "mcpServers": {
-              "playwright": {
-                "command": "npx",
-                "args": ["--yes", "@playwright/mcp@latest", "--headless", "--output-dir", "/tmp/screenshots"]
-              }
-            }
-          }
-          MCPEOF
-          sed -i 's/^[[:space:]]*//' /tmp/mcp-playwright.json
 
       # Single top-level Claude Code agent. The orchestrator skill drives:
       #   Phase 0   — Task-dispatches the context-builder subagent, which writes
@@ -997,9 +971,87 @@ jobs:
       # All parallelism happens via the Task tool inside this single
       # claude-code-action invocation. The wrapper gives us native rate-limit
       # fast-fail (the bare `claude -p` CLI hangs on quota walls; the SDK
-      # surfaces the error in <1s). Subagents inherit `--mcp-config` /
-      # `--allowedTools` from this parent — the functional subagent uses
-      # Playwright MCP, the others ignore it.
+      # surfaces the error in <1s).
+      #
+      # Playwright MCP is scoped to the `review-functional-tester` subagent
+      # via `.claude/agents/review-functional-tester.md` (auto-discovered
+      # by Claude Code from `$GITHUB_WORKSPACE/.claude/agents/`). The
+      # subagent file inline-defines `mcpServers` so the Playwright server
+      # spawns when the subagent starts — NOT at the parent orchestrator.
+      # Earlier we passed `--mcp-config` at the orchestrator level and
+      # relied on subagents inheriting it; in practice the server stayed in
+      # `status: "pending"` (Claude Code's lazy-spawn never fired because
+      # deferred MCP tool schemas aren't loaded until the server is up,
+      # ToolSearch can't find tools that aren't loaded, and the subagent
+      # silently fell back to curl/psql with "Playwright MCP tools were
+      # not available in this test context" buried in uncertain_observations).
+      # Inline-defining the server in the subagent forces it to spawn when
+      # the subagent starts; orchestrator no longer carries Playwright
+      # tooling at all (it never called those tools anyway). claude-code-action
+      # SHA bumped to the v1 release that ships Claude Code 2.1.132 (Agent
+      # SDK 0.2.132), which also fixed a 10GB+ RSS leak with stdio MCP
+      # servers — relevant if the leak was contributing to the pending state.
+      - name: 'Install functional-tester subagent definition'
+        shell: bash
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+          MODEL_FUNCTIONAL: ${{ inputs.model_functional }}
+          PIPELINE_DIR: ${{ env.CLAUDE_REVIEW_PIPELINE_DIR }}
+        run: |
+          mkdir -p .claude/agents
+          # heredoc with substitution for env vars; the YAML frontmatter
+          # fields (`mcpServers`, `tools`, etc.) are spec-compliant per
+          # Claude Code's subagent docs. The body is a one-line redirect to
+          # the full skill file so we don't duplicate the rubric.
+          cat > .claude/agents/review-functional-tester.md <<EOF
+          ---
+          name: review-functional-tester
+          description: QA agent that validates PR functionality end-to-end with Playwright MCP. Spawned by the review orchestrator to test user flows, take targeted screenshots tied to findings, and write /tmp/functional-meta.json + /tmp/functional-findings.json.
+          model: ${MODEL_FUNCTIONAL}
+          tools:
+            - Bash
+            - Read
+            - Write
+            - Glob
+            - Grep
+            - ToolSearch
+            - mcp__playwright__browser_navigate
+            - mcp__playwright__browser_take_screenshot
+            - mcp__playwright__browser_snapshot
+            - mcp__playwright__browser_console_messages
+            - mcp__playwright__browser_click
+            - mcp__playwright__browser_fill_form
+            - mcp__playwright__browser_wait_for
+            - mcp__playwright__browser_close
+            - mcp__playwright__browser_select_option
+            - mcp__playwright__browser_press_key
+            - mcp__playwright__browser_type
+            - mcp__playwright__browser_hover
+            - mcp__playwright__browser_resize
+            - mcp__playwright__browser_tabs
+            - mcp__playwright__browser_navigate_back
+            - mcp__playwright__browser_evaluate
+          mcpServers:
+            playwright:
+              type: stdio
+              command: npx
+              args:
+                - "--yes"
+                - "@playwright/mcp@latest"
+                - "--headless"
+                - "--output-dir"
+                - "/tmp/screenshots"
+          ---
+
+          Read ${PIPELINE_DIR}/skills/review-functional-tester.md and follow it exactly. The orchestrator spawned you for PR ${PR_NUMBER}. test-plan.md and context.md are at the repo root. Your first turn MUST be the MCP smoke check described in the skill — do not silently fall back to curl/psql when MCP is unavailable.
+          EOF
+          echo "Functional-tester subagent installed:"
+          ls -la .claude/agents/
+          # Verify YAML parses (best-effort — pyyaml may not be available).
+          if command -v python3 >/dev/null 2>&1; then
+            python3 -c "import sys, re; t=open('.claude/agents/review-functional-tester.md').read(); fm=re.match(r'^---\n(.*?)\n---\n', t, re.S); assert fm, 'no frontmatter'; print('frontmatter bytes:', len(fm.group(1)))" || echo "::warning::frontmatter validation failed"
+          fi
+
       - name: 'Review: orchestrate'
         id: claude_run
         # Don't fail the job if the orchestrator returns non-zero (e.g.
@@ -1008,7 +1060,7 @@ jobs:
         # downstream verdict-gate step reads them and posts an honest
         # crash banner if they're missing.
         continue-on-error: true
-        uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1
+        uses: anthropics/claude-code-action@9db782c3a17ef2bfc274cd17411bc3e0a5ba1345 # Claude Code 2.1.132
         env:
           REVIEW_BOT_USER: ${{ steps.review_identity.outputs.bot_user }}
           REVIEW_BUILD_AVAILABLE: ${{ (steps.code_check.outputs.needs_build == 'true' && steps.install.outputs.install_ok == 'true') && 'true' || 'false' }}
@@ -1031,13 +1083,12 @@ jobs:
           claude_code_oauth_token: ${{ env.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.review_identity.outputs.token }}
           prompt: |
-            Read ${{ env.CLAUDE_REVIEW_PIPELINE_DIR }}/skills/review-orchestrator.md and follow it exactly. PR number: ${{ github.event.pull_request.number || inputs.pr_number }}. You are the single top-level agent for this review — dispatch the context builder, the two judges, the round-2 thread classifier, and the functional tester via the Task tool per the skill above. Write /tmp/all-findings.json + /tmp/review-meta.json before exiting.
+            Read ${{ env.CLAUDE_REVIEW_PIPELINE_DIR }}/skills/review-orchestrator.md and follow it exactly. PR number: ${{ github.event.pull_request.number || inputs.pr_number }}. You are the single top-level agent for this review — dispatch the context builder, the two judges, the round-2 thread classifier, and the functional tester via the Task tool per the skill above. The functional tester is registered as the custom subagent type `review-functional-tester` (auto-discovered from .claude/agents/, owns Playwright MCP directly — just dispatch it, do not pass MCP config in the prompt). Write /tmp/all-findings.json + /tmp/review-meta.json before exiting.
           claude_args: |
             --model ${{ inputs.model_standard }}
             --permission-mode dontAsk
             --setting-sources user
-            --mcp-config /tmp/mcp-playwright.json
-            --allowedTools Bash,Read,Write,Glob,Grep,Task,ToolSearch,mcp__playwright__browser_navigate,mcp__playwright__browser_take_screenshot,mcp__playwright__browser_snapshot,mcp__playwright__browser_console_messages,mcp__playwright__browser_click,mcp__playwright__browser_fill_form,mcp__playwright__browser_wait_for,mcp__playwright__browser_close,mcp__playwright__browser_select_option,mcp__playwright__browser_press_key,mcp__playwright__browser_type,mcp__playwright__browser_hover,mcp__playwright__browser_resize,mcp__playwright__browser_tabs,mcp__playwright__browser_navigate_back,mcp__playwright__browser_evaluate
+            --allowedTools Bash,Read,Write,Glob,Grep,Task,ToolSearch
             --disallowedTools Edit,WebFetch,WebSearch
             --max-turns 100
           show_full_output: 'true'

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -998,13 +998,19 @@ jobs:
           MODEL_FUNCTIONAL: ${{ inputs.model_functional }}
           PIPELINE_DIR: ${{ env.CLAUDE_REVIEW_PIPELINE_DIR }}
         run: |
-          # Helper writes .claude/agents/review-functional-tester.md to cwd
-          # (Claude Code's project-level subagent discovery path) and
-          # validates the frontmatter against Claude Code's subagent schema.
-          # The validator catches the dict-vs-list mcpServers regression
-          # the first iteration of this PR shipped — see the helper script
-          # for the full schema rationale and reference to the canonical
-          # docs at https://code.claude.com/docs/en/sub-agents.
+          # Helper writes $HOME/.claude/agents/review-functional-tester.md
+          # (USER-scope, intentional — claude-code-action's restore-config.ts
+          # wipes workspace .claude/ on PR-head jobs as RCE-prevention; the
+          # source code's own comment confirms $HOME is untouched). The
+          # subagent's inline mcpServers spawns the Playwright server when
+          # the subagent starts. NOTE: the MCP tool *permissions* are still
+          # session-level — see the `--allowedTools` list in the orchestrator
+          # step below, which must include every mcp__playwright__* tool
+          # the subagent will call. dontAsk mode evaluates permissions
+          # against the session-level allowlist, not the subagent's tools:
+          # field; without the orchestrator-level grant, the subagent's
+          # tool calls return "permission denied" even though the server
+          # is connected (caught on dogfood seaters#475 round 2).
           bash "${CLAUDE_REVIEW_PIPELINE_DIR}/scripts/install-functional-tester-agent.sh"
 
       - name: 'Review: orchestrate'
@@ -1043,7 +1049,7 @@ jobs:
             --model ${{ inputs.model_standard }}
             --permission-mode dontAsk
             --setting-sources user
-            --allowedTools Bash,Read,Write,Glob,Grep,Task,ToolSearch
+            --allowedTools Bash,Read,Write,Glob,Grep,Task,ToolSearch,mcp__playwright__browser_navigate,mcp__playwright__browser_take_screenshot,mcp__playwright__browser_snapshot,mcp__playwright__browser_console_messages,mcp__playwright__browser_click,mcp__playwright__browser_fill_form,mcp__playwright__browser_wait_for,mcp__playwright__browser_close,mcp__playwright__browser_select_option,mcp__playwright__browser_press_key,mcp__playwright__browser_type,mcp__playwright__browser_hover,mcp__playwright__browser_resize,mcp__playwright__browser_tabs,mcp__playwright__browser_navigate_back,mcp__playwright__browser_evaluate
             --disallowedTools Edit,WebFetch,WebSearch
             --max-turns 100
           show_full_output: 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Run functional_mcp_gate_test.sh
         run: bash tests/functional_mcp_gate_test.sh
 
+      - name: Run install_functional_tester_agent_test.sh
+        run: bash tests/install_functional_tester_agent_test.sh
+
       - name: Run verdict_ladder_test.sh
         run: bash tests/verdict_ladder_test.sh
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Run screenshot_allowlist_test.sh
         run: bash tests/screenshot_allowlist_test.sh
 
+      - name: Run functional_mcp_gate_test.sh
+        run: bash tests/functional_mcp_gate_test.sh
+
       - name: Run verdict_ladder_test.sh
         run: bash tests/verdict_ladder_test.sh
 

--- a/README.md
+++ b/README.md
@@ -78,9 +78,14 @@ Without these, the pipeline still works — it auto-discovers what it can and ru
 ```
 PR opened / updated
     |
-[Setup] Node, deps, Playwright MCP config, dev environment
-        (launched in background — overlaps with the orchestrator's
-        context-build phase so total wall time = max(CB, dev-env)).
+[Setup] Node, deps, dev environment, install
+        .claude/agents/review-functional-tester.md (subagent definition
+        with inline `mcpServers` for Playwright MCP — server starts when
+        the orchestrator dispatches the subagent, NOT at orchestrator
+        start; eliminates the lazy-spawn vs ToolSearch chicken-and-egg
+        that left MCP "pending" silently). Dev-env launched in background —
+        overlaps with the orchestrator's context-build phase so total wall
+        time = max(CB, dev-env).
     |
 [One agent: Review: orchestrate]  (anthropics/claude-code-action)
     A single Sonnet orchestrator runs end-to-end and dispatches
@@ -516,13 +521,13 @@ If you have a polished config for a stack not covered here (e.g. Python/FastAPI,
 
 The pipeline consists of:
 
-- **Reusable workflow** (`.github/workflows/pr-review.yml`) — dev-env setup, MCP config, the single `claude-code-action` invocation, post-processing, review posting
+- **Reusable workflow** (`.github/workflows/pr-review.yml`) — dev-env setup, Playwright MCP package pre-warm, functional-tester subagent installation (`.claude/agents/review-functional-tester.md`), the single `claude-code-action` invocation, post-processing, review posting
 - **6 skill files** (`skills/`) — prompt templates defining review methodology:
   - `review-orchestrator` — the single top-level Claude Code agent; dispatches the context builder, judges, thread classifier, and functional tester via the `Task` tool, runs the debate, writes the final findings + meta
   - `review-context-builder` — Task subagent; gathers PR metadata, diff index, spec sources, and a 5-sentence diff summary into `context.md`
   - `review-judge` — Task subagent skill used by both the Opus and Haiku judges (correctness, security, spec, consistency, performance, tests)
   - `review-thread-classifier` — Task subagent (round-2 only); classifies prior findings + open inline threads (own bot, other bots, **humans**) as RESOLVED / STILL_PRESENT / NEW_CONTEXT
-  - `review-functional-tester` — Task subagent; Playwright-driven UI smoke + functional tests
+  - `review-functional-tester` — custom subagent type (auto-discovered from `.claude/agents/review-functional-tester.md`, written at workflow runtime); inline `mcpServers` block defines Playwright MCP scoped to this subagent, so the server starts when it spawns rather than relying on parent inheritance. First turn is an MCP smoke check that hard-fails the run as `overall: CRASH` if MCP is unavailable — silent fallback to curl is forbidden.
   - `review-test-planner` — embedded inside the context builder skill; picks the functional strategy (skip / quick / functional / pipeline-self-test) and writes scenarios into `test-plan.md`
 - **Functional prompt template** (`scripts/functional-prompt.template.txt`) — bootstraps the functional tester with auth + env info
 

--- a/prompts/setup-review.md
+++ b/prompts/setup-review.md
@@ -456,7 +456,9 @@ Push the changes on a branch, open a PR, and verify the workflow triggers. Expec
 - "Validate review config" shows all six sections detected and no "references files that don't exist" warnings
 - Context builder produces `context.md` and `test-plan.md`
 - Dev env setup starts your services (look for `API ready at ...` in logs — not just `API=false`)
+- "Install functional-tester subagent definition" writes `.claude/agents/review-functional-tester.md` to the runner's checkout (this is what gives the functional tester its own scoped Playwright MCP server — don't commit this file to your repo, the workflow rewrites it on every run from the `inputs.model_functional` value)
 - Orchestrator runs the two judges (Opus + Haiku) in parallel and (when applicable) the functional tester. The judge debate produces a single, deduped findings list — there is no separate `core` / `sweep` step.
+- For PRs with UI surface, the functional tester's Turn 1 is an MCP smoke check (`mcp__playwright__browser_navigate` to `about:blank`). If MCP is unavailable, the run hard-fails with `overall: CRASH` and the verdict gate flags it as `requires_human_review`. Silent fallback to curl/psql is forbidden — a curl-only PASS on a UI fix is the bug we're guarding against.
 - **Verdict: APPROVE** — because you followed Step 5's self-check. If you see findings here, read them and tighten the config; they're almost always real and point at something fixable.
 
 ## Verdict ladder (round 2)

--- a/scripts/build-review.sh
+++ b/scripts/build-review.sh
@@ -510,6 +510,25 @@ JUDGES_BOTH_FAILED=$(echo "$CORE_META" | jq -r '
     )
   else false end')
 
+# Functional MCP gate. The functional-tester subagent's first turn is a
+# smoke check that calls mcp__playwright__browser_navigate to about:blank;
+# on failure it writes overall=CRASH and exits before running scenarios.
+# Even with that loud-fail in place, a defence-in-depth string match here
+# catches the historical silent-fallback string in uncertain_observations
+# ("Playwright MCP tools were not available...") in case a future skill
+# regression re-introduces the curl-only path. Either signal forces COMMENT
+# + requires_human_review because we have NO UI evidence on a run that the
+# planner said needed UI testing.
+FUNCTIONAL_MCP_BROKEN=false
+FUNCTIONAL_MCP_BROKEN_REASON=""
+if [ "$FUNCTIONAL_OVERALL" = "CRASH" ] && echo "$FUNCTIONAL_META" | jq -e '(.summary // "") | test("Playwright MCP unavailable"; "i")' >/dev/null 2>&1; then
+  FUNCTIONAL_MCP_BROKEN=true
+  FUNCTIONAL_MCP_BROKEN_REASON="Playwright MCP smoke check failed — UI scenarios were not exercised. The .claude/agents/review-functional-tester.md subagent's inline mcpServers definition could not start the @playwright/mcp@latest stdio server. Check the runner has network + npx access; check the 'Pre-warm Playwright MCP package cache' step output."
+elif [ "$FUNCTIONAL_STRATEGY" = "functional" ] && echo "$FUNCTIONAL_META" | jq -e '[(.uncertain_observations // [])[] | select(test("Playwright MCP.*not.*avail|MCP.*unavailable|fall.*back to curl|all testing was done via curl"; "i"))] | length > 0' >/dev/null 2>&1; then
+  FUNCTIONAL_MCP_BROKEN=true
+  FUNCTIONAL_MCP_BROKEN_REASON="Functional tester admitted in uncertain_observations that Playwright MCP was unavailable and tests fell back to curl/psql. UI-touching changes need UI evidence; the smoke-check loud-fail in skills/review-functional-tester.md should have caught this — investigate why it was bypassed."
+fi
+
 if [ "$HAS_BLOCKING" = "true" ]; then
   VERDICT="REQUEST_CHANGES"
 elif [ "$HUMAN_REVIEW" = "true" ]; then
@@ -520,6 +539,11 @@ elif [ "$JUDGES_BOTH_FAILED" = "true" ]; then
 elif [ "$MANUAL_SPEC_PRESENT" = "false" ]; then
   VERDICT="COMMENT"
   echo "::warning::No manual spec available — downgrading APPROVE to COMMENT (core reviewer set manual_spec_present=false)"
+elif [ "$FUNCTIONAL_MCP_BROKEN" = "true" ]; then
+  VERDICT="COMMENT"
+  HUMAN_REVIEW="true"
+  CORE_META=$(echo "$CORE_META" | jq --arg r "$FUNCTIONAL_MCP_BROKEN_REASON" '. + {requires_human_review: true, requires_human_review_reason: $r}')
+  echo "::warning::Playwright MCP unavailable — downgrading APPROVE to COMMENT and flagging for human review. Reason: $FUNCTIONAL_MCP_BROKEN_REASON"
 elif [ "$TECHNICAL_CHANGE" = "true" ] && [ "$SMOKE_OK" = "false" ]; then
   VERDICT="COMMENT"
   echo "::warning::Technical change without successful smoke test (overall=$FUNCTIONAL_OVERALL, ok=${FUNCTIONAL_OK:-1}) — downgrading APPROVE to COMMENT"

--- a/scripts/build-review.sh
+++ b/scripts/build-review.sh
@@ -524,9 +524,14 @@ FUNCTIONAL_MCP_BROKEN_REASON=""
 if [ "$FUNCTIONAL_OVERALL" = "CRASH" ] && echo "$FUNCTIONAL_META" | jq -e '(.summary // "") | test("Playwright MCP unavailable"; "i")' >/dev/null 2>&1; then
   FUNCTIONAL_MCP_BROKEN=true
   FUNCTIONAL_MCP_BROKEN_REASON="Playwright MCP smoke check failed — UI scenarios were not exercised. The .claude/agents/review-functional-tester.md subagent's inline mcpServers definition could not start the @playwright/mcp@latest stdio server. Check the runner has network + npx access; check the 'Pre-warm Playwright MCP package cache' step output."
-elif [ "$FUNCTIONAL_STRATEGY" = "functional" ] && echo "$FUNCTIONAL_META" | jq -e '[(.uncertain_observations // [])[] | select(test("Playwright MCP.*not.*avail|MCP.*unavailable|fall.*back to curl|all testing was done via curl"; "i"))] | length > 0' >/dev/null 2>&1; then
+elif { [ "$FUNCTIONAL_STRATEGY" = "functional" ] || [ "$FUNCTIONAL_STRATEGY" = "quick" ]; } \
+     && echo "$FUNCTIONAL_META" | jq -e '[(.uncertain_observations // [])[] | select(test("Playwright MCP.*not.*avail|MCP.*unavailable|fall.*back to curl|all testing was done via curl"; "i"))] | length > 0' >/dev/null 2>&1; then
+  # Both `functional` and `quick` strategies dispatch the Playwright-bound
+  # functional tester; only `skip` and `pipeline-self-test` are MCP-free.
+  # Earlier the gate checked only `functional` and would have let a quick
+  # smoke run silent-fall-back to curl without flagging it.
   FUNCTIONAL_MCP_BROKEN=true
-  FUNCTIONAL_MCP_BROKEN_REASON="Functional tester admitted in uncertain_observations that Playwright MCP was unavailable and tests fell back to curl/psql. UI-touching changes need UI evidence; the smoke-check loud-fail in skills/review-functional-tester.md should have caught this — investigate why it was bypassed."
+  FUNCTIONAL_MCP_BROKEN_REASON="Functional tester admitted in uncertain_observations that Playwright MCP was unavailable and tests fell back to curl/psql (strategy=$FUNCTIONAL_STRATEGY). UI-touching changes need UI evidence; the smoke-check loud-fail in skills/review-functional-tester.md should have caught this — investigate why it was bypassed."
 fi
 
 if [ "$HAS_BLOCKING" = "true" ]; then

--- a/scripts/functional-prompt.template.txt
+++ b/scripts/functional-prompt.template.txt
@@ -1,15 +1,18 @@
-You are a QA engineer validating PR functionality end-to-end. Read {{PIPELINE_DIR}}/skills/review-functional-tester.md for the full spec. Test through the user's flow whenever possible: Playwright MCP for UI, browser_evaluate (fetch with cookies) for API checks from within the browser context, curl via Bash only when nothing else works.
+You are a QA engineer validating PR functionality end-to-end. Read {{PIPELINE_DIR}}/skills/review-functional-tester.md for the full spec — your subagent type is `review-functional-tester` and Playwright MCP is wired in directly via the subagent's `mcpServers` definition (no `--mcp-config` needed). Test through the user's flow whenever possible: Playwright MCP for UI, browser_evaluate (fetch with cookies) for API checks from within the browser context, curl via Bash only when nothing else works.
 
-TURN 1 — do ALL of these in parallel (one message, multiple tool calls):
-  a) ToolSearch query: select:mcp__playwright__browser_navigate,mcp__playwright__browser_take_screenshot,mcp__playwright__browser_snapshot,mcp__playwright__browser_console_messages,mcp__playwright__browser_click,mcp__playwright__browser_fill_form,mcp__playwright__browser_wait_for,mcp__playwright__browser_select_option,mcp__playwright__browser_press_key,mcp__playwright__browser_evaluate
-  b) Read test-plan.md (repo root)
-  c) Read context.md (repo root) — contains the acceptance criteria
+TURN 1 — MCP smoke check (UNBATCHED, isolated):
+  Call `mcp__playwright__browser_navigate` with `url: "about:blank"`. ONE tool call this turn — no other tools, no batching. The isolation is deliberate so an MCP startup failure is unambiguous.
 
-TURN 2 — authenticate in the browser. Batch:
+  • If it returns successfully → MCP is up; proceed to Turn 2.
+  • If it errors with "tool not found" / "MCP server unavailable" / "MCP not configured" / similar → STOP. Write the loud-fail outputs documented in skills/review-functional-tester.md "MCP smoke-check failure" section (`/tmp/functional-meta.json` overall=CRASH; `/tmp/functional-findings.json = []`) and exit. DO NOT silently fall back to curl/psql — a curl-only PASS on a UI fix is the bug we're guarding against.
+
+TURN 2 — Read test-plan.md (repo root) + Read context.md (repo root) in parallel.
+
+TURN 3 — authenticate in the browser. Batch:
   - browser_navigate to {{WEB_URL}}
   - {{AUTH_INSTRUCTIONS}}
 
-TURNS 3+ — execute each scenario. Pick the closest-to-user method:
+TURNS 4+ — execute each scenario. Pick the closest-to-user method:
   • UI scenarios → browser_navigate + browser_snapshot (DOM assert) + browser_take_screenshot (evidence) + browser_console_messages + interactions (click/fill)
   • API-backed scenarios → browser_evaluate with fetch(..., {credentials: 'include'}) — authenticated
   • Raw HTTP probing → curl via Bash with -b /tmp/test-cookies.txt

--- a/scripts/generate-functional-prompt.sh
+++ b/scripts/generate-functional-prompt.sh
@@ -105,16 +105,16 @@ if [ -n "$FUNC_TEMPLATE" ] && [ -f "$FUNC_TEMPLATE" ]; then
 else
   echo "::warning::No functional-prompt template found -- using minimal fallback"
   cat > /tmp/functional-prompt.txt <<FALLBACK_EOF
-You are a QA engineer validating PR functionality end-to-end. Read ${PIPELINE_DIR_VAL}/skills/review-functional-tester.md for the full spec. Test through the user's flow whenever possible: Playwright MCP for UI, browser_evaluate (fetch with cookies) for API checks from within the browser context, curl via Bash only when nothing else works.
+You are a QA engineer validating PR functionality end-to-end. Read ${PIPELINE_DIR_VAL}/skills/review-functional-tester.md for the full spec — your subagent type is review-functional-tester so Playwright MCP is wired in directly via the subagent's mcpServers definition. Test through the user's flow whenever possible: Playwright MCP for UI, browser_evaluate (fetch with cookies) for API checks from within the browser context, curl via Bash only when nothing else works.
 
-TURN 1 -- do ALL of these in parallel (one message, multiple tool calls):
-  a) ToolSearch query: select:mcp__playwright__browser_navigate,mcp__playwright__browser_take_screenshot,mcp__playwright__browser_snapshot,mcp__playwright__browser_console_messages,mcp__playwright__browser_click,mcp__playwright__browser_fill_form,mcp__playwright__browser_wait_for,mcp__playwright__browser_select_option,mcp__playwright__browser_press_key,mcp__playwright__browser_evaluate
-  b) Read test-plan.md (repo root)
-  c) Read context.md (repo root) -- contains the acceptance criteria
+TURN 1 -- MCP smoke check (UNBATCHED, isolated):
+  Call mcp__playwright__browser_navigate with url="about:blank". If it errors with "tool not found" / "MCP server unavailable" / similar: STOP, write the loud-fail outputs in skills/review-functional-tester.md "MCP smoke-check failure" section, and exit. Do NOT silently fall back to curl.
 
-TURN 2 -- $AUTH_INSTRUCTIONS
+TURN 2 -- Read test-plan.md + context.md in parallel (acceptance criteria live there).
 
-TURNS 3+ -- execute each scenario from the test plan.
+TURN 3 -- $AUTH_INSTRUCTIONS
+
+TURNS 4+ -- execute each scenario from the test plan.
 Web URL: $WEB_URL_VAL
 
 LAST 2 TURNS -- write output:

--- a/scripts/install-functional-tester-agent.sh
+++ b/scripts/install-functional-tester-agent.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# install-functional-tester-agent.sh
+#
+# Writes `.claude/agents/review-functional-tester.md` into the runner's
+# checkout cwd. Claude Code auto-discovers `.claude/agents/*.md` at session
+# start, so this file MUST exist before claude-code-action launches.
+#
+# This is the load-bearing workaround for the "Playwright MCP stays in
+# `status: pending`" silent failure: the subagent definition's inline
+# `mcpServers` block forces the server to spawn when the subagent starts,
+# rather than relying on the parent orchestrator's `--mcp-config` (which
+# leaves the server unspawned because the orchestrator itself never calls
+# Playwright tools, and the subagent's ToolSearch query can't discover
+# tools that aren't yet registered).
+#
+# Schema notes (verified against
+# https://code.claude.com/docs/en/sub-agents → "Scope MCP servers to a
+# subagent"):
+#
+#   - `tools:` is a comma-separated single-line string. YAML lists also
+#     parse but the comma form matches every existing subagent file in
+#     the official plugin packs.
+#   - `mcpServers:` is a YAML LIST. Each item is either a bare string
+#     (referencing an already-configured server) or a single-key
+#     mapping (`- name:` followed by the inline server config). The dict
+#     form `mcpServers: {playwright: {...}}` parses to a different shape
+#     and is silently ignored — first iteration of PR #31 shipped the
+#     dict form and would have left MCP unwired despite passing review.
+#   - The body (after the second `---`) becomes the subagent's system
+#     prompt. We keep it minimal — a one-line redirect to the full
+#     skill file — because the orchestrator's Task call also passes a
+#     user prompt with the full instructions (functional-prompt.txt).
+#
+# Required env vars (set by the calling workflow step):
+#   PR_NUMBER         — for the prompt body
+#   MODEL_FUNCTIONAL  — model alias for the subagent
+#   PIPELINE_DIR      — absolute path to the installed pipeline dir
+#                       (where skills/review-functional-tester.md lives)
+#
+# Caller is expected to chdir to the runner's workspace BEFORE invoking
+# (we write to ./.claude/agents/ relative to cwd, matching Claude Code's
+# project-level subagent discovery convention).
+
+set -euo pipefail
+
+: "${PR_NUMBER:?PR_NUMBER must be set}"
+: "${MODEL_FUNCTIONAL:?MODEL_FUNCTIONAL must be set}"
+: "${PIPELINE_DIR:?PIPELINE_DIR must be set}"
+
+mkdir -p .claude/agents
+
+cat > .claude/agents/review-functional-tester.md <<EOF
+---
+name: review-functional-tester
+description: QA agent that validates PR functionality end-to-end with Playwright MCP. Spawned by the review orchestrator to test user flows, take targeted screenshots tied to findings, and write /tmp/functional-meta.json + /tmp/functional-findings.json.
+model: ${MODEL_FUNCTIONAL}
+tools: Bash, Read, Write, Glob, Grep, ToolSearch, mcp__playwright__browser_navigate, mcp__playwright__browser_take_screenshot, mcp__playwright__browser_snapshot, mcp__playwright__browser_console_messages, mcp__playwright__browser_click, mcp__playwright__browser_fill_form, mcp__playwright__browser_wait_for, mcp__playwright__browser_close, mcp__playwright__browser_select_option, mcp__playwright__browser_press_key, mcp__playwright__browser_type, mcp__playwright__browser_hover, mcp__playwright__browser_resize, mcp__playwright__browser_tabs, mcp__playwright__browser_navigate_back, mcp__playwright__browser_evaluate
+mcpServers:
+  - playwright:
+      type: stdio
+      command: npx
+      args: ["--yes", "@playwright/mcp@latest", "--headless", "--output-dir", "/tmp/screenshots"]
+---
+
+Read ${PIPELINE_DIR}/skills/review-functional-tester.md and follow it exactly. The orchestrator spawned you for PR ${PR_NUMBER}. test-plan.md and context.md are at the repo root. Your first turn MUST be the MCP smoke check described in the skill — do not silently fall back to curl/psql when MCP is unavailable.
+EOF
+
+echo "Functional-tester subagent installed:"
+ls -la .claude/agents/
+
+# Schema validation. Two paths:
+#   1. ruby+psych (always present on macOS + ubuntu-latest GitHub runners)
+#   2. python+pyyaml fallback (some runners).
+# A simple `grep -E` line-pattern check is the third fallback.
+validate_with_ruby() {
+  ruby -ryaml -e '
+    text = File.read(".claude/agents/review-functional-tester.md")
+    fm = text.split("---", 3)[1]
+    abort "::error::no frontmatter" unless fm
+    data = YAML.safe_load(fm)
+    %w[name description tools mcpServers].each do |k|
+      abort "::error::missing required field \"#{k}\"" unless data.key?(k)
+    end
+    abort "::error::mcpServers must be a YAML list per Claude Code subagent schema; got #{data["mcpServers"].class}" unless data["mcpServers"].is_a?(Array)
+    abort "::error::mcpServers list is empty" if data["mcpServers"].empty?
+    first = data["mcpServers"][0]
+    abort "::error::mcpServers[0] must be a single-key mapping (server-name to inline config); got #{first.inspect}" unless first.is_a?(Hash) && first.size == 1
+    server_name, config = first.first
+    abort "::error::expected mcpServers[0] key \"playwright\"; got \"#{server_name}\"" unless server_name == "playwright"
+    %w[type command args].each do |k|
+      abort "::error::playwright config missing \"#{k}\"" unless config.key?(k)
+    end
+    abort "::error::playwright.type must be \"stdio\"; got \"#{config["type"]}\"" unless config["type"] == "stdio"
+    puts "OK: subagent frontmatter valid (ruby/psych); mcpServers list has #{data["mcpServers"].length} entry, playwright = #{config["command"]} #{config["args"].inspect}."
+  '
+}
+
+validate_with_python() {
+  python3 - <<'PYEOF'
+import sys, re, yaml
+text = open('.claude/agents/review-functional-tester.md').read()
+fm_match = re.match(r'^---\n(.*?)\n---\n', text, re.S)
+if not fm_match:
+    sys.exit("::error::no frontmatter")
+fm = yaml.safe_load(fm_match.group(1))
+for required in ('name', 'description', 'tools', 'mcpServers'):
+    if required not in fm:
+        sys.exit(f"::error::missing required field '{required}'")
+if not isinstance(fm['mcpServers'], list):
+    sys.exit(f"::error::mcpServers must be a YAML list; got {type(fm['mcpServers']).__name__}")
+if len(fm['mcpServers']) == 0:
+    sys.exit("::error::mcpServers list is empty")
+first = fm['mcpServers'][0]
+if not isinstance(first, dict) or len(first) != 1:
+    sys.exit(f"::error::mcpServers[0] must be a single-key mapping; got {first!r}")
+server_name, config = next(iter(first.items()))
+if server_name != 'playwright':
+    sys.exit(f"::error::expected mcpServers[0] key 'playwright'; got '{server_name}'")
+for required in ('type', 'command', 'args'):
+    if required not in config:
+        sys.exit(f"::error::playwright config missing '{required}'")
+if config['type'] != 'stdio':
+    sys.exit(f"::error::playwright.type must be 'stdio'; got '{config['type']}'")
+print(f"OK: subagent frontmatter valid (python/yaml); mcpServers list has {len(fm['mcpServers'])} entry, playwright = {config['command']} {config['args']}.")
+PYEOF
+}
+
+validate_with_grep() {
+  grep -qE '^mcpServers:[[:space:]]*$' .claude/agents/review-functional-tester.md \
+    || { echo "::error::mcpServers field not on its own line — schema may be malformed"; return 1; }
+  grep -qE '^[[:space:]]+- playwright:[[:space:]]*$' .claude/agents/review-functional-tester.md \
+    || { echo "::error::mcpServers must contain '  - playwright:' (YAML list with single-key mapping); dict form is silently ignored"; return 1; }
+  echo "OK: subagent frontmatter passes line-pattern validation (no YAML parser available for full schema check)."
+}
+
+if command -v ruby >/dev/null 2>&1; then
+  validate_with_ruby
+elif python3 -c 'import yaml' >/dev/null 2>&1; then
+  validate_with_python
+else
+  validate_with_grep
+fi

--- a/scripts/install-functional-tester-agent.sh
+++ b/scripts/install-functional-tester-agent.sh
@@ -41,15 +41,20 @@
 # (we write to ./.claude/agents/ relative to cwd, matching Claude Code's
 # project-level subagent discovery convention).
 
-set -euo pipefail
+# `set -uo pipefail` (no -e) per .github/review-config.md + bugbot.md. The
+# explicit `|| exit 1` chains below cover the cases where -e would have
+# fired, while preserving graceful continuation on the YAML-validator
+# fallback chain (ruby → python → grep): a missing parser is not a fatal
+# error, we just degrade to the next available method.
+set -uo pipefail
 
 : "${PR_NUMBER:?PR_NUMBER must be set}"
 : "${MODEL_FUNCTIONAL:?MODEL_FUNCTIONAL must be set}"
 : "${PIPELINE_DIR:?PIPELINE_DIR must be set}"
 
-mkdir -p .claude/agents
+mkdir -p .claude/agents || { echo "::error::failed to mkdir .claude/agents (cwd=$(pwd))"; exit 1; }
 
-cat > .claude/agents/review-functional-tester.md <<EOF
+cat > .claude/agents/review-functional-tester.md <<EOF || { echo "::error::failed to write .claude/agents/review-functional-tester.md"; exit 1; }
 ---
 name: review-functional-tester
 description: QA agent that validates PR functionality end-to-end with Playwright MCP. Spawned by the review orchestrator to test user flows, take targeted screenshots tied to findings, and write /tmp/functional-meta.json + /tmp/functional-findings.json.
@@ -134,9 +139,9 @@ validate_with_grep() {
 }
 
 if command -v ruby >/dev/null 2>&1; then
-  validate_with_ruby
+  validate_with_ruby || exit 1
 elif python3 -c 'import yaml' >/dev/null 2>&1; then
-  validate_with_python
+  validate_with_python || exit 1
 else
-  validate_with_grep
+  validate_with_grep || exit 1
 fi

--- a/scripts/install-functional-tester-agent.sh
+++ b/scripts/install-functional-tester-agent.sh
@@ -1,9 +1,20 @@
 #!/usr/bin/env bash
 # install-functional-tester-agent.sh
 #
-# Writes `.claude/agents/review-functional-tester.md` into the runner's
-# checkout cwd. Claude Code auto-discovers `.claude/agents/*.md` at session
-# start, so this file MUST exist before claude-code-action launches.
+# Writes `$HOME/.claude/agents/review-functional-tester.md` (user-scope).
+# Claude Code auto-discovers user-scope subagents from `~/.claude/agents/`
+# at session start, so this file MUST exist before claude-code-action
+# launches.
+#
+# IMPORTANT: this MUST go to user scope, NOT project scope (./.claude/agents/).
+# claude-code-action's `restore-config.ts` explicitly lists `.claude` in
+# SENSITIVE_PATHS and replaces the entire workspace `.claude/` tree with
+# origin/$base on PR-head jobs as an RCE-prevention measure. A project-scope
+# subagent file written before claude-code-action runs would be wiped.
+# `$HOME` is documented as untouched by the restore (the source code's own
+# comment: ".bashrc etc. — shells source these from $HOME; checkout cannot
+# reach $HOME"), so user scope is the survivable location.
+# Reference: https://github.com/anthropics/claude-code-action/blob/main/src/github/operations/restore-config.ts
 #
 # This is the load-bearing workaround for the "Playwright MCP stays in
 # `status: pending`" silent failure: the subagent definition's inline
@@ -37,9 +48,8 @@
 #   PIPELINE_DIR      — absolute path to the installed pipeline dir
 #                       (where skills/review-functional-tester.md lives)
 #
-# Caller is expected to chdir to the runner's workspace BEFORE invoking
-# (we write to ./.claude/agents/ relative to cwd, matching Claude Code's
-# project-level subagent discovery convention).
+# Caller does NOT need a specific cwd — we write to $HOME/.claude/agents/
+# (absolute path), which is invariant across the action's cwd changes.
 
 # `set -uo pipefail` (no -e) per .github/review-config.md + bugbot.md. The
 # explicit `|| exit 1` chains below cover the cases where -e would have
@@ -51,10 +61,14 @@ set -uo pipefail
 : "${PR_NUMBER:?PR_NUMBER must be set}"
 : "${MODEL_FUNCTIONAL:?MODEL_FUNCTIONAL must be set}"
 : "${PIPELINE_DIR:?PIPELINE_DIR must be set}"
+: "${HOME:?HOME must be set}"
 
-mkdir -p .claude/agents || { echo "::error::failed to mkdir .claude/agents (cwd=$(pwd))"; exit 1; }
+AGENT_DIR="$HOME/.claude/agents"
+AGENT_FILE="$AGENT_DIR/review-functional-tester.md"
 
-cat > .claude/agents/review-functional-tester.md <<EOF || { echo "::error::failed to write .claude/agents/review-functional-tester.md"; exit 1; }
+mkdir -p "$AGENT_DIR" || { echo "::error::failed to mkdir $AGENT_DIR"; exit 1; }
+
+cat > "$AGENT_FILE" <<EOF || { echo "::error::failed to write $AGENT_FILE"; exit 1; }
 ---
 name: review-functional-tester
 description: QA agent that validates PR functionality end-to-end with Playwright MCP. Spawned by the review orchestrator to test user flows, take targeted screenshots tied to findings, and write /tmp/functional-meta.json + /tmp/functional-findings.json.
@@ -70,16 +84,16 @@ mcpServers:
 Read ${PIPELINE_DIR}/skills/review-functional-tester.md and follow it exactly. The orchestrator spawned you for PR ${PR_NUMBER}. test-plan.md and context.md are at the repo root. Your first turn MUST be the MCP smoke check described in the skill — do not silently fall back to curl/psql when MCP is unavailable.
 EOF
 
-echo "Functional-tester subagent installed:"
-ls -la .claude/agents/
+echo "Functional-tester subagent installed at $AGENT_FILE:"
+ls -la "$AGENT_DIR"
 
 # Schema validation. Two paths:
 #   1. ruby+psych (always present on macOS + ubuntu-latest GitHub runners)
 #   2. python+pyyaml fallback (some runners).
 # A simple `grep -E` line-pattern check is the third fallback.
 validate_with_ruby() {
-  ruby -ryaml -e '
-    text = File.read(".claude/agents/review-functional-tester.md")
+  AGENT_FILE="$AGENT_FILE" ruby -ryaml -e '
+    text = File.read(ENV.fetch("AGENT_FILE"))
     fm = text.split("---", 3)[1]
     abort "::error::no frontmatter" unless fm
     data = YAML.safe_load(fm)
@@ -101,9 +115,9 @@ validate_with_ruby() {
 }
 
 validate_with_python() {
-  python3 - <<'PYEOF'
-import sys, re, yaml
-text = open('.claude/agents/review-functional-tester.md').read()
+  AGENT_FILE="$AGENT_FILE" python3 - <<'PYEOF'
+import os, sys, re, yaml
+text = open(os.environ['AGENT_FILE']).read()
 fm_match = re.match(r'^---\n(.*?)\n---\n', text, re.S)
 if not fm_match:
     sys.exit("::error::no frontmatter")
@@ -131,9 +145,9 @@ PYEOF
 }
 
 validate_with_grep() {
-  grep -qE '^mcpServers:[[:space:]]*$' .claude/agents/review-functional-tester.md \
+  grep -qE '^mcpServers:[[:space:]]*$' "$AGENT_FILE" \
     || { echo "::error::mcpServers field not on its own line — schema may be malformed"; return 1; }
-  grep -qE '^[[:space:]]+- playwright:[[:space:]]*$' .claude/agents/review-functional-tester.md \
+  grep -qE '^[[:space:]]+- playwright:[[:space:]]*$' "$AGENT_FILE" \
     || { echo "::error::mcpServers must contain '  - playwright:' (YAML list with single-key mapping); dict form is silently ignored"; return 1; }
   echo "OK: subagent frontmatter passes line-pattern validation (no YAML parser available for full schema check)."
 }

--- a/skills/review-functional-tester.md
+++ b/skills/review-functional-tester.md
@@ -70,13 +70,27 @@ The runtime ceiling is **200 turns** (configurable via `functional_max_turns`; r
 
 Budget sketch (a typical 4-scenario plan):
 
-- Turn 1: ToolSearch for Playwright MCP tools + Read `test-plan.md` + Read `context.md` (all in parallel — single response)
-- Turn 2: Navigate to the app + authenticate (batched)
-- Turns 3–8: Scenario 1 (typical: navigate, batched snapshot+screenshot+console, interact, verify)
-- Turns 9–14: Scenario 2
-- Turns 15–20: Scenario 3
-- Turns 21–26: Scenario 4
-- Turns 27–30: Targeted re-screenshots for findings + write output
+- **Turn 1: MCP smoke check.** Call `mcp__playwright__browser_navigate` with `url: "about:blank"` ALONE (no batching). This is the only turn that doesn't batch — it's deliberately isolated so MCP startup failures are unambiguous. If the call returns successfully, proceed to Turn 2. If the call errors with "tool not found", "MCP server unavailable", or any other MCP failure mode, **STOP and write the loud-fail outputs** described under "MCP smoke-check failure" below — DO NOT silently fall back to curl/psql.
+- Turn 2: Read `test-plan.md` + Read `context.md` (parallel)
+- Turn 3: Navigate to the app + authenticate (batched)
+- Turns 4–9: Scenario 1 (typical: navigate, batched snapshot+screenshot+console, interact, verify)
+- Turns 10–15: Scenario 2
+- Turns 16–21: Scenario 3
+- Turns 22–27: Scenario 4
+- Turns 28–30: Targeted re-screenshots for findings + write output
+
+### MCP smoke-check failure
+
+If Turn 1's `mcp__playwright__browser_navigate about:blank` errors:
+
+1. Write `/tmp/functional-meta.json`:
+   ```json
+   {"strategy": "functional", "overall": "CRASH", "summary": "Playwright MCP unavailable — UI testing skipped. Subagent's inline mcpServers definition failed to start the @playwright/mcp@latest stdio server. Check the runner has network + npx access; check `Pre-warm Playwright MCP package cache` workflow step output.", "screenshots": [], "areas_tested": [], "uncertain_observations": ["Playwright MCP smoke check failed on Turn 1 — see /tmp/functional-mcp-smoke.log if present. Falling back to curl/psql is forbidden by skill spec; the run is a CRASH so the verdict gate flags it."]}
+   ```
+2. Write `/tmp/functional-findings.json = []`.
+3. Exit immediately. Do NOT run any scenarios. Do NOT call curl. The verdict gate downstream will surface the CRASH and a human reviewer will look.
+
+This is **load-bearing**: a silent curl fallback was the bug we shipped this skill to fix. UI bugs slip through when the tester reports PASS-via-curl on a fix that needs UI verification. CRASH > false PASS.
 
 **STOP-and-write anchors (mandatory).** The agent does not get to decide when to stop:
 

--- a/skills/review-orchestrator.md
+++ b/skills/review-orchestrator.md
@@ -9,7 +9,7 @@ You are the **only** top-level Claude Code agent in the review pipeline. You DO 
 
 ## Tools
 
-`Read`, `Write`, `Bash`, `Glob`, `Grep`, `Task`. (Subagents inherit Playwright MCP from your `--mcp-config`; the functional tester subagent uses it, the others do not.)
+`Read`, `Write`, `Bash`, `Glob`, `Grep`, `Task`. You do NOT have Playwright MCP yourself — Phase 2 dispatches the `review-functional-tester` custom subagent (auto-discovered from `.claude/agents/review-functional-tester.md`) which inline-defines its own Playwright MCP server. That subagent's MCP starts when it spawns and is invisible to you.
 
 ## Output paths (defaults; the launching workflow may override)
 
@@ -140,7 +140,7 @@ Issue these in **one assistant response**:
    Read $CLAUDE_REVIEW_PIPELINE_DIR/skills/review-thread-classifier.md and follow it exactly. If bugbot.md exists at the repo root, Read it. You are the round-2 thread classifier for PR #${PR_NUMBER}. Inputs: /tmp/prior-state/review-state.json, /tmp/prior-bot-comments.json, /tmp/other-bot-comments.json, /tmp/human-inline-comments.json, /tmp/since-last.diff. Write /tmp/thread-resolution.json.
    ```
 
-4. **Functional tester** (when the functional-dispatch decision says yes). `model: "claude-sonnet-4-6"` (or whatever the workflow passes for the functional model). The functional skill is read by the subagent itself; the prompt is the contents of `/tmp/functional-prompt.txt` (which already contains the framing + env-var values for the dev-env). MCP tools are inherited from your `--mcp-config`.
+4. **Functional tester** (when the functional-dispatch decision says yes). Dispatch with `subagent_type: "review-functional-tester"` (custom type; the workflow installed `.claude/agents/review-functional-tester.md` which defines its tools, model, and inline `mcpServers` for Playwright). The prompt is the contents of `/tmp/functional-prompt.txt` (which already contains the framing + env-var values for the dev-env from Phase 0.5). Do NOT pass MCP config or override tools in the prompt — the subagent definition owns Playwright MCP and starts the server when it spawns. The orchestrator process never carries Playwright tooling.
 
 Wait for every dispatched Task to return.
 

--- a/tests/functional_mcp_gate_test.sh
+++ b/tests/functional_mcp_gate_test.sh
@@ -49,7 +49,7 @@ gate_for() {
   obs_match=$(echo "$meta" | jq -e '[(.uncertain_observations // [])[] | select(test("Playwright MCP.*not.*avail|MCP.*unavailable|fall.*back to curl|all testing was done via curl"; "i"))] | length > 0' >/dev/null 2>&1 && echo true || echo false)
   if [ "$overall" = "CRASH" ] && [ "$crash_match" = "true" ]; then
     echo "true"
-  elif [ "$strategy" = "functional" ] && [ "$obs_match" = "true" ]; then
+  elif { [ "$strategy" = "functional" ] || [ "$strategy" = "quick" ]; } && [ "$obs_match" = "true" ]; then
     echo "true"
   else
     echo "false"
@@ -143,6 +143,20 @@ META_G=$(jq -n '{
   uncertain_observations: ["MCP unavailable mid-run; switched to fetch."]
 }')
 assert_eq "G: post-launch MCP loss observation → broken=true" "true" "$(gate_for "$META_G" functional PASS)"
+
+# ── Case G2: same fallback string under strategy=quick. The orchestrator
+# dispatches the functional tester for both `functional` AND `quick`
+# strategies; an earlier version of the gate checked only `functional`
+# and would have let quick-strategy curl-fallback runs through silently. ──
+META_G2=$(jq -n '{
+  strategy: "quick",
+  overall: "PASS",
+  summary: "Quick smoke.",
+  screenshots: [],
+  areas_tested: ["smoke"],
+  uncertain_observations: ["Playwright MCP tools were not available; ran curl smoke instead."]
+}')
+assert_eq "G2: quick-strategy fallback observation → broken=true" "true" "$(gate_for "$META_G2" quick PASS)"
 
 # ── Case H: empty meta (no strategy / no overall) — must NOT crash. ──
 META_H='{}'

--- a/tests/functional_mcp_gate_test.sh
+++ b/tests/functional_mcp_gate_test.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# functional_mcp_gate_test.sh — fixture test for the FUNCTIONAL_MCP_BROKEN
+# gate in build-review.sh.
+#
+# Background. Earlier the functional-tester subagent silently fell back to
+# curl/psql when Playwright MCP wasn't available and reported the failure
+# only as a footnote in functional_meta.uncertain_observations: "Playwright
+# MCP tools were not available in this test context; all testing was done
+# via curl/psql." A backend-only PR like seaters#457 then produced PASS,
+# review verdict was COMMENT/APPROVE, and the developer never saw the gap.
+#
+# After this PR, two layers protect against the same hole:
+#   - skill-level: review-functional-tester.md "MCP smoke-check failure"
+#     forces overall=CRASH on a Turn-1 mcp__playwright__browser_navigate
+#     failure, with summary containing "Playwright MCP unavailable".
+#   - script-level (this test): build-review.sh's FUNCTIONAL_MCP_BROKEN
+#     gate triggers in two ways:
+#       a) overall == CRASH AND summary matches "Playwright MCP unavailable"
+#       b) strategy == "functional" AND any uncertain_observations entry
+#          matches the historical silent-fallback strings (defence-in-depth
+#          if a future skill regression re-introduces curl-only).
+#     Either signal flips the verdict to COMMENT and sets
+#     requires_human_review=true with a clear reason.
+
+cd "$(dirname "$0")/.."
+
+fail=0
+assert_eq() {
+  local label="$1" want="$2" got="$3"
+  if [ "$want" != "$got" ]; then
+    echo "FAIL: $label — want '$want', got '$got'"
+    fail=$((fail + 1))
+  else
+    echo "OK:   $label"
+  fi
+}
+
+# Inline the gate so the test doesn't have to source build-review.sh
+# (which would run the entire review pipeline). The expression here MUST
+# stay byte-identical to the one in scripts/build-review.sh; if you change
+# one, change the other and re-run this test.
+gate_for() {
+  local meta="$1" strategy="$2" overall="$3"
+  local crash_match
+  crash_match=$(echo "$meta" | jq -e '(.summary // "") | test("Playwright MCP unavailable"; "i")' >/dev/null 2>&1 && echo true || echo false)
+  local obs_match
+  obs_match=$(echo "$meta" | jq -e '[(.uncertain_observations // [])[] | select(test("Playwright MCP.*not.*avail|MCP.*unavailable|fall.*back to curl|all testing was done via curl"; "i"))] | length > 0' >/dev/null 2>&1 && echo true || echo false)
+  if [ "$overall" = "CRASH" ] && [ "$crash_match" = "true" ]; then
+    echo "true"
+  elif [ "$strategy" = "functional" ] && [ "$obs_match" = "true" ]; then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+
+# ── Case A: skill-level loud fail (overall=CRASH + summary match). ──
+META_A=$(jq -n '{
+  strategy: "functional",
+  overall: "CRASH",
+  summary: "Playwright MCP unavailable — UI testing skipped. Subagent failed to start.",
+  screenshots: [],
+  areas_tested: [],
+  uncertain_observations: ["Playwright MCP smoke check failed on Turn 1"]
+}')
+assert_eq "A: skill loud-fail (CRASH + summary) → broken=true" "true" "$(gate_for "$META_A" functional CRASH)"
+
+# ── Case B: defence-in-depth (silent-fallback string in uncertain_observations). ──
+# The historical bug shape from PR #457 round 1 — strategy=functional, overall=PASS,
+# but the tester admitted MCP was unavailable in uncertain_observations.
+META_B=$(jq -n '{
+  strategy: "functional",
+  overall: "PASS",
+  summary: "Tested via curl + psql.",
+  screenshots: [],
+  areas_tested: ["scenario-1", "scenario-2"],
+  uncertain_observations: [
+    "Some other unrelated note.",
+    "Playwright MCP tools were not available in this test context; all testing was done via curl/psql."
+  ]
+}')
+assert_eq "B: silent-fallback string in observations → broken=true" "true" "$(gate_for "$META_B" functional PASS)"
+
+# ── Case C: legitimate skip (no functional run) — must NOT trigger. ──
+META_C=$(jq -n '{
+  strategy: "skip",
+  overall: "PASS",
+  summary: "Functional testing skipped.",
+  screenshots: [],
+  areas_tested: [],
+  uncertain_observations: []
+}')
+assert_eq "C: legitimate skip → broken=false" "false" "$(gate_for "$META_C" skip PASS)"
+
+# ── Case D: real PASS (screenshots present, no MCP-broken string). ──
+META_D=$(jq -n '{
+  strategy: "functional",
+  overall: "PASS",
+  summary: "Tested 4 scenarios via Playwright. All passed.",
+  screenshots: [
+    {file: "/tmp/screenshots/01-list.png", description: "List page", area: "list"}
+  ],
+  areas_tested: ["scenario-1"],
+  uncertain_observations: ["Auth path is OAuth-only — verified the redirect path."]
+}')
+assert_eq "D: healthy functional PASS → broken=false" "false" "$(gate_for "$META_D" functional PASS)"
+
+# ── Case E: pipeline-self-test (deterministic; tests/*.sh, no MCP). ──
+# Must not trigger even though strategy != "skip".
+META_E=$(jq -n '{
+  strategy: "pipeline-self-test",
+  overall: "PASS",
+  summary: "Ran 11 bash test scripts; all passed.",
+  pass: 11, fail: 0, total: 11,
+  uncertain_observations: []
+}')
+assert_eq "E: pipeline-self-test → broken=false" "false" "$(gate_for "$META_E" pipeline-self-test PASS)"
+
+# ── Case F: CRASH with non-MCP summary (e.g. tester ran out of turns). ──
+# overall=CRASH alone is NOT enough — summary must mention MCP unavailability.
+# (A turn-budget crash still produced UI evidence; treating it as MCP-broken
+# would over-flag.)
+META_F=$(jq -n '{
+  strategy: "functional",
+  overall: "CRASH",
+  summary: "Functional tester agent did not complete; max turns hit.",
+  screenshots: [],
+  areas_tested: [],
+  uncertain_observations: []
+}')
+assert_eq "F: turn-budget crash (no MCP signal) → broken=false" "false" "$(gate_for "$META_F" functional CRASH)"
+
+# ── Case G: future regression — overall=PASS but observations contain
+# "MCP unavailable" (caught by the second-arm regex). ──
+META_G=$(jq -n '{
+  strategy: "functional",
+  overall: "PASS",
+  summary: "Tested everything.",
+  screenshots: [],
+  areas_tested: ["scenario-1"],
+  uncertain_observations: ["MCP unavailable mid-run; switched to fetch."]
+}')
+assert_eq "G: post-launch MCP loss observation → broken=true" "true" "$(gate_for "$META_G" functional PASS)"
+
+# ── Case H: empty meta (no strategy / no overall) — must NOT crash. ──
+META_H='{}'
+assert_eq "H: empty meta → broken=false (no crash)" "false" "$(gate_for "$META_H" '' '')"
+
+if [ "$fail" -eq 0 ]; then
+  echo
+  echo "All functional-MCP-gate tests passed."
+  exit 0
+else
+  echo
+  echo "$fail functional-MCP-gate test assertion(s) failed."
+  exit 1
+fi

--- a/tests/install_functional_tester_agent_test.sh
+++ b/tests/install_functional_tester_agent_test.sh
@@ -62,15 +62,31 @@ assert_eq "file written to \$HOME/.claude/agents/review-functional-tester.md" \
   "true" \
   "$([ -f "$AGENT_FILE" ] && echo true || echo false)"
 
-# Belt-and-braces: the file must NOT also have been written to project
-# scope (./.claude/agents/) — that's the path that claude-code-action
-# wipes, and writing there would have been the bug that motivated this
-# whole PR. Run from a fresh cwd so any pre-existing project file in
-# the test runner's working directory doesn't false-positive.
-WORKDIR=$(mktemp -d)
-( cd "$WORKDIR" && [ ! -e .claude ] ) && PROJECT_SCOPE_LEAKED=false || PROJECT_SCOPE_LEAKED=true
-rm -rf "$WORKDIR"
-assert_eq "did NOT also write to project-scope ./.claude/agents/" "false" "$PROJECT_SCOPE_LEAKED"
+# Belt-and-braces: the helper must NOT also write to project scope
+# (./.claude/agents/) — that's the path claude-code-action wipes, and
+# writing there would have been the bug that motivated this whole PR.
+# Run the helper a SECOND time from a controlled cwd inside its own
+# scratch dir, then assert the cwd has no `.claude/` directory after
+# the run. This actually exercises the SUT (running the helper from
+# that cwd), unlike a tautology that just checks "fresh empty dir is
+# still empty".
+SCOPE_TEST_DIR=$(mktemp -d)
+SCOPE_TEST_HOME=$(mktemp -d)
+(
+  cd "$SCOPE_TEST_DIR" && \
+  HOME="$SCOPE_TEST_HOME" \
+  PR_NUMBER=99999 \
+  MODEL_FUNCTIONAL=claude-sonnet-4-6 \
+  PIPELINE_DIR=/tmp/test-pipeline \
+    bash "$HELPER" >/dev/null 2>&1
+)
+PROJECT_SCOPE_LEAKED=false
+[ -e "$SCOPE_TEST_DIR/.claude" ] && PROJECT_SCOPE_LEAKED=true
+USER_SCOPE_WRITTEN=false
+[ -f "$SCOPE_TEST_HOME/.claude/agents/review-functional-tester.md" ] && USER_SCOPE_WRITTEN=true
+rm -rf "$SCOPE_TEST_DIR" "$SCOPE_TEST_HOME"
+assert_eq "helper writes ONLY to user scope (not ./.claude/ in cwd)" "false" "$PROJECT_SCOPE_LEAKED"
+assert_eq "helper writes to user scope (\$HOME/.claude/agents/...)"  "true"  "$USER_SCOPE_WRITTEN"
 
 # ── YAML structure assertions via ruby+psych (always present on the
 #    Shell tests + lint runner). ──

--- a/tests/install_functional_tester_agent_test.sh
+++ b/tests/install_functional_tester_agent_test.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# install_functional_tester_agent_test.sh — fixture test for the
+# `.claude/agents/review-functional-tester.md` writer.
+#
+# Background. The first iteration of PR #31 wrote the subagent file with
+# `mcpServers:` as a YAML dict. Claude Code's subagent schema (per
+# https://code.claude.com/docs/en/sub-agents → "Scope MCP servers to a
+# subagent") requires `mcpServers:` to be a YAML LIST where each entry is
+# either a string (referencing an already-configured server) or a
+# single-key mapping (`- name:` with the inline config below). The dict
+# form parses to a different shape and is silently ignored — the
+# Playwright server would never spawn even though `claude mcp list`
+# shows it as "configured".
+#
+# This test asserts that the helper produces:
+#   - YAML frontmatter that's parseable by ruby/psych or python/pyyaml
+#   - `mcpServers` is an Array of length >= 1
+#   - mcpServers[0] is a single-key Hash whose key is "playwright"
+#   - playwright config has type=stdio, command=npx, args includes
+#     "--headless" + "--output-dir" + "/tmp/screenshots"
+#   - tools is a comma-separated string with all 16 mcp__playwright__*
+#     tools listed (smoke check that the orchestrator dispatch will
+#     have access to the right tool space)
+#
+# Without this test, dict-vs-list regressions would only surface during a
+# real consumer review (when the functional tester silently falls back to
+# curl/psql and admits "MCP not available" in uncertain_observations).
+
+cd "$(dirname "$0")/.."
+
+fail=0
+assert_eq() {
+  local label="$1" want="$2" got="$3"
+  if [ "$want" != "$got" ]; then
+    echo "FAIL: $label — want '$want', got '$got'"
+    fail=$((fail + 1))
+  else
+    echo "OK:   $label"
+  fi
+}
+
+# ── Run the helper in a sandbox cwd so we don't pollute the repo. ──
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+HELPER="$(pwd)/scripts/install-functional-tester-agent.sh"
+
+# Drop CWD into a fresh dir; the helper writes relative to cwd.
+cd "$TMP"
+
+PR_NUMBER=12345 \
+MODEL_FUNCTIONAL=claude-sonnet-4-6 \
+PIPELINE_DIR=/tmp/test-pipeline \
+  bash "$HELPER" >/tmp/install-out.log 2>&1 \
+  || { echo "FAIL: helper exited non-zero"; cat /tmp/install-out.log; exit 1; }
+
+assert_eq "file written to .claude/agents/review-functional-tester.md" \
+  "true" \
+  "$([ -f .claude/agents/review-functional-tester.md ] && echo true || echo false)"
+
+# ── YAML structure assertions via ruby+psych (always present on the
+#    Shell tests + lint runner). ──
+RUBY_OUT=$(ruby -ryaml -e '
+  text = File.read(".claude/agents/review-functional-tester.md")
+  fm_str = text.split("---", 3)[1]
+  data = YAML.safe_load(fm_str)
+  puts "name=#{data["name"]}"
+  puts "model=#{data["model"]}"
+  puts "tools_class=#{data["tools"].class}"
+  puts "mcpServers_class=#{data["mcpServers"].class}"
+  puts "mcpServers_length=#{data["mcpServers"].length}"
+  first = data["mcpServers"][0]
+  puts "first_class=#{first.class}"
+  puts "first_keys=#{first.keys.inspect}"
+  puts "playwright_type=#{first["playwright"]["type"]}"
+  puts "playwright_command=#{first["playwright"]["command"]}"
+  puts "playwright_args=#{first["playwright"]["args"].inspect}"
+  puts "body_first_line=#{text.split("---", 3)[2].lines.find { |l| l.strip.length > 0 }.strip}"
+' 2>&1)
+
+get() { echo "$RUBY_OUT" | grep -E "^$1=" | sed -E "s/^$1=//"; }
+
+assert_eq "frontmatter.name"        "review-functional-tester"            "$(get name)"
+assert_eq "frontmatter.model"       "claude-sonnet-4-6"                   "$(get model)"
+assert_eq "frontmatter.tools type"  "String"                              "$(get tools_class)"
+assert_eq "mcpServers IS a list"    "Array"                               "$(get mcpServers_class)"
+assert_eq "mcpServers length"       "1"                                   "$(get mcpServers_length)"
+assert_eq "mcpServers[0] is a Hash" "Hash"                                "$(get first_class)"
+assert_eq "mcpServers[0] single key 'playwright'" '["playwright"]'        "$(get first_keys)"
+assert_eq "playwright.type"         "stdio"                               "$(get playwright_type)"
+assert_eq "playwright.command"      "npx"                                 "$(get playwright_command)"
+
+# args list contains the --output-dir /tmp/screenshots pair (load-bearing
+# — without --output-dir the MCP server writes screenshots to a session
+# tmpdir that the upload step never finds).
+ARGS=$(get playwright_args)
+assert_eq "playwright.args includes --headless" "true" \
+  "$(echo "$ARGS" | grep -qE '"--headless"' && echo true || echo false)"
+assert_eq "playwright.args includes --output-dir /tmp/screenshots" "true" \
+  "$(echo "$ARGS" | grep -qE '"--output-dir".*"/tmp/screenshots"' && echo true || echo false)"
+assert_eq "playwright.args includes @playwright/mcp@latest" "true" \
+  "$(echo "$ARGS" | grep -qE '"@playwright/mcp@latest"' && echo true || echo false)"
+
+# ── tools field MUST list every Playwright MCP tool the skill uses, or
+#    the subagent's tool list is incomplete and Claude Code will refuse
+#    those calls even with MCP connected. ──
+EXPECTED_PLAYWRIGHT_TOOLS=(
+  mcp__playwright__browser_navigate
+  mcp__playwright__browser_take_screenshot
+  mcp__playwright__browser_snapshot
+  mcp__playwright__browser_console_messages
+  mcp__playwright__browser_click
+  mcp__playwright__browser_fill_form
+  mcp__playwright__browser_wait_for
+  mcp__playwright__browser_close
+  mcp__playwright__browser_select_option
+  mcp__playwright__browser_press_key
+  mcp__playwright__browser_type
+  mcp__playwright__browser_hover
+  mcp__playwright__browser_resize
+  mcp__playwright__browser_tabs
+  mcp__playwright__browser_navigate_back
+  mcp__playwright__browser_evaluate
+)
+# Pull the comma-separated value off the `tools:` line, split, and trim
+# each token so the membership test is exact. A regex with anchors is
+# fragile around the `: ` separator and the trailing newline; iterating
+# tokens is the boring-correct version.
+TOOLS_VALUE=$(grep -E '^tools:' .claude/agents/review-functional-tester.md | sed -E 's/^tools:[[:space:]]*//')
+declare -A TOOLS_SET
+while IFS= read -r tok; do
+  tok="$(echo "$tok" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+  [ -n "$tok" ] && TOOLS_SET["$tok"]=1
+done < <(echo "$TOOLS_VALUE" | tr ',' '\n')
+
+for t in "${EXPECTED_PLAYWRIGHT_TOOLS[@]}"; do
+  assert_eq "tools list contains $t" "true" \
+    "$([ "${TOOLS_SET[$t]:-}" = "1" ] && echo true || echo false)"
+done
+
+# Bash + Read + Write must also be there or the subagent can't run
+# scenarios at all.
+for t in Bash Read Write Glob Grep ToolSearch; do
+  assert_eq "tools list contains base tool $t" "true" \
+    "$([ "${TOOLS_SET[$t]:-}" = "1" ] && echo true || echo false)"
+done
+
+# ── Body smoke: must include the smoke-check directive so the subagent
+#    knows to fail loud rather than fall back to curl. ──
+BODY_HAS_SMOKE_CHECK=$(grep -qE 'first turn MUST be the MCP smoke check' .claude/agents/review-functional-tester.md && echo true || echo false)
+assert_eq "body contains MCP smoke-check directive" "true" "$BODY_HAS_SMOKE_CHECK"
+
+BODY_REFERENCES_SKILL=$(grep -qE '/skills/review-functional-tester\.md' .claude/agents/review-functional-tester.md && echo true || echo false)
+assert_eq "body references the full skill file" "true" "$BODY_REFERENCES_SKILL"
+
+# Substituted env vars actually substituted (not literal $PR_NUMBER).
+NO_LITERAL_VARS=$(grep -qE '\$(PR_NUMBER|PIPELINE_DIR|MODEL_FUNCTIONAL)' .claude/agents/review-functional-tester.md && echo true || echo false)
+assert_eq "no literal '\$VAR' tokens (heredoc substituted env vars)" "false" "$NO_LITERAL_VARS"
+
+if [ "$fail" -eq 0 ]; then
+  echo
+  echo "All install-functional-tester-agent tests passed."
+  exit 0
+else
+  echo
+  echo "$fail install-functional-tester-agent test assertion(s) failed."
+  exit 1
+fi

--- a/tests/install_functional_tester_agent_test.sh
+++ b/tests/install_functional_tester_agent_test.sh
@@ -2,7 +2,7 @@
 set -uo pipefail
 
 # install_functional_tester_agent_test.sh — fixture test for the
-# `.claude/agents/review-functional-tester.md` writer.
+# `$AGENT_FILE` writer.
 #
 # Background. The first iteration of PR #31 wrote the subagent file with
 # `mcpServers:` as a YAML dict. Claude Code's subagent schema (per
@@ -41,28 +41,41 @@ assert_eq() {
   fi
 }
 
-# ── Run the helper in a sandbox cwd so we don't pollute the repo. ──
+# ── Run the helper in a sandbox HOME so we don't pollute the developer's
+#    real ~/.claude/agents/. The helper writes to $HOME/.claude/agents/
+#    (user scope, intentional — claude-code-action's restore-config.ts
+#    wipes workspace .claude/ on PR-head jobs as an RCE prevention,
+#    so project scope can't be used). ──
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 HELPER="$(pwd)/scripts/install-functional-tester-agent.sh"
+AGENT_FILE="$TMP/.claude/agents/review-functional-tester.md"
 
-# Drop CWD into a fresh dir; the helper writes relative to cwd.
-cd "$TMP"
-
+HOME="$TMP" \
 PR_NUMBER=12345 \
 MODEL_FUNCTIONAL=claude-sonnet-4-6 \
 PIPELINE_DIR=/tmp/test-pipeline \
   bash "$HELPER" >/tmp/install-out.log 2>&1 \
   || { echo "FAIL: helper exited non-zero"; cat /tmp/install-out.log; exit 1; }
 
-assert_eq "file written to .claude/agents/review-functional-tester.md" \
+assert_eq "file written to \$HOME/.claude/agents/review-functional-tester.md" \
   "true" \
-  "$([ -f .claude/agents/review-functional-tester.md ] && echo true || echo false)"
+  "$([ -f "$AGENT_FILE" ] && echo true || echo false)"
+
+# Belt-and-braces: the file must NOT also have been written to project
+# scope (./.claude/agents/) — that's the path that claude-code-action
+# wipes, and writing there would have been the bug that motivated this
+# whole PR. Run from a fresh cwd so any pre-existing project file in
+# the test runner's working directory doesn't false-positive.
+WORKDIR=$(mktemp -d)
+( cd "$WORKDIR" && [ ! -e .claude ] ) && PROJECT_SCOPE_LEAKED=false || PROJECT_SCOPE_LEAKED=true
+rm -rf "$WORKDIR"
+assert_eq "did NOT also write to project-scope ./.claude/agents/" "false" "$PROJECT_SCOPE_LEAKED"
 
 # ── YAML structure assertions via ruby+psych (always present on the
 #    Shell tests + lint runner). ──
-RUBY_OUT=$(ruby -ryaml -e '
-  text = File.read(".claude/agents/review-functional-tester.md")
+RUBY_OUT=$(AGENT_FILE="$AGENT_FILE" ruby -ryaml -e '
+  text = File.read(ENV.fetch("AGENT_FILE"))
   fm_str = text.split("---", 3)[1]
   data = YAML.safe_load(fm_str)
   puts "name=#{data["name"]}"
@@ -127,7 +140,7 @@ EXPECTED_PLAYWRIGHT_TOOLS=(
 # each token so the membership test is exact. A regex with anchors is
 # fragile around the `: ` separator and the trailing newline; iterating
 # tokens is the boring-correct version.
-TOOLS_VALUE=$(grep -E '^tools:' .claude/agents/review-functional-tester.md | sed -E 's/^tools:[[:space:]]*//')
+TOOLS_VALUE=$(grep -E '^tools:' "$AGENT_FILE" | sed -E 's/^tools:[[:space:]]*//')
 declare -A TOOLS_SET
 while IFS= read -r tok; do
   tok="$(echo "$tok" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
@@ -148,14 +161,14 @@ done
 
 # ── Body smoke: must include the smoke-check directive so the subagent
 #    knows to fail loud rather than fall back to curl. ──
-BODY_HAS_SMOKE_CHECK=$(grep -qE 'first turn MUST be the MCP smoke check' .claude/agents/review-functional-tester.md && echo true || echo false)
+BODY_HAS_SMOKE_CHECK=$(grep -qE 'first turn MUST be the MCP smoke check' $AGENT_FILE && echo true || echo false)
 assert_eq "body contains MCP smoke-check directive" "true" "$BODY_HAS_SMOKE_CHECK"
 
-BODY_REFERENCES_SKILL=$(grep -qE '/skills/review-functional-tester\.md' .claude/agents/review-functional-tester.md && echo true || echo false)
+BODY_REFERENCES_SKILL=$(grep -qE '/skills/review-functional-tester\.md' $AGENT_FILE && echo true || echo false)
 assert_eq "body references the full skill file" "true" "$BODY_REFERENCES_SKILL"
 
 # Substituted env vars actually substituted (not literal $PR_NUMBER).
-NO_LITERAL_VARS=$(grep -qE '\$(PR_NUMBER|PIPELINE_DIR|MODEL_FUNCTIONAL)' .claude/agents/review-functional-tester.md && echo true || echo false)
+NO_LITERAL_VARS=$(grep -qE '\$(PR_NUMBER|PIPELINE_DIR|MODEL_FUNCTIONAL)' $AGENT_FILE && echo true || echo false)
 assert_eq "no literal '\$VAR' tokens (heredoc substituted env vars)" "false" "$NO_LITERAL_VARS"
 
 if [ "$fail" -eq 0 ]; then


### PR DESCRIPTION
## Summary

User caught while reviewing seaters#457: across the v2 architecture (single-orchestrator + dual-judge), the functional tester subagent silently fell back to curl/psql whenever Playwright MCP wasn't available, with the failure buried as a footnote in `uncertain_observations`. UI bugs were slipping through with curl-only verification.

Smoking gun from PR #457's run artifact:
- `mcp_servers: [{name: "playwright", status: "pending"}]` in orchestrator init
- 0 `mcp__playwright__*` tool calls across 15,030 lines of orchestrator output
- `uncertain_observations[3]: "Playwright MCP tools were not available in this test context; all testing was done via curl/psql."`

## Root cause

1. **Lazy-spawn vs ToolSearch chicken-and-egg.** We passed `--mcp-config` at the orchestrator level. The stdio Playwright server lazy-spawns on first tool call. The orchestrator never calls Playwright tools (only the functional tester does). The subagent's Turn 1 used `ToolSearch select:mcp__playwright__*` to discover the deferred tool schemas — but those schemas aren't registered until the server is up, and the server doesn't start without a tool call. Stuck in `pending`.
2. **Stale claude-code-action SHA.** Pinned to b47fd72 (Claude Code 2.1.101). v2.1.132 explicitly fixed unbounded memory growth (10GB+ RSS) with stdio MCP servers — a known contributor to `pending` state.

## Fix

**Subagent-scoped MCP via `.claude/agents/review-functional-tester.md`** (workflow installs at runtime). YAML frontmatter has inline `mcpServers: { playwright: { type: stdio, command: npx, ... } }` plus the full tool list. Claude Code auto-discovers `.claude/agents/*.md` in cwd; when the orchestrator dispatches `subagent_type: "review-functional-tester"`, the subagent spawns with its own MCP server. Server connects when subagent starts, not at orchestrator init. Chicken-and-egg gone.

Orchestrator no longer carries Playwright tooling:
- Dropped `--mcp-config /tmp/mcp-playwright.json` from claude_args
- Dropped 17 `mcp__playwright__*` from `--allowedTools`
- Dropped the `/tmp/mcp-playwright.json` write (kept npx tarball pre-warm — still useful for cold runners)

**Loud-fail smoke check.** Turn 1 of the functional tester is now an UNBATCHED `mcp__playwright__browser_navigate` to about:blank. On failure, writes `overall: CRASH` with summary `"Playwright MCP unavailable — UI testing skipped"` and exits BEFORE running scenarios. Silent fallback to curl/psql is explicitly forbidden in the skill.

**Defence-in-depth verdict gate.** `FUNCTIONAL_MCP_BROKEN` in build-review.sh fires when (a) `overall=CRASH` AND summary mentions "Playwright MCP unavailable", OR (b) `strategy=functional` AND `uncertain_observations` contains historical silent-fallback strings. Either signal flips verdict to COMMENT + `requires_human_review=true` with a clear reason. 8 assertions in `tests/functional_mcp_gate_test.sh`.

**Bump claude-code-action to 9db782c** (Claude Code 2.1.132 / Agent SDK 0.2.132).

## Test plan

- [x] All 12 existing tests still green (added 1 new: `tests/functional_mcp_gate_test.sh`)
- [x] Shellcheck clean on `build-review.sh` and `generate-functional-prompt.sh`
- [ ] **End-to-end validation**: run the new pipeline against a seaters PR with UI surface (PR #457 is backend-only and won't validate the UI path); confirm:
  - MCP server connects (no `pending` in init)
  - Functional tester calls real `mcp__playwright__browser_*` tools
  - Screenshots land in `/tmp/screenshots/` and upload to review-assets
  - Screenshots embed inline-with-finding (the existing functional-findings → all-findings merge from PR #30)
  - `screenshot_count > 0` in review-result.json

## Architecture note

This is the **single-orchestrator architecture** that ships under the `v2` tag, not a "v3". `v2` is the consumer-facing release line; "single-orchestrator" / "dual-judge debate" are internal nicknames for what's at v2 right now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CI review workflow’s functional-testing execution and verdict gating; misconfiguration could cause functional runs to crash or downgrade verdicts unexpectedly, but changes are localized to the review pipeline tooling.
> 
> **Overview**
> Ensures Playwright MCP actually runs for the functional tester by **moving MCP server configuration out of the orchestrator** and into a runtime-installed `review-functional-tester` subagent definition (`$HOME/.claude/agents/review-functional-tester.md`), while keeping an `npx` pre-warm step to avoid MCP startup timeouts.
> 
> Adds a **loud-fail MCP smoke check** (Turn 1 navigate to `about:blank`) and a defence-in-depth verdict gate in `build-review.sh` that downgrades to `COMMENT` + `requires_human_review` when MCP is unavailable or the tester reports curl-only fallback (now covering both `quick` and `functional` strategies).
> 
> Updates workflow prompts/docs and bumps `anthropics/claude-code-action` to a newer Claude Code version, plus adds regression tests for the MCP gate and subagent installer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 731a41781e00ac188bdcdac3ad1728b29dfcadd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->