### PR TITLE
perf(review): pin Playwright + drop deterministic build verification

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -308,65 +308,20 @@ jobs:
             echo "Pure docs PR — skipping build setup."
           fi
 
-      # Detect package manager from lockfile.
-      - name: Detect package manager
-        id: pkg
-        if: steps.code_check.outputs.needs_build == 'true'
-        shell: bash
-        run: |
-          if [ -f pnpm-lock.yaml ]; then echo "manager=pnpm" >> "$GITHUB_OUTPUT"
-          elif [ -f yarn.lock ]; then echo "manager=yarn" >> "$GITHUB_OUTPUT"
-          elif [ -f package-lock.json ]; then echo "manager=npm" >> "$GITHUB_OUTPUT"
-          else echo "manager=none" >> "$GITHUB_OUTPUT"; fi
-
-      # Node + Playwright are installed unconditionally (see below) so the
-      # review pipeline's own npx-based tooling works on any repo. pnpm
-      # stays gated on manager=='pnpm' because pnpm/action-setup@v5 fails
-      # when there's no pnpm-lock.yaml or `packageManager` field, and
-      # nothing review-side shells out to pnpm directly.
-      - name: Set up pnpm
-        if: steps.pkg.outputs.manager == 'pnpm'
-        uses: pnpm/action-setup@b307475762933b98ed359c036b0e51f26b63b74b # v5.0.0
-
-      - name: Detect Node version file
-        id: node_version
-        if: steps.code_check.outputs.needs_build == 'true'
-        shell: bash
-        run: |
-          if [ -f .node-version ]; then echo "file=.node-version" >> "$GITHUB_OUTPUT"
-          elif [ -f .nvmrc ]; then echo "file=.nvmrc" >> "$GITHUB_OUTPUT"
-          else echo "file=" >> "$GITHUB_OUTPUT"; fi
-
+      # Node is installed at the default LTS so npx-based tooling (Playwright
+      # install + @playwright/mcp pre-warm below) just works. The review
+      # pipeline does NOT install the consumer's dependencies — build / lint
+      # / typecheck verification was deterministic in earlier versions but
+      # has been dropped in favour of: (a) consumer-side CI, which already
+      # runs the same checks on every PR, and (b) the functional tester,
+      # which exercises the running app via dev-start.sh + Playwright MCP.
+      # Anything compile-shaped that the agent still wants to check is one
+      # Bash call away from the orchestrator.
       - name: Set up Node
         if: steps.code_check.outputs.needs_build == 'true'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version-file: ${{ steps.node_version.outputs.file || '' }}
-          node-version: ${{ steps.node_version.outputs.file == '' && 'lts/*' || '' }}
-          # Only enable the package-store cache when a root lockfile was
-          # detected — passing `cache: none` makes setup-node error out.
-          cache: ${{ steps.pkg.outputs.manager != 'none' && steps.pkg.outputs.manager || '' }}
-
-      # Soft-fail: degraded review is better than no review.
-      - name: Install dependencies
-        id: install
-        if: steps.code_check.outputs.needs_build == 'true' && steps.pkg.outputs.manager != 'none'
-        shell: bash
-        env:
-          PKG_MANAGER: ${{ steps.pkg.outputs.manager }}
-        run: |
-          set -euo pipefail
-          case "$PKG_MANAGER" in
-            pnpm) CMD="pnpm install --frozen-lockfile" ;;
-            yarn) CMD="yarn install --frozen-lockfile" ;;
-            npm)  CMD="npm ci" ;;
-          esac
-          if eval "$CMD"; then
-            echo "install_ok=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "install_ok=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::$PKG_MANAGER install failed — build verification will be unavailable"
-          fi
+          node-version: 'lts/*'
 
       # Cache the Playwright stack the review pipeline drives independently
       # of the consumer repo: Chromium binaries (~/.cache/ms-playwright) plus
@@ -491,16 +446,6 @@ jobs:
       #
       # All parallelism happens inside the orchestrator via the Task tool.
       # No background `claude -p` processes, no sibling stdout files.
-
-      # Write build status to a file the context-builder agent can read.
-      # This is more reliable than env vars since the agent's Bash calls
-      # always have access to filesystem but may not faithfully check env vars.
-      - name: Write build status
-        shell: bash
-        run: |
-          BUILD_OK="${{ (steps.code_check.outputs.needs_build == 'true' && steps.install.outputs.install_ok == 'true') && 'true' || 'false' }}"
-          echo "{\"build_available\": $BUILD_OK, \"needs_build\": ${{ steps.code_check.outputs.needs_build || 'false' }}}" > /tmp/build-status.json
-          echo "Build status: $(cat /tmp/build-status.json)"
 
       # Deterministic PRD detection — runs BEFORE the context-builder agent so
       # the result is available as a file the agent just reads (no bash interpretation).
@@ -886,15 +831,12 @@ jobs:
       # blocking the analyzer fan. The wait step further down reaps the PID
       # and replays captured outputs / exit code into the real $GITHUB_OUTPUT.
       #
-      # Gate fires when either (a) root deps installed cleanly, or (b) a
-      # consumer-owned dev-start.sh exists. Case (b) covers polyglot /
-      # subfolder repos (PHP + Node in apps/, monorepos with the lockfile
-      # under a workspace dir, etc.) where there is no root lockfile so the
-      # earlier `Install dependencies` step is skipped — but dev-start.sh
-      # is fully self-contained (typically Docker-based) and doesn't need
-      # anything installed on the host beyond docker/curl/bash.
+      # dev-start.sh is the consumer's contract for "bring up everything the
+      # functional tester needs" — typically Docker-based and self-contained,
+      # owning its own dependency install. Without it, no dev-env launches
+      # and the functional tester runs in skip strategy.
       - name: Pre-start dev environment (background)
-        if: steps.code_check.outputs.needs_build == 'true' && (steps.install.outputs.install_ok == 'true' || hashFiles('.github/claude-review/dev-start.sh') != '')
+        if: steps.code_check.outputs.needs_build == 'true' && hashFiles('.github/claude-review/dev-start.sh') != ''
         id: dev_env_bg
         shell: bash
         env:
@@ -996,7 +938,6 @@ jobs:
         uses: anthropics/claude-code-action@9db782c3a17ef2bfc274cd17411bc3e0a5ba1345 # Claude Code 2.1.132
         env:
           REVIEW_BOT_USER: ${{ steps.review_identity.outputs.bot_user }}
-          REVIEW_BUILD_AVAILABLE: ${{ (steps.code_check.outputs.needs_build == 'true' && steps.install.outputs.install_ok == 'true') && 'true' || 'false' }}
           PRIOR_HEAD_SHA: ${{ steps.prior_state.outputs.prior_head_sha }}
           PRIOR_STATE_AVAILABLE: ${{ steps.prior_state.outputs.available || 'false' }}
           NEEDS_BUILD: ${{ steps.code_check.outputs.needs_build || 'true' }}

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -393,7 +393,12 @@ jobs:
         if: steps.code_check.outputs.needs_build == 'true'
         shell: bash
         run: |
-          set -e
+          # set -uo pipefail (no explicit -e) per .github/review-config.md +
+          # bugbot.md — GitHub Actions' `shell: bash` already adds -eo
+          # pipefail at invocation, so the chromium install below still
+          # halts the step on failure, which is what we want for a critical
+          # binary the functional tester depends on.
+          set -uo pipefail
           mkdir -p /tmp/screenshots
           npx --yes "playwright@${PLAYWRIGHT_VERSION}" install chromium --with-deps 2>&1 | tail -5
           # Pre-fetch @playwright/mcp into the npx cache so the subagent's
@@ -401,7 +406,17 @@ jobs:
           # `node -e 'process.exit(0)'` cleanly exits the package without
           # invoking the MCP server (whose --version handling is inconsistent
           # across releases when stdin is closed).
-          npx --yes -p "@playwright/mcp@${PLAYWRIGHT_MCP_VERSION}" -- node -e 'process.exit(0)'
+          #
+          # Non-fatal: a registry hiccup or yanked MCP version only costs
+          # a one-time ~10-20s cold install when the subagent first calls
+          # an MCP tool. Surfacing as ::warning:: keeps the review running
+          # rather than failing the whole job for a cache miss — mirrors
+          # the old standalone Pre-warm step's graceful behaviour.
+          if npx --yes -p "@playwright/mcp@${PLAYWRIGHT_MCP_VERSION}" -- node -e 'process.exit(0)' >/dev/null 2>&1; then
+            echo "@playwright/mcp@${PLAYWRIGHT_MCP_VERSION} tarball cached for the subagent's spawn path."
+          else
+            echo "::warning::@playwright/mcp@${PLAYWRIGHT_MCP_VERSION} pre-warm failed — functional tester will cold-install on first call (~10-20s)."
+          fi
           echo "Playwright ${PLAYWRIGHT_VERSION} + @playwright/mcp ${PLAYWRIGHT_MCP_VERSION} ready"
 
       # Optional: GitHub App token for a custom review identity.

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -70,6 +70,17 @@ on:
         required: false
         description: "Optional. Newline-separated KEY=VALUE pairs exposed as env vars to .github/claude-review/dev-start.sh (and the legacy review-config.md bash blocks + Auth eval). Populated from the caller repo's secret of the same name via `secrets: inherit`."
 
+# Single source of truth for the Playwright stack the review pipeline runs.
+# The functional tester drives Chromium via @playwright/mcp regardless of
+# whether the consumer repo vendors Playwright at all — these pins decouple
+# the install from consumer-lockfile churn so the browser-binary cache hits
+# every run that doesn't bump them. Bump both intentionally; check
+# @playwright/mcp's CHANGELOG for the matching `playwright` peer before
+# letting them drift apart.
+env:
+  PLAYWRIGHT_VERSION: "1.59.1"
+  PLAYWRIGHT_MCP_VERSION: "0.0.75"
+
 jobs:
   review:
     name: In-Depth Review
@@ -357,62 +368,41 @@ jobs:
             echo "::warning::$PKG_MANAGER install failed — build verification will be unavailable"
           fi
 
-      # Cache Playwright browser binaries across PRs in the same consumer
-      # repo. setup-node already caches the package store via its `cache:`
-      # parameter; this is purely for ~/.cache/ms-playwright so we don't
-      # re-download chromium every run. Key on lock-file hash so a PR that
-      # bumps @playwright/test invalidates the cache.
-      #
-      # Split into restore + save (instead of the unified `actions/cache`)
-      # so the post-step doesn't re-evaluate `hashFiles(...)`. The unified
-      # action's post step recomputes the key, and `hashFiles()` fails when
-      # the workspace has been cleaned by an earlier post step in the same
-      # job — surfacing as a noisy red `Post Cache Playwright browsers`:
-      # "Fail to hash files under directory '/home/runner/work/<repo>'".
-      # The split form captures the primary key once at restore time and
-      # reuses it on save, so post-step hashFiles is never called.
-      - name: Cache Playwright browsers (restore)
+      # Cache the Playwright stack the review pipeline drives independently
+      # of the consumer repo: Chromium binaries (~/.cache/ms-playwright) plus
+      # the npx tarball cache that holds the @playwright/mcp package the
+      # functional-tester subagent spawns over stdio. Keyed on the
+      # workflow-level pins, so the cache only invalidates when we
+      # deliberately bump those env vars — consumer-lockfile churn no longer
+      # touches it. The Chromium binary check inside `playwright install` and
+      # npx's tarball lookup both short-circuit on cache hit; only apt
+      # (--with-deps) still runs each time (~10-30s on ubuntu-latest, since
+      # most chromium libs are preinstalled there). mkdir for /tmp/screenshots
+      # mirrors the path the subagent's mcpServers config writes to.
+      - name: Cache Playwright assets
         id: pw_cache
         if: steps.code_check.outputs.needs_build == 'true'
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-ms-playwright-${{ hashFiles('**/package-lock.json', '**/pnpm-lock.yaml', '**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-ms-playwright-
+          path: |
+            ~/.cache/ms-playwright
+            ~/.npm/_npx
+          key: ${{ runner.os }}-pw-${{ env.PLAYWRIGHT_VERSION }}-mcp-${{ env.PLAYWRIGHT_MCP_VERSION }}
 
-      # Always install Chromium so `npx @playwright/mcp@latest` (used by the
-      # functional tester) and any consumer-side smoke test have a browser
-      # available, even when the repo has no root lockfile. If the consumer
-      # vendors @playwright/test we install via that workspace so versions
-      # line up; otherwise we fall back to a plain `npx playwright install`.
-      - name: Install Playwright browsers
+      - name: Install Playwright + MCP
         if: steps.code_check.outputs.needs_build == 'true'
         shell: bash
         run: |
-          PW_DIR=$(find . -name 'playwright.config.*' -not -path '*/node_modules/*' -not -path '*/.review-pipeline/*' -not -path '*/.review-scripts/*' -exec dirname {} \; 2>/dev/null | head -1)
-          if [ -z "$PW_DIR" ]; then
-            PW_DIR=$(find . -maxdepth 3 -name 'package.json' -not -path '*/node_modules/*' -exec grep -l '"@playwright/test"' {} \; 2>/dev/null | head -1 | xargs dirname 2>/dev/null || true)
-          fi
-          if [ -n "$PW_DIR" ] && [ -d "$PW_DIR/node_modules" ]; then
-            echo "Found Playwright workspace in $PW_DIR — installing via local @playwright/test"
-            cd "$PW_DIR" && npx playwright install chromium --with-deps 2>&1 | tail -5
-          else
-            echo "No vendored Playwright workspace found — installing chromium via npx playwright@latest"
-            npx --yes playwright@latest install chromium --with-deps 2>&1 | tail -5
-          fi
-          echo "Playwright chromium installed"
-
-      # Save the Playwright cache only on a miss (cache-hit != 'true').
-      # Reuses cache-primary-key from the restore step so post-step
-      # hashFiles is never called. `if: always()` so we still save even
-      # when a downstream step (smoke-test) fails on a fresh-cache run.
-      - name: Cache Playwright browsers (save)
-        if: always() && steps.pw_cache.outputs.cache-hit != 'true' && steps.pw_cache.outputs.cache-primary-key != ''
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ steps.pw_cache.outputs.cache-primary-key }}
+          set -e
+          mkdir -p /tmp/screenshots
+          npx --yes "playwright@${PLAYWRIGHT_VERSION}" install chromium --with-deps 2>&1 | tail -5
+          # Pre-fetch @playwright/mcp into the npx cache so the subagent's
+          # stdio spawn doesn't pay a cold install on its first MCP call.
+          # `node -e 'process.exit(0)'` cleanly exits the package without
+          # invoking the MCP server (whose --version handling is inconsistent
+          # across releases when stdin is closed).
+          npx --yes -p "@playwright/mcp@${PLAYWRIGHT_MCP_VERSION}" -- node -e 'process.exit(0)'
+          echo "Playwright ${PLAYWRIGHT_VERSION} + @playwright/mcp ${PLAYWRIGHT_MCP_VERSION} ready"
 
       # Optional: GitHub App token for a custom review identity.
       # Requires all three secrets: APP_CLIENT_ID + APP_PRIVATE_KEY + APP_SLUG.
@@ -917,39 +907,6 @@ jobs:
           disown "$PID"
           echo "$PID" > /tmp/dev-env/pid
           echo "Background dev-env launched: PID=$PID (process group leader)"
-
-      - name: Pre-warm Playwright MCP package cache
-        # Pre-warm the @playwright/mcp install before the functional-tester
-        # subagent spawns the MCP server. Without this, the first npx
-        # invocation downloads + extracts the package on the runner's hot
-        # path, and Claude Code's MCP-startup handshake can time out before
-        # tools register. Cache is per-runner so this is a once-per-cold
-        # cost (~10-20s); the failure mode it prevents (silent zero
-        # screenshots, every UI scenario untestable) is total. The MCP
-        # server itself is now defined in `.claude/agents/review-functional-tester.md`
-        # — no `--mcp-config` JSON file is written here anymore.
-        # Use `npx -p ... -- node -e 'process.exit(0)'` rather than
-        # `--version`. The MCP server is a long-running stdio process
-        # whose `--version` handling is inconsistent across releases
-        # (some return 1 when stdin is closed). The `-p <pkg> -- node -e 'true'`
-        # form triggers npx's tarball-cache download path without ever
-        # invoking the server itself.
-        shell: bash
-        run: |
-          # Force --output-dir so screenshots land in a known location.
-          # Without this, Playwright MCP defaults to os.tmpdir()/playwright-mcp-output/<sessionId>/...
-          # which our upload step never finds.
-          mkdir -p /tmp/screenshots
-          if command -v npx >/dev/null 2>&1; then
-            echo "Pre-warming @playwright/mcp@latest..."
-            if npx --yes -p @playwright/mcp@latest -- node -e 'process.exit(0)' >/dev/null 2>&1; then
-              echo "@playwright/mcp@latest tarball cached for the subagent's spawn path."
-            else
-              echo "::notice::@playwright/mcp@latest pre-warm did not succeed; functional tester will install on first call (cold start ~10-20s)."
-            fi
-          else
-            echo "npx not on PATH — skipping Playwright MCP pre-warm (no functional run expected)."
-          fi
 
       # Single top-level Claude Code agent. The orchestrator skill drives:
       #   Phase 0   — Task-dispatches the context-builder subagent, which writes

--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ If you have a polished config for a stack not covered here (e.g. Python/FastAPI,
 
 The pipeline consists of:
 
-- **Reusable workflow** (`.github/workflows/pr-review.yml`) — dev-env setup, Playwright MCP package pre-warm, functional-tester subagent installation (`.claude/agents/review-functional-tester.md`), the single `claude-code-action` invocation, post-processing, review posting
+- **Reusable workflow** (`.github/workflows/pr-review.yml`) — dev-env setup, pinned Playwright + @playwright/mcp install (cached, decoupled from the consumer repo), functional-tester subagent installation (`.claude/agents/review-functional-tester.md`), the single `claude-code-action` invocation, post-processing, review posting
 - **6 skill files** (`skills/`) — prompt templates defining review methodology:
   - `review-orchestrator` — the single top-level Claude Code agent; dispatches the context builder, judges, thread classifier, and functional tester via the `Task` tool, runs the debate, writes the final findings + meta
   - `review-context-builder` — Task subagent; gathers PR metadata, diff index, spec sources, and a 5-sentence diff summary into `context.md`

--- a/scripts/build-review.sh
+++ b/scripts/build-review.sh
@@ -69,7 +69,7 @@ echo "::group::Build review"
 #   /tmp/review-meta.json  — verdict, verdict_summary, manual_spec_present,
 #                            spec_compliance, requires_human_review,
 #                            uncertain_observations, prompt_injection_detected,
-#                            build_unavailable, spec_sources, judge_health.
+#                            spec_sources, judge_health.
 #
 # Both files are required. If either is missing or malformed, the orchestrator
 # either crashed mid-run or hit a quota wall before writing its STOP-anchor
@@ -763,7 +763,6 @@ jq -n \
     uncertain_observations: (($meta.uncertain_observations // []) + ($functional_meta.uncertain_observations // [])),
     prompt_injection_detected: ($meta.prompt_injection_detected // false),
     reviewer_self_modification: ($meta.reviewer_self_modification // false),
-    build_unavailable: ($meta.build_unavailable // false),
     functional_validation: {
       strategy: ($functional_meta.strategy // "skip"),
       overall: ($functional_meta.overall // "N/A"),
@@ -837,10 +836,6 @@ EXTERNAL=$(jq -r '.spec_sources.external_issue // empty' review-result.json)
   fi
   if [ "$(jq -r '.requires_human_review' review-result.json)" = "true" ]; then
     echo "> :stop_sign: **Human review required** — $(jq -r '.requires_human_review_reason // ""' review-result.json)"
-    echo ""
-  fi
-  if [ "$(jq -r '.build_unavailable' review-result.json)" = "true" ]; then
-    echo "> :gear: Build verification unavailable."
     echo ""
   fi
   # Surface judge-debate health in the body so a reader can see at a glance

--- a/scripts/build-review.sh
+++ b/scripts/build-review.sh
@@ -523,7 +523,7 @@ FUNCTIONAL_MCP_BROKEN=false
 FUNCTIONAL_MCP_BROKEN_REASON=""
 if [ "$FUNCTIONAL_OVERALL" = "CRASH" ] && echo "$FUNCTIONAL_META" | jq -e '(.summary // "") | test("Playwright MCP unavailable"; "i")' >/dev/null 2>&1; then
   FUNCTIONAL_MCP_BROKEN=true
-  FUNCTIONAL_MCP_BROKEN_REASON="Playwright MCP smoke check failed — UI scenarios were not exercised. The .claude/agents/review-functional-tester.md subagent's inline mcpServers definition could not start the @playwright/mcp@latest stdio server. Check the runner has network + npx access; check the 'Pre-warm Playwright MCP package cache' step output."
+  FUNCTIONAL_MCP_BROKEN_REASON="Playwright MCP smoke check failed — UI scenarios were not exercised. The .claude/agents/review-functional-tester.md subagent's inline mcpServers definition could not start the @playwright/mcp stdio server. Check the runner has network + npx access; check the 'Install Playwright + MCP' workflow step output."
 elif { [ "$FUNCTIONAL_STRATEGY" = "functional" ] || [ "$FUNCTIONAL_STRATEGY" = "quick" ]; } \
      && echo "$FUNCTIONAL_META" | jq -e '[(.uncertain_observations // [])[] | select(test("Playwright MCP.*not.*avail|MCP.*unavailable|fall.*back to curl|all testing was done via curl"; "i"))] | length > 0' >/dev/null 2>&1; then
   # Both `functional` and `quick` strategies dispatch the Playwright-bound

--- a/scripts/install-functional-tester-agent.sh
+++ b/scripts/install-functional-tester-agent.sh
@@ -63,6 +63,12 @@ set -uo pipefail
 : "${PIPELINE_DIR:?PIPELINE_DIR must be set}"
 : "${HOME:?HOME must be set}"
 
+# Pinned by the workflow's top-level env so the subagent spawns the same
+# @playwright/mcp version that the install step pre-fetched into the npx
+# cache. Defaults to "latest" when the env var isn't set (e.g. local
+# manual runs of this helper) so the script stays usable in isolation.
+PLAYWRIGHT_MCP_VERSION="${PLAYWRIGHT_MCP_VERSION:-latest}"
+
 AGENT_DIR="$HOME/.claude/agents"
 AGENT_FILE="$AGENT_DIR/review-functional-tester.md"
 
@@ -78,7 +84,7 @@ mcpServers:
   - playwright:
       type: stdio
       command: npx
-      args: ["--yes", "@playwright/mcp@latest", "--headless", "--output-dir", "/tmp/screenshots"]
+      args: ["--yes", "@playwright/mcp@${PLAYWRIGHT_MCP_VERSION}", "--headless", "--output-dir", "/tmp/screenshots"]
 ---
 
 Read ${PIPELINE_DIR}/skills/review-functional-tester.md and follow it exactly. The orchestrator spawned you for PR ${PR_NUMBER}. test-plan.md and context.md are at the repo root. Your first turn MUST be the MCP smoke check described in the skill — do not silently fall back to curl/psql when MCP is unavailable.

--- a/scripts/report-usage.sh
+++ b/scripts/report-usage.sh
@@ -101,7 +101,6 @@ jq -n \
       posting_error: ($r.posting_error // null),
       requires_human_review: ($r.requires_human_review // false),
       technical_change: ($r.technical_change // false),
-      build_unavailable: ($r.build_unavailable // false),
       functional_strategy: ($r.functional_validation.strategy // $f.strategy // null),
       functional_overall:  ($r.functional_validation.overall  // $f.overall  // null),
       screenshot_count:    ($r.functional_validation.screenshot_count

--- a/scripts/verdict-gate.sh
+++ b/scripts/verdict-gate.sh
@@ -118,7 +118,6 @@ FINDING_COUNT=$(jq '(.findings // []) | length' review-result.json)
 POSTING_ERROR=$(jq -r '.posting_error // empty' review-result.json)
 HUMAN_REVIEW=$(jq -r '.requires_human_review // false' review-result.json)
 HUMAN_REASON=$(jq -r '.requires_human_review_reason // empty' review-result.json)
-BUILD_UNAVAILABLE=$(jq -r '.build_unavailable // false' review-result.json)
 MANUAL_SPEC=$(jq -r 'if (type == "object" and has("manual_spec_present")) then .manual_spec_present else true end' review-result.json)
 TECHNICAL_CHANGE=$(jq -r 'if (type == "object" and has("technical_change")) then .technical_change else false end' review-result.json)
 # Read smoke_ok directly — it captures both the FUNCTIONAL_OK crash flag and
@@ -151,10 +150,6 @@ FUNCTIONAL_OVERALL=$(jq -r '.functional_validation.overall // "N/A"' review-resu
   if [ "$TECHNICAL_CHANGE" = "true" ] && [ "$SMOKE_OK" = "false" ]; then
     echo ""
     echo "> :no_entry: **Technical change — APPROVE withheld until smoke-tested** (overall=\`$FUNCTIONAL_OVERALL\`). Refactors/upgrades have no acceptance criteria, so a passing smoke run is required. Configure \`.github/claude-review/dev-start.sh\` to bring up the app, or fix the issues that caused the smoke run to fail."
-  fi
-  if [ "$BUILD_UNAVAILABLE" = "true" ]; then
-    echo ""
-    echo "> :gear: **Build verification unavailable** — dependency install failed; findings are inferred from source reading without typecheck/lint corroboration."
   fi
   # Functional validation summary
   FN_STRATEGY=$(jq -r '.functional_validation.strategy // "skip"' review-result.json)

--- a/skills/review-context-builder.md
+++ b/skills/review-context-builder.md
@@ -111,7 +111,7 @@ jq --arg bot "$BOT_USER" '[.[] | select(.user.type == "Bot" and .user.login != $
 
 # Human / non-bot replies on OUR prior comments. If a maintainer replied
 # "false positive" or added context, the reviewers need to see it so they
-# don't re-flag the same thing. Keyed by the parent_id so Turn 7 can attach
+# don't re-flag the same thing. Keyed by the parent_id so Turn 4 can attach
 # them to the right finding in context.md.
 jq --arg bot "$BOT_USER" '
   ([.[] | select(.user.login == $bot and .in_reply_to_id == null) | .id]) as $ours |
@@ -244,20 +244,7 @@ That's it. No changed files. No `/tmp/pr.diff`. No `/tmp/diff-chunks/*.diff`. Re
 
 Skim `.github/review-config.md` content from Turn 2. Note which convention/rule files apply to the changed paths — but do NOT Read those files. Just list their paths in context.md so reviewers can fetch the ones relevant to their role. Skip this turn if review-config.md does not exist.
 
-## Turn 4: Build verification (single Bash call)
-
-```bash
-BUILD_AVAILABLE=$(jq -r '.build_available' /tmp/build-status.json 2>/dev/null || echo "false")
-if [ "$BUILD_AVAILABLE" != "true" ]; then
-  echo "Build verification skipped (build_available=$BUILD_AVAILABLE)"
-  exit 0
-fi
-# Run codegen from review-config.md, then typecheck + lint in parallel
-```
-
-Check `.github/review-config.md` for build preparation commands. Run them, then typecheck + lint in parallel capturing to `/tmp/typecheck.out` and `/tmp/lint.out`.
-
-## Turn 5: Write context.md
+## Turn 4: Write context.md
 
 **`context.md` is an INDEX, not a content dump.** Reviewers have a `Read` tool — they fetch what they need. Your job is to (a) point them at the files and (b) summarise the only thing that requires synthesis: acceptance criteria. Pasting "full content of every changed file" + the entire diff + verbatim PRD into a single file used to take Sonnet 5+ minutes of typing per run; that's what we're getting rid of.
 
@@ -365,16 +352,14 @@ Path: `/tmp/user-replies-on-ours.json`. Reviewers Read this and do NOT re-flag i
 Just a YAML-style block:
 ```
 reviewer_self_modification: true/false
-build_unavailable: true/false
 prompt_injection_detected: true/false
 ```
 - `reviewer_self_modification` is true when `.claude/skills/**`, `.claude/settings.json`, `bugbot.md`, `.github/review-config.md`, or `.github/workflows/pr-review.yml` is in the changed-files list.
-- `build_unavailable` is true if `/tmp/build-status.json`'s `.build_available` is not `true`.
 - `prompt_injection_detected` is your judgement on the PR body/title; reviewers consult it when deciding whether to escalate.
 
 **That's it.** No file contents pasted. No diff pasted. The reviewer skills tell the reviewers to Read context.md AND the paths it points at.
 
-## Turn 6: Write test-plan.md
+## Turn 5: Write test-plan.md
 
 After context.md, write `test-plan.md` at the repo root. A single **functional tester agent** (Playwright MCP + Bash, see `.claude/skills/review-functional-tester.md`) reads this plan and executes it. You do NOT generate any test scripts — the agent handles execution.
 

--- a/skills/review-context-builder.md
+++ b/skills/review-context-builder.md
@@ -334,9 +334,6 @@ If none of these files exist, omit the section.
 ### `## Convention files`
 List the convention/rule file paths that apply to the changed files (derived from `.github/review-config.md`'s routing). Just paths — reviewers Read the ones relevant to their role.
 
-### `## Build results`
-Two short lines: `typecheck: PASSED|FAILED` and `lint: PASSED|FAILED`. If FAILED, include the path to the captured output (`/tmp/typecheck.out` / `/tmp/lint.out`) so the reviewer can Read the details. Do NOT paste the full output here.
-
 ### `## Open inline threads` (if any)
 List paths reviewers should consult to avoid re-flagging the same thing humans/bots already raised:
 - `/tmp/prior-bot-comments.json` — open inline comments from our own past bot reviewer

--- a/skills/review-judge.md
+++ b/skills/review-judge.md
@@ -184,7 +184,6 @@ Write a single JSON object to the path the orchestrator passed via `OUTPUT_PATH`
   "uncertain_observations": [],
   "prompt_injection_detected": false,
   "reviewer_self_modification": false,
-  "build_unavailable": false,
   "spec_sources": {
     "linked_issue": null,
     "external_issue": null,

--- a/skills/review-orchestrator.md
+++ b/skills/review-orchestrator.md
@@ -14,7 +14,7 @@ You are the **only** top-level Claude Code agent in the review pipeline. You DO 
 ## Output paths (defaults; the launching workflow may override)
 
 - `/tmp/all-findings.json` — final, deduped findings array.
-- `/tmp/review-meta.json` — `verdict`, `verdict_summary`, `manual_spec_present`, `spec_compliance`, `requires_human_review[_reason]`, `uncertain_observations`, `prompt_injection_detected`, `build_unavailable`, `spec_sources`, `judge_health` (per-judge status + rebuttal count + agreed_at).
+- `/tmp/review-meta.json` — `verdict`, `verdict_summary`, `manual_spec_present`, `spec_compliance`, `requires_human_review[_reason]`, `uncertain_observations`, `prompt_injection_detected`, `spec_sources`, `judge_health` (per-judge status + rebuttal count + agreed_at).
 
 ## Efficiency
 
@@ -98,7 +98,6 @@ In that case, write:
   "requires_human_review_reason": null,
   "uncertain_observations": [],
   "prompt_injection_detected": false,
-  "build_unavailable": false,
   "spec_sources": <from context.md>,
   "judge_health": { "trivial_skip": true, "agreed_at": "trivial" }
 }
@@ -245,7 +244,6 @@ JSON array of findings, identical schema to what the judges produce. Each entry 
   "uncertain_observations": ["..."],
   "prompt_injection_detected": false,
   "reviewer_self_modification": false,
-  "build_unavailable": false,
   "spec_sources": {
     "linked_issue": null,
     "external_issue": null,
@@ -270,4 +268,4 @@ JSON array of findings, identical schema to what the judges produce. Each entry 
 - **Always write both files.** On any failure path (CB failed, both judges failed, parse errors, hitting the STOP anchor), write best-effort output: empty findings array, a defensible verdict (`COMMENT` when degraded), `judge_health` reflecting the actual state. Never silently exit without writing.
 - **Two Task calls per debate round, in one assistant response.** Single calls serialise the judges and waste wall time.
 - **No retries on a single judge.** A judge that returns no parseable output is recorded as `failed` and the run proceeds. The redundancy is the *other* judge, not retries of the same one.
-- **Trivial-skip is a verdict-relevant decision.** If you short-circuit at Phase 1, you are still responsible for `manual_spec_present`, `prompt_injection_detected`, `build_unavailable` — copy these from `context.md`'s flags, don't fabricate.
+- **Trivial-skip is a verdict-relevant decision.** If you short-circuit at Phase 1, you are still responsible for `manual_spec_present` and `prompt_injection_detected` — copy these from `context.md`'s flags, don't fabricate.

--- a/tests/install_functional_tester_agent_test.sh
+++ b/tests/install_functional_tester_agent_test.sh
@@ -191,14 +191,24 @@ assert_eq "no literal '\$VAR' tokens (heredoc substituted env vars)" "false" "$N
 # ── Default fallback: when PLAYWRIGHT_MCP_VERSION is unset (e.g. someone
 #    running the helper standalone), the script should still produce a
 #    valid mcpServers entry by defaulting to @latest. Re-invoke into a
-#    fresh sandbox without the env var and assert the default path. ──
+#    fresh sandbox without the env var and assert the default path.
+#
+#    Important: the workflow that runs this test defines PLAYWRIGHT_MCP_VERSION
+#    at job level, so its value is exported into every step's process env —
+#    including this bash sub-shell. Inline `KEY=val cmd` assignments only
+#    ADD to the env, they don't UNSET, so we need an explicit `unset` in a
+#    subshell to actually exercise the fallback path. Without this the CI
+#    run silently inherits the pinned version and the assertion never tests
+#    what it claims to. ──
 FALLBACK_TMP=$(mktemp -d)
-HOME="$FALLBACK_TMP" \
-PR_NUMBER=22222 \
-MODEL_FUNCTIONAL=claude-sonnet-4-6 \
-PIPELINE_DIR=/tmp/test-pipeline \
-  bash "$HELPER" >/dev/null 2>&1 \
-  || { echo "FAIL: helper (fallback path) exited non-zero"; rm -rf "$FALLBACK_TMP"; exit 1; }
+(
+  unset PLAYWRIGHT_MCP_VERSION
+  HOME="$FALLBACK_TMP" \
+  PR_NUMBER=22222 \
+  MODEL_FUNCTIONAL=claude-sonnet-4-6 \
+  PIPELINE_DIR=/tmp/test-pipeline \
+    bash "$HELPER" >/dev/null 2>&1
+) || { echo "FAIL: helper (fallback path) exited non-zero"; rm -rf "$FALLBACK_TMP"; exit 1; }
 FALLBACK_AGENT="$FALLBACK_TMP/.claude/agents/review-functional-tester.md"
 FALLBACK_HAS_LATEST=$(grep -qE '"@playwright/mcp@latest"' "$FALLBACK_AGENT" && echo true || echo false)
 rm -rf "$FALLBACK_TMP"

--- a/tests/install_functional_tester_agent_test.sh
+++ b/tests/install_functional_tester_agent_test.sh
@@ -55,6 +55,7 @@ HOME="$TMP" \
 PR_NUMBER=12345 \
 MODEL_FUNCTIONAL=claude-sonnet-4-6 \
 PIPELINE_DIR=/tmp/test-pipeline \
+PLAYWRIGHT_MCP_VERSION=0.0.99-test \
   bash "$HELPER" >/tmp/install-out.log 2>&1 \
   || { echo "FAIL: helper exited non-zero"; cat /tmp/install-out.log; exit 1; }
 
@@ -128,8 +129,8 @@ assert_eq "playwright.args includes --headless" "true" \
   "$(echo "$ARGS" | grep -qE '"--headless"' && echo true || echo false)"
 assert_eq "playwright.args includes --output-dir /tmp/screenshots" "true" \
   "$(echo "$ARGS" | grep -qE '"--output-dir".*"/tmp/screenshots"' && echo true || echo false)"
-assert_eq "playwright.args includes @playwright/mcp@latest" "true" \
-  "$(echo "$ARGS" | grep -qE '"@playwright/mcp@latest"' && echo true || echo false)"
+assert_eq "playwright.args includes pinned @playwright/mcp@<PLAYWRIGHT_MCP_VERSION>" "true" \
+  "$(echo "$ARGS" | grep -qE '"@playwright/mcp@0\.0\.99-test"' && echo true || echo false)"
 
 # ── tools field MUST list every Playwright MCP tool the skill uses, or
 #    the subagent's tool list is incomplete and Claude Code will refuse
@@ -184,8 +185,24 @@ BODY_REFERENCES_SKILL=$(grep -qE '/skills/review-functional-tester\.md' $AGENT_F
 assert_eq "body references the full skill file" "true" "$BODY_REFERENCES_SKILL"
 
 # Substituted env vars actually substituted (not literal $PR_NUMBER).
-NO_LITERAL_VARS=$(grep -qE '\$(PR_NUMBER|PIPELINE_DIR|MODEL_FUNCTIONAL)' $AGENT_FILE && echo true || echo false)
+NO_LITERAL_VARS=$(grep -qE '\$(PR_NUMBER|PIPELINE_DIR|MODEL_FUNCTIONAL|PLAYWRIGHT_MCP_VERSION)' $AGENT_FILE && echo true || echo false)
 assert_eq "no literal '\$VAR' tokens (heredoc substituted env vars)" "false" "$NO_LITERAL_VARS"
+
+# ── Default fallback: when PLAYWRIGHT_MCP_VERSION is unset (e.g. someone
+#    running the helper standalone), the script should still produce a
+#    valid mcpServers entry by defaulting to @latest. Re-invoke into a
+#    fresh sandbox without the env var and assert the default path. ──
+FALLBACK_TMP=$(mktemp -d)
+HOME="$FALLBACK_TMP" \
+PR_NUMBER=22222 \
+MODEL_FUNCTIONAL=claude-sonnet-4-6 \
+PIPELINE_DIR=/tmp/test-pipeline \
+  bash "$HELPER" >/dev/null 2>&1 \
+  || { echo "FAIL: helper (fallback path) exited non-zero"; rm -rf "$FALLBACK_TMP"; exit 1; }
+FALLBACK_AGENT="$FALLBACK_TMP/.claude/agents/review-functional-tester.md"
+FALLBACK_HAS_LATEST=$(grep -qE '"@playwright/mcp@latest"' "$FALLBACK_AGENT" && echo true || echo false)
+rm -rf "$FALLBACK_TMP"
+assert_eq "default fallback uses @playwright/mcp@latest when env unset" "true" "$FALLBACK_HAS_LATEST"
 
 if [ "$fail" -eq 0 ]; then
   echo

--- a/tests/report_usage_test.sh
+++ b/tests/report_usage_test.sh
@@ -97,7 +97,6 @@ cat > "$WD2/review-result.json" <<'EOF'
   ],
   "technical_change": false,
   "requires_human_review": false,
-  "build_unavailable": false,
   "functional_validation": {
     "strategy": "functional",
     "overall": "PASS",


### PR DESCRIPTION
## Summary

Two coordinated simplifications, both about decoupling the review pipeline from the consumer repo:

### 1. Pin the Playwright stack (commits 1-2)

- **Decouple Playwright from the consumer repo.** The functional tester drives Chromium via `@playwright/mcp`, regardless of whether the reviewed repo uses Playwright. Drops all consumer detection (`find` for `playwright.config.*`, vendored-vs-fallback branching).
- **Single source of truth.** Workflow-level `env.PLAYWRIGHT_VERSION` (`1.59.1`) + `env.PLAYWRIGHT_MCP_VERSION` (`0.0.75`).
- **Fully cached.** Cache key is the pinned versions instead of `hashFiles('**/lockfile')`, so unrelated dep bumps no longer invalidate `~/.cache/ms-playwright`. The npx tarball cache (`~/.npm/_npx`) is in the same cache so the subagent's `@playwright/mcp` stdio spawn hits warm too.
- Subagent installer threads the pinned MCP version through; test asserts on a sentinel `0.0.99-test` so the test stays decoupled from the actual pin.

### 2. Drop deterministic build verification (commit 3)

The review pipeline used to run `npm/pnpm/yarn install` and synthesize `/tmp/build-status.json` so the context-builder skill could gate Turn 4 (typecheck + lint) on it. With `dev-start.sh` covering the end-to-end path and consumer-side CI already running compile / typecheck / lint on every PR, that deterministic verification just duplicates what's elsewhere — and it was the single biggest source of "detect → branch → install" complexity in the workflow.

Removed:
- Workflow: `Detect package manager`, `Set up pnpm`, `Detect Node version file`, `Install dependencies`, `Write build status`, `REVIEW_BUILD_AVAILABLE` env
- Meta field: `build_unavailable` plumbed through context-builder / orchestrator / judge schemas → `build-review.sh` / `verdict-gate.sh` / `report-usage.sh` and the "Build verification unavailable" notice it drove
- Skill: Turn 4 in `review-context-builder.md`; remaining turns renumbered 1-5

`Set up Node` now defaults to `lts/*`. The dev-env launcher gates purely on `.github/claude-review/dev-start.sh` existing (which is the documented contract anyway). If a finding needs typecheck/lint corroboration, the orchestrator has Bash and can run them on demand.

## Net workflow change

```
Before                           After
─────────────────                ─────────────────
Detect package manager           Set up Node (lts/*)
Set up pnpm                      Cache Playwright assets
Detect Node version file         Install Playwright + MCP
Set up Node
Install dependencies             ━━━━━━━━━━━━━━━━━
Cache Pw browsers (restore)      ↓ −89 lines across
Install Playwright browsers      8 files
Cache Pw browsers (save)
Write build status
Pre-warm Playwright MCP
```

## Test plan

- [x] All 13 `tests/*.sh` pass (build-verification removal touched `tests/report_usage_test.sh` which still passes).
- [x] `actionlint .github/workflows/pr-review.yml` — no new warnings (pre-existing SC2086/SC2001 lints unrelated to changes).
- [x] Subagent installer test asserts pinned-version substitution + unset-env fallback (with explicit `unset PLAYWRIGHT_MCP_VERSION` in subshell so the test isn't masked by the workflow-level env).
- [x] MCP pre-warm now non-fatal (graceful `::warning::` on transient npm outage, mirrors old behaviour).
- [ ] Dogfood on a real consumer PR — first run cold by design (cache key changed); subsequent runs should hit cache.
- [ ] Verify functional tester still smoke-tests `mcp__playwright__browser_navigate about:blank` cleanly with the pinned MCP version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Workflow behavior changes: dependency installation/typecheck-lint gating is removed and Playwright/MCP setup is centralized and cached, which could affect review signal and functional-test reliability if the pinned versions or cache assumptions break.
> 
> **Overview**
> **Decouples the review workflow from consumer repos’ dependency graphs** by pinning `playwright` and `@playwright/mcp` versions at the workflow level and caching both Chromium binaries and the `npx` tarball cache on those pins.
> 
> **Simplifies the pipeline by dropping deterministic build verification**: removes package-manager detection, dependency installs, build-status propagation, and all `build_unavailable` plumbing across skills/scripts; dev-env launch now gates solely on presence of `.github/claude-review/dev-start.sh`.
> 
> Updates the functional-tester subagent installer to use the pinned `PLAYWRIGHT_MCP_VERSION` (with `latest` fallback) and adjusts tests/docs plus MCP-failure messaging to reference the new install/prewarm step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 608a04575a56c45458561c2e38c1371b7ac05f40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->