### PR TITLE
fix(review): don't pin verdict when round-2 falls back to full-diff scoping

### DIFF
--- a/scripts/build-review.sh
+++ b/scripts/build-review.sh
@@ -699,12 +699,22 @@ if [ "$ROUND2_VALID" = "true" ]; then
         fi
         ;;
     esac
+  elif [ ! -f /tmp/since-last.diff ]; then
+    # Shallow-clone fallback: PRIOR_HEAD_SHA was outside this clone, so
+    # the context builder couldn't produce /tmp/since-last.diff (see
+    # review-context-builder.md "Round-2 fallback"). The orchestrator
+    # correctly skipped the thread classifier per its gating, and the
+    # judges reverted to round-1 full-diff scoping. Their per-PR verdict
+    # is informed about the whole PR — pinning would punish a clean
+    # re-review just because the runner couldn't reach the prior HEAD.
+    # Trust the per-PR verdict; HAS_BLOCKING already escalates new blockers.
+    echo "::notice::Round-2 shallow-clone fallback: /tmp/since-last.diff absent (PRIOR_HEAD_SHA outside the clone). Classifier was correctly skipped; judges reviewed the full diff. Using per-PR verdict '$PER_PR_VERDICT' without pin."
   else
-    # Degraded round-2: prior state is valid but thread-resolution.json
-    # is missing or malformed (thread classifier didn't run, since-last.diff
-    # couldn't be computed, or the agent crashed). Pin VERDICT to the
-    # more-severe of (PRIOR_VERDICT, current per-PR VERDICT) — never
-    # silently downgrade REQUEST_CHANGES.
+    # Degraded round-2: since-last.diff existed so the classifier was
+    # supposed to run, but /tmp/thread-resolution.json is missing or
+    # malformed (agent crashed, timed out, schema-broke). Pin VERDICT to
+    # the more-severe of (PRIOR_VERDICT, current per-PR VERDICT) — never
+    # silently downgrade REQUEST_CHANGES on genuinely missing data.
     DEGRADED_REASON="missing"
     [ -f /tmp/thread-resolution.json ] && DEGRADED_REASON="malformed"
     VERDICT=$(verdict_max "$PRIOR_VERDICT" "$PER_PR_VERDICT")

--- a/tests/verdict_ladder_test.sh
+++ b/tests/verdict_ladder_test.sh
@@ -138,6 +138,73 @@ assert_eq "max(REQUEST_CHANGES, COMMENT)"     "REQUEST_CHANGES" "$(verdict_max R
 assert_eq "max(UNKNOWN, APPROVE)"             "REQUEST_CHANGES" "$(verdict_max UNKNOWN APPROVE)"
 assert_eq "max(empty, APPROVE)"               "REQUEST_CHANGES" "$(verdict_max '' APPROVE)"
 
+# decide_degraded <PRIOR_VERDICT> <PER_PR_VERDICT> <SINCE_LAST_EXISTS> <THREAD_RES_EXISTS>
+# Echoes "<FINAL_VERDICT>|<OVERRIDE_REASON>". Mirrors build-review.sh's
+# RESOLUTION_VALID=false branch after the shallow-clone-fallback split:
+#
+#   since-last.diff absent      → trust per-PR (judges saw full diff)
+#   since-last.diff present     → classifier was supposed to run; pin via
+#                                  verdict_max because resolution is unknown
+decide_degraded() {
+  local PRIOR_VERDICT="$1"
+  local PER_PR_VERDICT="$2"
+  local SINCE_LAST_EXISTS="$3"
+  local THREAD_RES_EXISTS="$4"
+
+  local VERDICT="$PER_PR_VERDICT"
+  local LADDER_OVERRIDE_REASON=""
+
+  if [ "$SINCE_LAST_EXISTS" = "false" ]; then
+    :  # shallow-clone fallback — no pin, no override reason
+  else
+    local DEGRADED_REASON="missing"
+    [ "$THREAD_RES_EXISTS" = "true" ] && DEGRADED_REASON="malformed"
+    VERDICT=$(verdict_max "$PRIOR_VERDICT" "$PER_PR_VERDICT")
+    if [ "$VERDICT" != "$PER_PR_VERDICT" ]; then
+      LADDER_OVERRIDE_REASON="prior verdict was $PRIOR_VERDICT and the round-2 thread-resolution was $DEGRADED_REASON; pinned to the more severe of (prior, per-PR) so we never silently downgrade"
+    fi
+  fi
+
+  echo "${VERDICT}|${LADDER_OVERRIDE_REASON}"
+}
+
+echo ""
+echo "── degraded round-2 branch split (shallow-clone vs real failure) ──"
+
+# Headline case: qiv#350 (PRIOR_HEAD_SHA outside shallow clone). Prior was
+# REQUEST_CHANGES, judges reviewed the full diff in round-1 fallback mode
+# and landed APPROVE. Old behaviour pinned to REQUEST_CHANGES; new
+# behaviour trusts the per-PR verdict.
+got=$(decide_degraded REQUEST_CHANGES APPROVE false false)
+assert_eq "shallow-clone: prior=REQUEST_CHANGES, per-PR=APPROVE → APPROVE (no pin)" "APPROVE|" "$got"
+
+# Same fallback, per-PR landed COMMENT (minor finding in the full re-review).
+got=$(decide_degraded REQUEST_CHANGES COMMENT false false)
+assert_eq "shallow-clone: prior=REQUEST_CHANGES, per-PR=COMMENT → COMMENT (no pin)" "COMMENT|" "$got"
+
+# Fallback with a benign prior: no behaviour change expected.
+got=$(decide_degraded APPROVE APPROVE false false)
+assert_eq "shallow-clone: prior=APPROVE, per-PR=APPROVE → APPROVE (no pin)" "APPROVE|" "$got"
+
+# Real degraded round-2: since-last.diff existed, classifier should have run
+# but its output is missing — pin must still fire (this is the protection
+# against the classifier crashing).
+got=$(decide_degraded REQUEST_CHANGES APPROVE true false)
+assert_eq "degraded: prior=REQUEST_CHANGES, per-PR=APPROVE, thread-res missing → REQUEST_CHANGES (pin)" \
+  "REQUEST_CHANGES|prior verdict was REQUEST_CHANGES and the round-2 thread-resolution was missing; pinned to the more severe of (prior, per-PR) so we never silently downgrade" "$got"
+
+# Real degraded with a malformed thread-resolution.json (classifier crashed
+# mid-write). Different DEGRADED_REASON in the override message.
+got=$(decide_degraded REQUEST_CHANGES APPROVE true true)
+assert_eq "degraded: prior=REQUEST_CHANGES, per-PR=APPROVE, thread-res malformed → REQUEST_CHANGES (pin)" \
+  "REQUEST_CHANGES|prior verdict was REQUEST_CHANGES and the round-2 thread-resolution was malformed; pinned to the more severe of (prior, per-PR) so we never silently downgrade" "$got"
+
+# Real degraded but prior was benign and per-PR matched it — pin is a no-op
+# and we must not capture an override reason (it'd misleadingly narrate
+# a non-existent override).
+got=$(decide_degraded APPROVE APPROVE true false)
+assert_eq "degraded: prior=APPROVE, per-PR=APPROVE → APPROVE (pin no-op, no override)" "APPROVE|" "$got"
+
 echo ""
 if [ "$fail" -eq 0 ]; then
   echo "All verdict-ladder tests passed."


### PR DESCRIPTION
## Summary

- When PRIOR_HEAD_SHA falls outside the runner's shallow clone (depth 50 — common on rebase-onto-main PRs), the context builder can't write `/tmp/since-last.diff`, the orchestrator skips the thread classifier per its gating, and the judges revert to round-1 full-diff scoping. Before this fix, `build-review.sh` interpreted the absent thread-resolution as "degraded round-2" and pinned to `max(prior, per-PR)`, producing false-positive `REQUEST_CHANGES` notices (e.g. Panenco/qiv#350 ran twice and both showed `per-PR judgement was APPROVE / COMMENT; ... round-2 thread-resolution was missing`).
- The new logic splits the `RESOLUTION_VALID=false` branch on `/tmp/since-last.diff` presence: absent → shallow-clone fallback, no pin (judges saw the whole PR); present → classifier was supposed to run but didn't deliver, pin still fires unchanged.
- `HAS_BLOCKING` continues to escalate new blockers via the per-PR ladder, so a clean-looking PR that introduces new criticals can't sneak through this branch.

## Test plan

- [x] `bash tests/verdict_ladder_test.sh` — six new cases covering shallow-clone fallback (APPROVE/COMMENT/APPROVE prior) and real degraded round-2 (missing + malformed thread-resolution, plus the no-op pin case)
- [x] `for t in tests/*.sh; do bash "$t"; done` — all 13 fixture tests still pass
- [x] `bash -n scripts/build-review.sh` — syntax check clean
- [ ] Real-PR validation: next round-2 on a PR where PRIOR_HEAD_SHA falls outside the shallow clone should no longer show the "Verdict pinned by the round-2 ladder ... thread-resolution was missing" banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the round-2 verdict ladder behavior in degraded scenarios, which can alter whether PRs get `REQUEST_CHANGES` vs `APPROVE/COMMENT` during CI reviews. Scope is small and covered by new decision-table tests, but it affects review gating outcomes.
> 
> **Overview**
> Adjusts `build-review.sh` round-2 degraded handling to **distinguish shallow-clone fallback from genuine classifier failure**. When `/tmp/since-last.diff` is missing (prior HEAD outside the shallow clone), it now trusts the judges’ per-PR verdict instead of pinning to `max(prior, current)`; when `since-last.diff` exists but `/tmp/thread-resolution.json` is missing/malformed, it continues to fail-closed by pinning.
> 
> Expands `verdict_ladder_test.sh` with a small helper (`decide_degraded`) and new fixtures to cover the new branch split (fallback vs missing/malformed classifier output) and ensure override reasons are only emitted on real overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70f0d83ff7470dc47894e280a6e9b900ceb96220. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->