### PR TITLE
fix(review): accept allowed_warning OAuth status as healthy

### DIFF
--- a/scripts/pick-oauth-token.sh
+++ b/scripts/pick-oauth-token.sh
@@ -8,9 +8,13 @@
 # that the headless `/usage` slash command does NOT expose (it returns a
 # static string with no API call). The only proactive signal available is
 # the `rate_limit_event` line emitted by `--output-format stream-json`
-# during a real call — its `rate_limit_info.status` field is "allowed"
-# when the window still has capacity, anything else when it doesn't. So
-# we issue a tiny Haiku probe per candidate, parse the event, and pick a
+# during a real call. Its `rate_limit_info.status` reports:
+#   "allowed"          — under the soft threshold; fully usable
+#   "allowed_warning"  — past the soft threshold but calls still go through
+#   "blocked"          — over the cap; subsequent calls fail
+#   anything else      — abnormal (network error, expired token, etc.)
+# Both "allowed" and "allowed_warning" mean the token can serve a review.
+# We issue a tiny Haiku probe per candidate, parse the event, and pick a
 # token that's actually usable. Pool of one skips the probe entirely.
 #
 # Inputs (env):
@@ -158,7 +162,11 @@ main() {
     RESETS[i]="$resets"
     human_resets=$(format_resets "$resets")
     printf 'token #%d %s — status=%s resetsAt=%s\n' "$i" "$fp" "$status" "$human_resets"
-    [ "$status" = "allowed" ] && ALLOWED_IDX+=("$i")
+    # Accept any "allowed*" status — the API uses "allowed_warning" once
+    # the soft threshold is crossed but calls still go through. Strict
+    # equality ("allowed") was rejecting accounts the operator could
+    # plainly see still had capacity on claude.ai/usage.
+    case "$status" in allowed|allowed_*) ALLOWED_IDX+=("$i") ;; esac
   done
   echo "::endgroup::"
 

--- a/tests/pick_oauth_token_test.sh
+++ b/tests/pick_oauth_token_test.sh
@@ -33,14 +33,19 @@ assert_contains() {
 }
 
 # Stub probe. Token content drives the simulated status:
-#   prefix "allowed-" → status=allowed (with future resetsAt)
-#   prefix "blocked-" → status=blocked
-#   prefix "warning-" → status=warning
-#   prefix "noevent-" → emit nothing → picker classifies as invalid
-#   anything else     → status=invalid (no rate_limit_event line)
+#   prefix "allowed-"         → status=allowed (with future resetsAt)
+#   prefix "allowedwarning-"  → status=allowed_warning (past soft threshold,
+#                               but calls still go through — must be treated
+#                               as healthy)
+#   prefix "blocked-"         → status=blocked
+#   prefix "warning-"         → status=warning  (NOT "allowed_warning" —
+#                               bare "warning" is treated as exhausted)
+#   prefix "noevent-"         → emit nothing → picker classifies as invalid
+#   anything else             → status=invalid (no rate_limit_event line)
 PROBE_STUB='
 case "$CLAUDE_CODE_OAUTH_TOKEN" in
   allowed-*) printf "%s\n" "{\"type\":\"rate_limit_event\",\"rate_limit_info\":{\"status\":\"allowed\",\"resetsAt\":1778065800,\"rateLimitType\":\"five_hour\"}}" ;;
+  allowedwarning-*) printf "%s\n" "{\"type\":\"rate_limit_event\",\"rate_limit_info\":{\"status\":\"allowed_warning\",\"resetsAt\":1778065800,\"rateLimitType\":\"five_hour\"}}" ;;
   blocked-*) printf "%s\n" "{\"type\":\"rate_limit_event\",\"rate_limit_info\":{\"status\":\"blocked\",\"resetsAt\":1778100000,\"rateLimitType\":\"five_hour\"}}" ;;
   warning-*) printf "%s\n" "{\"type\":\"rate_limit_event\",\"rate_limit_info\":{\"status\":\"warning\",\"resetsAt\":1778099999,\"rateLimitType\":\"five_hour\"}}" ;;
   noevent-*) printf "%s\n" "{\"type\":\"result\",\"is_error\":true}" ;;
@@ -118,7 +123,35 @@ assert_contains "Mixed pool → picks the allowed candidate" \
 assert_contains "Mixed pool → healthy_count=1" "healthy_count=1" "$RESULT"
 assert_contains "Mixed pool → pool_size=3" "pool_size=3" "$RESULT"
 
+# --- 5b. allowed_warning treated as healthy (regression: bare "allowed"
+# strict-equality used to reject these even though calls still went
+# through — the user's claude.ai/usage screenshots showed plenty of
+# headroom, but the picker exited 1). -----
+INPUT=$'allowedwarning-only'
+RESULT=$(unset CLAUDE_CODE_OAUTH_TOKEN
+  CLAUDE_CODE_OAUTH_TOKENS="$INPUT" run_picker)
+# Pool of 1 takes the fast path so the probe doesn't even fire — wrap in a
+# real pool of 2 to force the probe path and exercise the status check.
+INPUT=$'allowedwarning-1\nallowedwarning-2'
+RESULT=$(unset CLAUDE_CODE_OAUTH_TOKEN
+  CLAUDE_CODE_OAUTH_TOKENS="$INPUT" run_picker)
+assert_eq "Pool of 2 allowed_warning → exits 0" "rc=0" "$(echo "$RESULT" | grep '^rc=')"
+assert_contains "Pool of 2 allowed_warning → healthy_count=2" \
+  "healthy_count=2" "$RESULT"
+
+# Mixed: 1 allowed + 1 allowed_warning + 1 blocked → 2 healthy, picker
+# treats both allowed* statuses as eligible.
+INPUT=$'allowed-fresh\nallowedwarning-near-cap\nblocked-1'
+RESULT=$(unset CLAUDE_CODE_OAUTH_TOKEN
+  CLAUDE_CODE_OAUTH_TOKENS="$INPUT" run_picker)
+assert_eq "Mixed allowed* + blocked → exits 0" "rc=0" "$(echo "$RESULT" | grep '^rc=')"
+assert_contains "Mixed allowed* + blocked → healthy_count=2" \
+  "healthy_count=2" "$RESULT"
+
 # --- 6. All exhausted (blocked + warning + invalid) → exits 1 with table ----
+# Note: "warning" here is the bare status (NOT "allowed_warning") — that
+# value indicates an abnormal probe result, not a healthy token. Bare
+# warning, blocked, and invalid all stay exhausted.
 INPUT=$'blocked-1\nwarning-2\nnoevent-3'
 RESULT=$(unset CLAUDE_CODE_OAUTH_TOKEN
   CLAUDE_CODE_OAUTH_TOKENS="$INPUT" run_picker)


### PR DESCRIPTION
## Summary

The token picker fast-failed with `All N OAuth tokens are exhausted or invalid` on accounts that still had plenty of headroom. From the failing run:

```
token #0 7b60d2b6... — status=allowed_warning resetsAt=2026-05-11T04:00Z
token #1 f93892c5... — status=allowed_warning resetsAt=2026-05-14T06:00Z
##[error]All 2 OAuth tokens are exhausted or invalid — review cannot run.
```

Both accounts were comfortably under cap on `claude.ai/usage` (51% / 76% weekly). The Claude Code CLI's `rate_limit_event` reports `allowed_warning` once a soft threshold is crossed but calls still go through — the picker's strict `[ "$status" = "allowed" ]` was treating it as exhausted.

## Fix

Replace the strict-equality check with a `case` glob that accepts any `allowed*` prefix. `blocked` / bare `warning` / `invalid` stay rejected.

```bash
case "$status" in allowed|allowed_*) ALLOWED_IDX+=("$i") ;; esac
```

Updated the header comment to document all four statuses we've seen (`allowed`, `allowed_warning`, `blocked`, anything else).

## Test plan

- [x] Added `allowedwarning-*` stub case to `tests/pick_oauth_token_test.sh` so the helper's status-classification path is covered going forward.
- [x] New assertions: pool-of-`allowed_warning` exits 0 with `healthy_count=N`; mixed `allowed` + `allowed_warning` + `blocked` pool counts both `allowed*` as healthy.
- [x] Existing assertions still pass — bare `warning` (without the `allowed_` prefix) is still treated as exhausted.
- [x] All other Bash tests in `tests/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to token-picking logic to accept `allowed_warning`, plus added test coverage; main impact is CI token selection behavior.
> 
> **Overview**
> Fixes the OAuth token picker to treat `rate_limit_info.status` values matching `allowed*` (including `allowed_warning`) as healthy, preventing false fast-fail when tokens are still usable.
> 
> Updates documentation/comments to reflect observed rate-limit statuses and extends the bash test stub + assertions to cover `allowed_warning` pools and mixed `allowed`/`allowed_warning` scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a51a96c6a8d264c69410a94a48a5224ecbf171d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->