### PR TITLE
fix(skills): scope-bound findings to PR diff + make a11y/test-coverage project-opt-in

### DIFF
--- a/prompts/setup-review.md
+++ b/prompts/setup-review.md
@@ -127,6 +127,31 @@ Before reporting a finding that cites a library or component, confirm it exists:
 
 The "Accepted supply-chain trade-offs" line is what keeps the reviewer quiet about `@v2 + secrets: inherit`. Leave it in on every repo that uses `@v2`.
 
+### Optional: opt back into test-coverage / a11y emphasis
+
+By default, the shipped skills do **not** emit `missing-test`, `weak-test`, or `a11y-violation` findings — they're project-opt-in. This keeps reviews quiet on routine PRs (a sibling-spec convention from one project shouldn't fire false positives on another, and axe-core on every page surfaces violations on shared components the PR didn't touch). If your project genuinely wants these enforced, add a section to `bugbot.md` describing your project's convention:
+
+```markdown
+## Test-coverage convention
+
+Every non-trivial changed handler/hook/util/service in `src/api/**` or `src/services/**`
+must have a sibling spec at `<filename>.spec.ts` or `<filename>.test.ts`. PRs that
+add such files without a sibling spec should get a `missing-test` finding pointing
+at the topmost added line of the new module. Out of scope: tests, generated code,
+config files.
+
+## Accessibility focus
+
+Frontend changes that touch form labels, ARIA attributes, semantic markup, or
+keyboard handlers should run an axe-core WCAG 2.1 AA audit on the changed page.
+The functional tester picks this up via the test-plan's `a11y: true` flag — the
+test planner already sets it when the diff matches those triggers; no action
+needed here unless you want it ALWAYS on (in which case add: "Always treat the
+test plan as `a11y: true` regardless of diff").
+```
+
+Without these sections, the bot stays quiet about test/a11y — the perimeter is the diff, and the conventions are yours to declare.
+
 ## Step 4: Create .github/review-config.md
 
 Create `.github/review-config.md` with these sections. This is the most important file — it tells the review pipeline how to build, test, and validate your project.

--- a/scripts/functional-prompt.template.txt
+++ b/scripts/functional-prompt.template.txt
@@ -53,13 +53,7 @@ LAST 2 TURNS — write output:
   - /tmp/functional-findings.json — array of findings (id, title, severity, type, path, line_start, line_end, evidence, reasoning, expected, screenshot)
   - /tmp/functional-meta.json — {strategy, areas_tested, screenshots[{file, description, area}], overall, summary, uncertain_observations}
 
-ACCESSIBILITY — after testing each distinct page (once per page, not after every click), run an axe-core WCAG 2.1 AA audit via browser_evaluate:
-  async () => {
-    if (!window.axe) { const s = document.createElement('script'); s.src = 'https://cdnjs.cloudflare.com/ajax/libs/axe-core/4.10.2/axe.min.js'; document.head.appendChild(s); await new Promise((r,e)=>{s.onload=r;s.onerror=e}); }
-    const results = await axe.run(document, { runOnly: ['wcag2a','wcag2aa'] });
-    return results.violations.map(v => ({id:v.id, impact:v.impact, description:v.description, nodes:v.nodes.length, target:v.nodes.slice(0,3).map(n=>n.target.join(' > ')), help:v.helpUrl}));
-  }
-Map axe impact → finding severity: critical→major, serious→minor, moderate/minor→note. Type: a11y-violation. If axe fails to load, note it in uncertain_observations and move on.
+ACCESSIBILITY — opt-in only. SKIP THIS SECTION ENTIRELY unless test-plan.md's front-matter has `a11y: true`. The test planner sets that flag only when the diff touches a11y-relevant surface (form/label markup, ARIA, semantic elements, color contrast, keyboard handlers, focus management). For routine UI changes (copy, layout shifts, components reusing existing primitives), running axe burns turns and produces noise findings on shared components the PR didn't touch. When `a11y: true` IS set, see skills/review-functional-tester.md "Accessibility (opt-in)" section for the audit script + the rule that findings must point at files in the PR's `## Per-file diff index`.
 
 severity: critical=crash/data-loss, major=spec-mismatch/broken-flow/a11y-critical, minor=visual-glitch/a11y-serious, note=observation
 type: spec-mismatch | ui-regression | endpoint-failure | smoke-failure | a11y-violation

--- a/skills/review-functional-tester.md
+++ b/skills/review-functional-tester.md
@@ -16,7 +16,16 @@ The feature is built and running. You have a real browser (Playwright MCP), can 
 
 Read both. The plan tells you WHAT to test. The context tells you WHY (acceptance criteria, spec).
 
-## How to decide: UI, browser-fetch, or curl?
+## Scope rule (load-bearing)
+
+**Every finding's `path` MUST appear in `## Per-file diff index` of context.md.** The PR's diff is the review's perimeter — your job is to validate THIS PR's changes, not the codebase's pre-existing state.
+
+When a real-user flow surfaces a problem on a shared component or page region the PR didn't touch (e.g. an axe violation on an existing sidebar, a console error from third-party JS, a 403 on a static asset), do NOT file it as a finding. Add ONE line to `uncertain_observations` describing what you saw and move on. Two reasons:
+
+1. The author can't fix it in this PR — it's not in their diff.
+2. The same out-of-scope issue tends to recur on every functional run; filing it as a finding clutters every review with the same noise.
+
+If a finding's natural `path` would be a file you didn't change, that's the signal to drop it. Common case: axe-core returns a DOM violation on a shared component — the violation lives in the component's source file, which isn't in the diff index → drop.
 
 **Always prefer the method closest to the real user flow.**
 
@@ -210,11 +219,13 @@ Always write both files, even on partial completion.
 
 Overall: FAIL if any critical/major, WARN if any minor, PASS otherwise.
 
-## Accessibility checks
+## Accessibility checks (opt-in)
 
-A11y audits are **opt-in per plan**, not per scenario. The test planner marks the plan with `a11y: true` when the diff touches a11y-relevant surface (form labels, semantic markup, color/contrast, keyboard handlers). When the plan does not set `a11y: true`, **skip this section entirely** — running axe-core on every page burns turns without proportional signal on routine PRs.
+A11y audits are **opt-in per plan**, not per scenario. The test planner marks the plan with `a11y: true` when the diff touches a11y-relevant surface (form labels, semantic markup, color/contrast, keyboard handlers). **When the plan does not set `a11y: true`, skip this section entirely** — and that's the default for most PRs. Routine UI changes (copy, layout shifts, components that reuse existing primitives) do not need an a11y audit; running axe burns turns and surfaces violations on shared components the PR didn't touch.
 
-When a11y IS in scope, run **one** axe-core WCAG 2.1 AA audit on the **single most a11y-relevant page** (typically the page whose markup actually changed in the diff), not one per scenario. Use `browser_evaluate`:
+When a11y IS in scope, the **scope rule above still applies**: an axe violation on a shared component file the PR didn't modify → don't file. Note in `uncertain_observations` that "page X has pre-existing a11y issues at <selector>" if the observation is informative; otherwise skip silently. Only file findings whose `path` is in the diff index AND whose root cause is something the PR actually introduced or modified.
+
+Run **one** axe-core WCAG 2.1 AA audit on the **single most a11y-relevant page** (typically the page whose markup actually changed in the diff), not one per scenario. Use `browser_evaluate`:
 
 ```js
 async () => {

--- a/skills/review-judge.md
+++ b/skills/review-judge.md
@@ -7,7 +7,15 @@ description: Independent code-review judge. Reads context.md + the cited diff/sp
 
 You are one of two independent judges. Both judges read the same inputs and produce the same output schema. The orchestrator compares your output with the other judge's, and either accepts both or asks you to defend / concede in a rebuttal round.
 
-You cover the **whole review** — correctness, security, spec compliance, consistency, performance, conventions, test coverage. There is no role split. The other judge is your peer, not your opposite.
+You cover the **whole review** — correctness, security, spec compliance, consistency, performance, and conventions on the diff. Test coverage and accessibility checks are **project-opt-in** (see "Project-driven finding types" below) — do not file them by default.
+
+The other judge is your peer, not your opposite.
+
+## Scope rule (load-bearing)
+
+**Every finding's `path` MUST appear in `## Per-file diff index` of context.md.** The PR's diff is the review's perimeter. If a candidate finding's natural `path` is a file not in the diff index, drop it. A real-but-out-of-scope issue (e.g. a pre-existing bug in a sibling file) belongs on a separate PR; flagging it here clutters every review with the same noise and trains authors to dismiss findings.
+
+This applies even to consistency/sibling-pattern findings: cite the sibling for context inside `reasoning` if helpful, but the finding's `path` must be the changed file, not the sibling.
 
 ## Efficiency
 
@@ -50,15 +58,23 @@ You own the full review. Use the type that best fits the issue:
 | `security` | Auth bypass, injection, SSRF, XSS, secrets in code. |
 | `wrong-impl` | Code compiles but doesn't do what the spec says, or produces nonsensical behavior. |
 | `consistency` | Diverges from sibling-file patterns. Quote the sibling file + line. |
-| `weak-test` | SUT is mocked; assertions only check mocks; test still passes if SUT is deleted. Show how. |
-| `missing-test` | Non-trivial changed file (handler/hook/util/service/route) has no sibling spec. Verify by attempting Read of `foo.spec.*` / `foo.test.*` / `__tests__/foo.spec.*` — first Read error means UNTESTED. |
 | `performance` | N+1 in hot path, unbounded query, expensive op in loop. Identify the loop/query exactly. |
 | `design-smell` | The change introduces a pattern worse than what exists. Show the better sibling. |
 | `overcomplicated` | Unnecessarily complex when a simpler approach exists in the codebase. Show the simpler sibling. |
 
+### Project-driven finding types (opt-in)
+
+These types are NOT filed by default. They fire only when the consumer's `bugbot.md` or `.github/review-config.md` declares the convention:
+
+| Type | When to use |
+|---|---|
+| `weak-test` | SUT is mocked; assertions only check mocks; test still passes if SUT is deleted. **Only file when `bugbot.md` calls out the project's testing contract** (e.g. "every handler must have an integration test that exercises the real SUT"). |
+| `missing-test` | Non-trivial changed file has no test coverage. **Only file when `bugbot.md` declares the project's test-layout convention** (e.g. "sibling spec required next to every handler", "co-located `*.test.ts`", "`__tests__/foo.spec.*`"). Without that explicit convention, judges from different ecosystems disagree on what "missing test" means and the finding becomes noise. If the convention is absent but the change is genuinely untested in a way that worries you, mention it under `uncertain_observations` instead of as a finding. |
+| `a11y-violation` | Accessibility regression. **Only file when the test plan sets `a11y: true`** (the test planner sets that flag when the diff actually touches a11y-relevant surface). The functional tester owns most of these; judges may file one if they spot a clear a11y issue in the diff (e.g. missing `aria-label` on a new icon-only button), pointing at the changed line. |
+
 ### Out of scope for everyone
 
-Cosmetic/formatting (linter territory), speculative extensibility, docstrings on unchanged code.
+Cosmetic/formatting (linter territory), speculative extensibility, docstrings on unchanged code, pre-existing issues on files the PR didn't touch.
 
 ## Severity
 
@@ -149,7 +165,7 @@ Write a single JSON object to the path the orchestrator passed via `OUTPUT_PATH`
       "id": "j1",
       "title": "...",
       "severity": "critical|major|minor|note",
-      "type": "bug|spec-mismatch|security|wrong-impl|consistency|weak-test|missing-test|performance|design-smell|overcomplicated",
+      "type": "bug|spec-mismatch|security|wrong-impl|consistency|performance|design-smell|overcomplicated|weak-test|missing-test|a11y-violation",
       "path": "relative/file/path.ts",
       "line_start": 42,
       "line_end": 47,

--- a/skills/review-test-planner.md
+++ b/skills/review-test-planner.md
@@ -239,7 +239,7 @@ Pick the flow that exercises the code paths most affected by the change. Use jud
 - **Build/config change** → the most-trafficked authenticated page (the build is global)
 - **Trivial `quick` PR** → just hit the changed page/endpoint
 
-Pass criterion: page loads, no uncaught console errors, no 5xx on documented routes, axe-core a11y has no new criticals vs. main.
+Pass criterion: page loads, no uncaught console errors, no 5xx on documented routes. (A11y is opt-in via `a11y: true` in the plan front-matter — see the "Accessibility opt-in" section above. Do NOT include axe-core in the default smoke pass criterion; that creates noise findings on shared components the PR didn't touch.)
 
 ```markdown
 ### 1. App still works end-to-end


### PR DESCRIPTION
## Summary

User flagged that reviews surface findings unrelated to the PR's actual changes. Screenshot example: 6 a11y violations on a shared `event-sidebar` component pointing at line 1 — none of the violations were in files the PR touched.

Three leaks in shipped skills were producing this noise:

1. **`scripts/functional-prompt.template.txt`** unconditionally told the tester to run axe-core on every page — overriding the skill's own opt-in rule. Fixed: a11y is now skipped unless `test-plan.md` sets `a11y: true`.
2. **`skills/review-test-planner.md`** had `axe-core a11y has no new criticals` baked into the default smoke-pass criterion. Removed.
3. **`skills/review-judge.md`** had `missing-test` as a default finding type with one ecosystem's hardcoded sibling-spec convention. Reclassified `missing-test` / `weak-test` / `a11y-violation` as **project-opt-in** types — they fire only when the consumer's `bugbot.md` / `.github/review-config.md` declares the convention.

Plus an explicit **scope rule** at the top of both judge and functional-tester skills:

> Every finding's `path` MUST appear in `## Per-file diff index` of context.md. The PR's diff is the review's perimeter. Out-of-scope issues → one line in `uncertain_observations`, no finding.

## What does NOT change

- The `post-review.sh` "Findings outside diff hunks" body-section safety net stays (per user direction). It catches findings with imprecise line targets that still belong to changed files; with this skill change there should be far fewer to catch.
- Verdict ladder, judge debate, thread classifier — untouched.
- All 13 shell tests still pass (no script-side behaviour change — this is pure skill prompt calibration).

## How consumers opt back in

Documented in `prompts/setup-review.md` (Step 3). Add to `bugbot.md`:

```markdown
## Test-coverage convention
Every changed handler in `src/api/**` must have a sibling `<filename>.spec.ts`.
PRs adding handlers without specs should get a `missing-test` finding...

## Accessibility focus
Frontend changes touching form labels / ARIA / semantic markup / keyboard
handlers should run an axe audit on the changed page. (test planner already
sets `a11y: true` when the diff matches; this section is for "always on".)
```

Without these sections, the bot stays quiet about test/a11y. The diff is the perimeter; conventions are the consumer's to declare.

## Test plan

- [x] All 13 existing shell tests pass
- [x] No script changes — pure prompt edits
- [ ] Reviewer + Cursor + Aikido on this PR
- [ ] Validate on a real PR after merge: confirm a11y audits no longer fire on routine UI PRs unless explicitly enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes review-agent prompting and could suppress previously-reported findings (especially a11y and missing/weak tests) unless projects explicitly opt in. Behavior is limited to the review pipeline prompts, not production code.
> 
> **Overview**
> **Scopes review findings to the PR diff perimeter.** Adds a load-bearing rule to `review-judge` and `review-functional-tester` that every finding’s `path` must be in `context.md`’s `## Per-file diff index`, with out-of-scope issues going to `uncertain_observations` instead.
> 
> **Makes a11y and test-coverage findings project-opt-in.** Updates the functional tester prompt to only run axe-core when `test-plan.md` sets `a11y: true`, removes axe-core from the test planner’s default smoke pass criteria, and reclassifies `missing-test`/`weak-test`/`a11y-violation` as opt-in finding types gated by consumer-declared conventions.
> 
> **Documents how to re-enable stricter checks.** Extends `prompts/setup-review.md` with guidance for consumers to opt back into test-coverage and accessibility emphasis via `bugbot.md` conventions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 299daa714c786b23c6b389a695557becbc36dad9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->