### PR TITLE
fix(review): grant subagent the full Playwright MCP server via wildcard

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -919,12 +919,15 @@ jobs:
           # subagent's inline mcpServers spawns the Playwright server when
           # the subagent starts. NOTE: the MCP tool *permissions* are still
           # session-level — see the `--allowedTools` list in the orchestrator
-          # step below, which must include every mcp__playwright__* tool
-          # the subagent will call. dontAsk mode evaluates permissions
-          # against the session-level allowlist, not the subagent's tools:
-          # field; without the orchestrator-level grant, the subagent's
-          # tool calls return "permission denied" even though the server
-          # is connected (caught on dogfood seaters#475 round 2).
+          # step below, which uses the bare `mcp__playwright` server-wildcard
+          # so the subagent can call ANY tool the @playwright/mcp package
+          # exposes (browser_drag, browser_handle_dialog, browser_network_*,
+          # etc.) without us having to enumerate. dontAsk mode evaluates
+          # permissions against the session-level allowlist, not the
+          # subagent's tools: field; without the orchestrator-level grant,
+          # the subagent's tool calls return "permission denied" even
+          # though the server is connected (caught on dogfood seaters#475
+          # round 2).
           bash "${CLAUDE_REVIEW_PIPELINE_DIR}/scripts/install-functional-tester-agent.sh"
 
       - name: 'Review: orchestrate'
@@ -962,7 +965,7 @@ jobs:
             --model ${{ inputs.model_standard }}
             --permission-mode dontAsk
             --setting-sources user
-            --allowedTools Bash,Read,Write,Glob,Grep,Task,ToolSearch,mcp__playwright__browser_navigate,mcp__playwright__browser_take_screenshot,mcp__playwright__browser_snapshot,mcp__playwright__browser_console_messages,mcp__playwright__browser_click,mcp__playwright__browser_fill_form,mcp__playwright__browser_wait_for,mcp__playwright__browser_close,mcp__playwright__browser_select_option,mcp__playwright__browser_press_key,mcp__playwright__browser_type,mcp__playwright__browser_hover,mcp__playwright__browser_resize,mcp__playwright__browser_tabs,mcp__playwright__browser_navigate_back,mcp__playwright__browser_evaluate
+            --allowedTools Bash,Read,Write,Glob,Grep,Task,ToolSearch,mcp__playwright
             --disallowedTools Edit,WebFetch,WebSearch
             --max-turns 100
           show_full_output: 'true'

--- a/scripts/build-review.sh
+++ b/scripts/build-review.sh
@@ -951,14 +951,18 @@ if [ "$FUNCTIONAL_OVERALL" != "N/A" ] && [ "$FUNCTIONAL_STRATEGY" != "skip" ]; t
       ' /tmp/functional-findings.json
       echo ""
     fi
-    # Screenshot gallery
+    # Screenshot gallery — render each as caption + inline image so the
+    # whole gallery is visible at a glance once the parent Functional
+    # Validation section is expanded. The previous form wrapped each shot
+    # in its own <details>, which forced the reader to expand twice (once
+    # for the section, once per screenshot) before seeing anything.
+    # Skip non-image entries up front: the functional tester sometimes
+    # records API-response JSON dumps as "screenshots" for API-only
+    # scenarios; we only render actual image files so the body never
+    # claims a screenshot exists when there is nothing to embed.
     if [ "$FUNCTIONAL_SCREENSHOT_COUNT" -gt 0 ]; then
       echo "#### Screenshots"
       echo ""
-      # Skip non-image entries up front: the functional tester sometimes
-      # records API-response JSON dumps as "screenshots" for API-only
-      # scenarios; we only render actual image files so the body never
-      # claims a screenshot exists when there is nothing to embed.
       echo "$FUNCTIONAL_META" | jq -r --argjson urls "$SCREENSHOT_URLS" \
         --arg repo "$GITHUB_REPOSITORY" --arg run "${GITHUB_RUN_ID:-}" '
         .screenshots[] |
@@ -967,7 +971,7 @@ if [ "$FUNCTIONAL_OVERALL" != "N/A" ] && [ "$FUNCTIONAL_STRATEGY" != "skip" ]; t
         ($file | split("/") | last) as $basename |
         ($urls[$basename] // null) as $url |
         if $url then
-          "<details><summary>\(.description)</summary>\n\n![\(.description)](\($url))\n\n</details>\n"
+          "**\(.description)**\n\n![\(.description)](\($url))\n"
         else
           "- **\(.description)** — *see [build artifacts](https://github.com/\($repo)/actions/runs/\($run))*\n"
         end

--- a/scripts/install-functional-tester-agent.sh
+++ b/scripts/install-functional-tester-agent.sh
@@ -79,7 +79,7 @@ cat > "$AGENT_FILE" <<EOF || { echo "::error::failed to write $AGENT_FILE"; exit
 name: review-functional-tester
 description: QA agent that validates PR functionality end-to-end with Playwright MCP. Spawned by the review orchestrator to test user flows, take targeted screenshots tied to findings, and write /tmp/functional-meta.json + /tmp/functional-findings.json.
 model: ${MODEL_FUNCTIONAL}
-tools: Bash, Read, Write, Glob, Grep, ToolSearch, mcp__playwright__browser_navigate, mcp__playwright__browser_take_screenshot, mcp__playwright__browser_snapshot, mcp__playwright__browser_console_messages, mcp__playwright__browser_click, mcp__playwright__browser_fill_form, mcp__playwright__browser_wait_for, mcp__playwright__browser_close, mcp__playwright__browser_select_option, mcp__playwright__browser_press_key, mcp__playwright__browser_type, mcp__playwright__browser_hover, mcp__playwright__browser_resize, mcp__playwright__browser_tabs, mcp__playwright__browser_navigate_back, mcp__playwright__browser_evaluate
+tools: Bash, Read, Write, Glob, Grep, ToolSearch, mcp__playwright
 mcpServers:
   - playwright:
       type: stdio

--- a/tests/install_functional_tester_agent_test.sh
+++ b/tests/install_functional_tester_agent_test.sh
@@ -20,9 +20,15 @@ set -uo pipefail
 #   - mcpServers[0] is a single-key Hash whose key is "playwright"
 #   - playwright config has type=stdio, command=npx, args includes
 #     "--headless" + "--output-dir" + "/tmp/screenshots"
-#   - tools is a comma-separated string with all 16 mcp__playwright__*
-#     tools listed (smoke check that the orchestrator dispatch will
-#     have access to the right tool space)
+#   - tools includes the bare `mcp__playwright` server-wildcard so the
+#     subagent can call any tool the @playwright/mcp package exposes
+#     (browser_drag, browser_handle_dialog, browser_network_*, run_code_unsafe,
+#     etc.) without us needing to enumerate. Earlier versions enumerated
+#     16 specific tool names; the enumeration kept silently breaking
+#     whenever @playwright/mcp added a tool the agent legitimately needed
+#     (caught on dogfood seaters round 2 — browser_drag denied with
+#     "Permission to use mcp__playwright__browser_drag has been denied
+#     because Claude Code is running in don't ask mode").
 #
 # Without this test, dict-vs-list regressions would only surface during a
 # real consumer review (when the functional tester silently falls back to
@@ -132,31 +138,12 @@ assert_eq "playwright.args includes --output-dir /tmp/screenshots" "true" \
 assert_eq "playwright.args includes pinned @playwright/mcp@<PLAYWRIGHT_MCP_VERSION>" "true" \
   "$(echo "$ARGS" | grep -qE '"@playwright/mcp@0\.0\.99-test"' && echo true || echo false)"
 
-# ── tools field MUST list every Playwright MCP tool the skill uses, or
-#    the subagent's tool list is incomplete and Claude Code will refuse
-#    those calls even with MCP connected. ──
-EXPECTED_PLAYWRIGHT_TOOLS=(
-  mcp__playwright__browser_navigate
-  mcp__playwright__browser_take_screenshot
-  mcp__playwright__browser_snapshot
-  mcp__playwright__browser_console_messages
-  mcp__playwright__browser_click
-  mcp__playwright__browser_fill_form
-  mcp__playwright__browser_wait_for
-  mcp__playwright__browser_close
-  mcp__playwright__browser_select_option
-  mcp__playwright__browser_press_key
-  mcp__playwright__browser_type
-  mcp__playwright__browser_hover
-  mcp__playwright__browser_resize
-  mcp__playwright__browser_tabs
-  mcp__playwright__browser_navigate_back
-  mcp__playwright__browser_evaluate
-)
-# Pull the comma-separated value off the `tools:` line, split, and trim
-# each token so the membership test is exact. A regex with anchors is
-# fragile around the `: ` separator and the trailing newline; iterating
-# tokens is the boring-correct version.
+# ── tools field MUST grant the subagent access to the Playwright MCP
+#    server. The bare `mcp__playwright` token is Claude Code's
+#    server-wildcard form: it allows every tool the server exposes
+#    without enumeration. Asserting on the wildcard (instead of a
+#    closed list of tool names) keeps this test useful even when
+#    @playwright/mcp adds new tools the agent legitimately needs. ──
 TOOLS_VALUE=$(grep -E '^tools:' "$AGENT_FILE" | sed -E 's/^tools:[[:space:]]*//')
 declare -A TOOLS_SET
 while IFS= read -r tok; do
@@ -164,10 +151,22 @@ while IFS= read -r tok; do
   [ -n "$tok" ] && TOOLS_SET["$tok"]=1
 done < <(echo "$TOOLS_VALUE" | tr ',' '\n')
 
-for t in "${EXPECTED_PLAYWRIGHT_TOOLS[@]}"; do
-  assert_eq "tools list contains $t" "true" \
-    "$([ "${TOOLS_SET[$t]:-}" = "1" ] && echo true || echo false)"
+assert_eq "tools list contains mcp__playwright server-wildcard" "true" \
+  "$([ "${TOOLS_SET[mcp__playwright]:-}" = "1" ] && echo true || echo false)"
+
+# Guard against accidental drift back to enumeration: if any
+# `mcp__playwright__<tool>` token shows up alongside the wildcard, the
+# enumerated tokens are dead weight and a future maintainer might trim
+# the wildcard thinking the explicit list is the real one. Reject that
+# shape so we keep a single source of truth.
+ENUMERATED_LEAK=false
+for t in "${!TOOLS_SET[@]}"; do
+  case "$t" in
+    mcp__playwright__*) ENUMERATED_LEAK=true ;;
+  esac
 done
+assert_eq "no enumerated mcp__playwright__<tool> tokens alongside wildcard" \
+  "false" "$ENUMERATED_LEAK"
 
 # Bash + Read + Write must also be there or the subagent can't run
 # scenarios at all.


### PR DESCRIPTION
## Summary

The functional tester crashed mid-run on a recent dogfood:

> Permission to use `mcp__playwright__browser_drag` has been denied because Claude Code is running in don't ask mode.

`browser_drag` wasn't in the orchestrator's enumerated `--allowedTools` list. Six legitimate-use tools were missing (`drag`, `drop`, `file_upload`, `handle_dialog`, `network_request`, `network_requests`), and the enumeration was always one `@playwright/mcp` release away from breaking again.

## Fix

Switch to Claude Code's bare-server wildcard form: `mcp__playwright` (no tool name) allows every tool the server registers, present and future.

```diff
-  --allowedTools Bash,Read,Write,Glob,Grep,Task,ToolSearch,mcp__playwright__browser_navigate,mcp__playwright__browser_take_screenshot,...,mcp__playwright__browser_evaluate
+  --allowedTools Bash,Read,Write,Glob,Grep,Task,ToolSearch,mcp__playwright
```

Same change in the subagent's `tools:` field (dontAsk mode resolves permissions against both the orchestrator-level allowlist AND the subagent's tools list, so they need to agree).

The non-Playwright disallowlist (`Edit`, `WebFetch`, `WebSearch`) stays intact. This widens Playwright access only — it does not affect what the subagent can do outside the browser.

## Why a wildcard, not "enumerate the missing six"

This is the second time the enumeration has gone stale. The functional tester legitimately needs whatever tools `@playwright/mcp` exposes; gating each one through a manual allowlist update is a maintenance leak that surfaces only mid-review when a real PR is being held up. The wildcard form is the documented "I trust this server" mechanism — the right primitive for the job.

## Drift guard

Test now asserts on the wildcard plus rejects any `mcp__playwright__<tool>` token appearing alongside it. If someone tries to re-enumerate later they'll see the wildcard sitting there as dead weight and may trim it; the guard fails the test in that case so the wildcard stays load-bearing.

## Test plan

- [x] `tests/install_functional_tester_agent_test.sh` — wildcard assertion + drift guard.
- [x] `tests/functional_mcp_gate_test.sh`, `tests/screenshot_allowlist_test.sh` — unaffected, still pass.
- [x] `actionlint .github/workflows/pr-review.yml` — clean.
- [ ] Dogfood: re-run the failed seaters PR. Expected: `browser_drag` and friends resolve without prompting; functional tester completes the scenario it was on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the CI review agent’s allowed tool scope from an enumerated list to the full `mcp__playwright` server wildcard, which could enable additional browser/MCP capabilities if misused. Changes are confined to the PR review workflow/subagent config and a rendering tweak to screenshot output.
> 
> **Overview**
> **Functional tester Playwright permissions are broadened to avoid dontAsk-mode failures.** The workflow and `review-functional-tester` subagent switch from enumerating specific `mcp__playwright__*` tools to granting the `mcp__playwright` server wildcard in both the orchestrator `--allowedTools` and the subagent `tools:` list.
> 
> **Review output is adjusted for readability.** The functional validation screenshot gallery now renders inline images with captions (and skips non-image entries) instead of nesting each screenshot in its own `<details>`.
> 
> **Tests are updated to enforce the new contract.** The installer test now asserts presence of the `mcp__playwright` wildcard and adds a drift guard that fails if any `mcp__playwright__<tool>` tokens reappear alongside it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7ea4c83a38a1ad058f98a6aa45bd9d0a8a893e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->