### PR TITLE
fix(skills): scope round-2 since-last to PR-touched files only

### DIFF
--- a/skills/review-context-builder.md
+++ b/skills/review-context-builder.md
@@ -71,22 +71,41 @@ print(f'Split diff: {kept} reviewable chunks, {skipped} skipped ({total_lines} l
 # previous review and per-file chunks for that subset. The two debating
 # judges read `/tmp/since-last.diff` and `/tmp/since-last-chunks/` so
 # round 2 stays narrowly scoped to changes since the last review.
+#
+# The naked `git diff PRIOR..HEAD` includes any commits the author merged
+# in from the target branch (Panenco/qiv#350: a Gemini model bump from
+# `main` landed in since-last and the judges then "approved" the bump as
+# if it were the PR's own work). Scope the range to files in /tmp/pr.diff
+# (GitHub-computed PR diff, already base..head — target-merge noise is
+# already filtered there) so since-last only ever describes the PR's own
+# changes since the prior review.
 if [ -n "${PRIOR_HEAD_SHA:-}" ]; then
   if git cat-file -e "$PRIOR_HEAD_SHA" 2>/dev/null; then
-    git diff "$PRIOR_HEAD_SHA..HEAD" > /tmp/since-last.diff
+    mapfile -t PR_FILES_ARR < <(awk '/^diff --git / { sub(/^a\//,"",$3); sub(/^b\//,"",$4); print $3; print $4 }' /tmp/pr.diff | sort -u)
     mkdir -p /tmp/since-last-chunks
-    # Use git directly (one diff per file) — avoids the inline-python diff
-    # parser, which silently produced 0 chunks in some CI environments.
-    # `git diff --name-only` lists files changed in the range; we then run
-    # a focused `git diff <range> -- <path>` per file. The work is bounded
-    # by the count of changed files (typically 1-5 between consecutive
-    # review rounds), so per-file invocation is fine.
-    while IFS= read -r path; do
-      [ -z "$path" ] && continue
-      safe="${path//\//--}"
-      git diff "$PRIOR_HEAD_SHA..HEAD" -- "$path" > "/tmp/since-last-chunks/${safe}.diff"
-    done < <(git diff --name-only "$PRIOR_HEAD_SHA..HEAD")
-    echo "Round-2 since-last.diff: $(wc -l < /tmp/since-last.diff) lines, $(ls /tmp/since-last-chunks/ 2>/dev/null | wc -l) per-file chunks"
+    if [ "${#PR_FILES_ARR[@]}" -eq 0 ]; then
+      # PR has no own files vs target (rare: round triggered after a
+      # merge-only push with no author work). Empty since-last → planner
+      # picks `skip`, smoke gate inherits prior, verdict ladder pins via
+      # prior. Nothing for the judges to (re-)review.
+      : > /tmp/since-last.diff
+      echo "Round-2 since-last: PR touches no files vs target — emitting empty since-last (merge-only round)."
+    else
+      git diff "$PRIOR_HEAD_SHA..HEAD" -- "${PR_FILES_ARR[@]}" > /tmp/since-last.diff
+      # Per-file chunks for the same scoped range. `git diff --name-only`
+      # respects the same pathspec, so files touched only by a
+      # target-merge commit are filtered out here too. Drop empty chunks
+      # so the diff index doesn't list a file whose since-last diff is
+      # zero bytes (happens when an author-touched file was reverted
+      # to its prior-review state by a subsequent merge).
+      while IFS= read -r path; do
+        [ -z "$path" ] && continue
+        safe="${path//\//--}"
+        git diff "$PRIOR_HEAD_SHA..HEAD" -- "$path" > "/tmp/since-last-chunks/${safe}.diff"
+        [ -s "/tmp/since-last-chunks/${safe}.diff" ] || rm -f "/tmp/since-last-chunks/${safe}.diff"
+      done < <(git diff --name-only "$PRIOR_HEAD_SHA..HEAD" -- "${PR_FILES_ARR[@]}")
+      echo "Round-2 since-last.diff: $(wc -l < /tmp/since-last.diff) lines, $(ls /tmp/since-last-chunks/ 2>/dev/null | wc -l) per-file chunks (scoped to PR-touched files; target-merge noise filtered)."
+    fi
   else
     echo "::warning::PRIOR_HEAD_SHA=$PRIOR_HEAD_SHA not present in this clone — round-2 scope reduction unavailable, full diff will be reviewed."
   fi

--- a/tests/round2_since_last_scoping_test.sh
+++ b/tests/round2_since_last_scoping_test.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# round2_since_last_scoping_test.sh — fixture test for the PR-file
+# scoping in the round-2 since-last computation (review-context-builder).
+#
+# Scenario reproduces Panenco/qiv#350 round 3: the author merged `main`
+# into the PR branch between prior review and the new push. The target
+# merge brought in changes to files the PR doesn't touch (the Gemini
+# bump). Before the fix, `git diff PRIOR..HEAD` swept those in and the
+# judges reviewed them as if they were the PR's own work.
+#
+# This test simulates the same shape with a tiny synthetic repo:
+#   - PR branch touches app.ts
+#   - target branch independently touches unrelated.ts
+#   - author merges target into PR
+# and verifies the awk-based PR-file extraction + the resulting scoped
+# since-last only describes the PR's own files.
+
+cd "$(dirname "$0")/.."
+
+fail=0
+assert_eq() {
+  local label="$1" want="$2" got="$3"
+  if [ "$want" != "$got" ]; then
+    printf 'FAIL: %s\n  want: %q\n  got:  %q\n' "$label" "$want" "$got"
+    fail=$((fail + 1))
+  else
+    echo "OK:   $label"
+  fi
+}
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# ── Synthetic repo ──
+(
+  cd "$TMP"
+  git init -q -b main
+  git config user.email t@t.t
+  git config user.name t
+
+  echo "v1" > app.ts
+  echo "v1" > unrelated.ts
+  git add . && git commit -qm "initial"
+
+  # PR branch: author commits one round-2 edit to app.ts
+  git checkout -q -b pr
+  echo "v2-pr" > app.ts
+  git commit -qam "pr: round-1 work"
+
+  # Prior review captured this commit
+  PRIOR_HEAD=$(git rev-parse HEAD)
+  echo "$PRIOR_HEAD" > "$TMP/prior-head"
+
+  # Target branch moves on independently — touches unrelated.ts only
+  git checkout -q main
+  echo "v2-main" > unrelated.ts
+  git commit -qam "main: gemini bump (target-only)"
+
+  # Author merges target back into PR branch (the qiv#350 trigger)
+  git checkout -q pr
+  git merge -q --no-edit main
+
+  # /tmp/pr.diff simulation: GitHub's PR diff is base..head, target-merge
+  # noise already filtered. We compute it the same way `gh pr diff` does.
+  PR_BASE=$(git merge-base main HEAD)
+  git diff "$PR_BASE..HEAD" > "$TMP/pr.diff"
+)
+
+PRIOR_HEAD=$(cat "$TMP/prior-head")
+
+# ── PR_FILES extraction (mirrors the skill exactly) ──
+mapfile -t PR_FILES_ARR < <(awk '/^diff --git / { sub(/^a\//,"",$3); sub(/^b\//,"",$4); print $3; print $4 }' "$TMP/pr.diff" | sort -u)
+
+assert_eq "PR_FILES extraction: only app.ts (target-merge noise excluded)" "app.ts" "${PR_FILES_ARR[*]}"
+
+# ── since-last scoping ──
+cd "$TMP"
+
+UNSCOPED_NAMES=$(git diff --name-only "$PRIOR_HEAD..HEAD" | sort | tr '\n' ' ' | sed 's/ $//')
+assert_eq "unscoped since-last DOES include target-merge file (regression baseline)" \
+  "unrelated.ts" "$UNSCOPED_NAMES"
+
+SCOPED_NAMES=$(git diff --name-only "$PRIOR_HEAD..HEAD" -- "${PR_FILES_ARR[@]}" | sort | tr '\n' ' ' | sed 's/ $//')
+assert_eq "scoped since-last EXCLUDES target-merge file" "" "$SCOPED_NAMES"
+
+git diff "$PRIOR_HEAD..HEAD" -- "${PR_FILES_ARR[@]}" > "$TMP/since-last.diff"
+SCOPED_BYTES=$(wc -c < "$TMP/since-last.diff" | tr -d ' ')
+assert_eq "scoped since-last.diff is empty when only target-merge happened" "0" "$SCOPED_BYTES"
+
+# ── PR did real round-2 work — scoping keeps it ──
+(
+  cd "$TMP"
+  echo "v3-pr" > app.ts
+  git commit -qam "pr: round-2 work"
+)
+
+# pr.diff doesn't change (same file set), so PR_FILES_ARR stays the same.
+NEW_SCOPED_NAMES=$(git -C "$TMP" diff --name-only "$PRIOR_HEAD..HEAD" -- "${PR_FILES_ARR[@]}" | sort | tr '\n' ' ' | sed 's/ $//')
+assert_eq "scoped since-last keeps PR's own round-2 edit" "app.ts" "$NEW_SCOPED_NAMES"
+
+git -C "$TMP" diff "$PRIOR_HEAD..HEAD" -- "${PR_FILES_ARR[@]}" > "$TMP/since-last.diff"
+NEW_SCOPED_BYTES=$(wc -c < "$TMP/since-last.diff" | tr -d ' ')
+[ "$NEW_SCOPED_BYTES" -gt 0 ] \
+  && echo "OK:   scoped since-last.diff is non-empty when author edited a PR file" \
+  || { echo "FAIL: scoped since-last.diff should be non-empty"; fail=$((fail + 1)); }
+
+# ── Empty pr.diff (merge-only PR with no own files) ──
+: > "$TMP/empty-pr.diff"
+mapfile -t EMPTY_ARR < <(awk '/^diff --git / { sub(/^a\//,"",$3); sub(/^b\//,"",$4); print $3; print $4 }' "$TMP/empty-pr.diff" | sort -u)
+assert_eq "empty /tmp/pr.diff yields empty PR_FILES_ARR (no fatal)" "0" "${#EMPTY_ARR[@]}"
+
+# ── Rename: PR diff captures both `a/old` and `b/new` ──
+RENAME_DIFF=$(cat <<'EOF'
+diff --git a/old.ts b/new.ts
+similarity index 90%
+rename from old.ts
+rename to new.ts
+index 0000000..0000001
+--- a/old.ts
++++ b/new.ts
+@@ -1 +1 @@
+-foo
++bar
+EOF
+)
+echo "$RENAME_DIFF" > "$TMP/rename-pr.diff"
+mapfile -t RENAME_ARR < <(awk '/^diff --git / { sub(/^a\//,"",$3); sub(/^b\//,"",$4); print $3; print $4 }' "$TMP/rename-pr.diff" | sort -u)
+assert_eq "rename captures both old and new paths" "new.ts old.ts" "${RENAME_ARR[*]}"
+
+echo ""
+if [ "$fail" -eq 0 ]; then
+  echo "All round-2 since-last scoping tests passed."
+  exit 0
+else
+  echo "$fail round-2 since-last scoping test(s) failed."
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- On Panenco/qiv#350 round 3, the bot reviewed a Gemini model bump that was merged in from `main` and characterised it as the PR's own round-2 work. Root cause: `git diff PRIOR_HEAD_SHA..HEAD` in `skills/review-context-builder.md` sweeps in everything reachable from HEAD that wasn't in PRIOR_HEAD_SHA — including merge commits pulling target content. The judges then dutifully summarised that content as if the PR author had written it.
- Derive the PR's own file set from `/tmp/pr.diff` (GitHub's PR diff is already base..head — target-merge noise is filtered there) and use it as a pathspec for both `/tmp/since-last.diff` and the per-file chunks. Files touched only by a target-merge commit no longer leak into since-last.
- Empty-pr-diff edge case (merge-only round) emits an empty since-last and lets the existing downstream behaviour (planner `skip` → smoke inheritance → verdict pin via prior) handle the round.

## Test plan

- [x] `bash tests/round2_since_last_scoping_test.sh` — new fixture test simulates the qiv#350 shape (PR touches `app.ts`; target independently touches `unrelated.ts`; author merges target in). Asserts that unscoped diff DOES include `unrelated.ts` (regression baseline) while the new scoped diff EXCLUDES it. Also covers: PR's own round-2 edit is preserved, empty `/tmp/pr.diff` is non-fatal, renames capture both `a/old` and `b/new`.
- [x] `for t in tests/*.sh; do bash "$t"; done` — all 14 fixture tests pass (13 existing + 1 new)
- [ ] Real-PR validation: next round on a PR that merged target since the prior review should describe only the PR's own changes (or land an empty since-last if only target merges happened)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how the review pipeline computes round-2 diffs and per-file chunks; mistakes could hide relevant changes or surface the wrong files for review.
> 
> **Overview**
> Fixes round-2 review scoping so `/tmp/since-last.diff` (and per-file chunks) only includes changes to files actually touched by the PR, filtering out noise introduced by merges from the target branch.
> 
> Derives the PR file set from `/tmp/pr.diff` and uses it as a pathspec for `git diff`/`git diff --name-only`, adds explicit handling for merge-only rounds (emit an empty since-last), and drops empty per-file since-last chunks.
> 
> Adds `tests/round2_since_last_scoping_test.sh`, a fixture-style test that reproduces the target-merge regression and covers edge cases like empty PR diffs and renames.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b1a7c19e8bf89cb055f9cf8a6bbcff143a6c688. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->