### PR TITLE
fix(review): install default pnpm on runner so dev-start.sh works without corepack preamble

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -323,6 +323,19 @@ jobs:
         with:
           node-version: 'lts/*'
 
+      # Put a default pnpm on PATH so consumer dev-start.sh scripts that
+      # shell out to `pnpm install` work without a corepack preamble. The
+      # contract still expects dev-start.sh to activate the project's
+      # *pinned* version (typically via `corepack enable`, picked up from
+      # the consumer's package.json#packageManager) — this is a safety
+      # net so a missing preamble doesn't silently skip functional testing.
+      - name: Set up pnpm (default fallback)
+        if: steps.code_check.outputs.needs_build == 'true'
+        uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
+        with:
+          version: 10
+          run_install: false
+
       # Cache the Playwright stack the review pipeline drives independently
       # of the consumer repo: Chromium binaries (~/.cache/ms-playwright) plus
       # the npx tarball cache that holds the @playwright/mcp package the

--- a/README.md
+++ b/README.md
@@ -256,7 +256,10 @@ for i in $(seq 1 30); do
 done
 [ "$READY" = "true" ] || { echo "::error::Postgres never became ready in 60s"; exit 1; }
 
-# Install, codegen, migrate.
+# Install, codegen, migrate. The pipeline puts a default pnpm on PATH,
+# but pin your project's real version via `packageManager` + corepack so
+# lockfile semantics match local.
+corepack enable
 pnpm install --frozen-lockfile
 # e.g. pnpm exec prisma generate && pnpm exec prisma migrate deploy
 
@@ -280,6 +283,7 @@ Rules:
 - No `set -e` — the subshell wrapper already tolerates exit N, and `set -e` surprises you in idioms like `curl || true`.
 - Readiness loops must explicitly test the flag after the loop and `exit 1` on timeout. Silent-success loops are flagged by the reviewer.
 - Paths in `cp`/`source`/`cat` are scanned at job start; the Validate step warns if any don't exist.
+- Pin your package manager. The runner provides a default pnpm (`pnpm/action-setup` with `version: 10`) so scripts that call `pnpm` directly keep working, but it won't necessarily match your local version. For pnpm/yarn projects, set `"packageManager"` in the root `package.json` and call `corepack enable` near the top of `dev-start.sh` to activate the exact version you pinned.
 
 If the project has nothing to start (pure-docs, lib-only), do **not** create this file. Its absence is the signal for degraded mode (core + sweep reviewers run; no functional tester). An empty-but-present `dev-start.sh` will fail the step.
 

--- a/prompts/setup-review.md
+++ b/prompts/setup-review.md
@@ -228,6 +228,12 @@ if [ "$READY" != "true" ]; then
 fi
 
 # <Step 2 — install deps>
+# Activate the project-pinned package manager. The pipeline puts a default
+# pnpm on PATH so this script keeps working if you forget the preamble, but
+# you should pin your real version here — pnpm@9.x and pnpm@10.x have
+# different lockfile semantics and the fallback won't match yours.
+# Node ≥ 16.9 includes corepack; it reads package.json#packageManager.
+corepack enable
 pnpm install --frozen-lockfile
 
 # <Step 3 — migrations / codegen>
@@ -264,6 +270,7 @@ Rules:
 - **One place, not two.** If you put commands here, keep `review-config.md`'s `## Functional validation` section as prose only (see Step 4). The script is the source of truth for *how* to bring things up; the markdown is the source of truth for *what* the tester should expect.
 - **Generated code matters.** If your tests import from a generated SDK / GraphQL client / `openapi-generator` output that isn't checked in, run the generator here *before* starting the dev server — otherwise `tsc --watch` / `nest start` floods the log with TS2307 noise (or, worse, the compile never settles). valcori's `dev-start.sh` runs `pnpm run generate-sdk` before `start:dev` for exactly this reason.
 - **Test it locally.** Run `bash .github/claude-review/dev-start.sh` from a clean checkout before committing and confirm the services bind on the ports you list in `### Known service ports`. If it doesn't boot locally, it won't boot in CI — this is where circular imports, missing codegen, and misconfigured `DATABASE_URL` surface.
+- **Pin your package manager.** The runner ships a default pnpm via `pnpm/action-setup`, but it won't necessarily match what you use locally. For pnpm/yarn projects, set `"packageManager"` in the root `package.json` (e.g. `"pnpm@10.33.0"`) and call `corepack enable` near the top of `dev-start.sh` — that activates the exact version you pinned. Skipping this works *most of the time* because the fallback is recent, but lockfile-version mismatches will surface as confusing install errors.
 
 If the project has no services to start (pure-docs repo, lib-only package), do **not** create this file. Its absence triggers degraded mode (the orchestrator's two judges still run; no functional tester). An empty-but-present `dev-start.sh` will fail the step — either commit a real one or don't commit one at all.
 


### PR DESCRIPTION
## Summary

- Adds `pnpm/action-setup@v6` (SHA-pinned) at `version: 10` to `pr-review.yml`, right after `Set up Node`, so consumer `dev-start.sh` scripts that call `pnpm install` directly stop hitting command-not-found on the runner.
- Updates `README.md` and `prompts/setup-review.md` to document the new default and to clarify that consumers should still pin their exact version via `packageManager` + `corepack enable` in `dev-start.sh` — the runner default is a safety net, not a substitute for matching local lockfile semantics.

## Why

Every claude-review run on a pnpm-based consumer (e.g. Panenco/qiv PR #324) has produced this artifact:

```
/tmp/functional-meta.json:
{"strategy": "skip", "overall": "PASS",
 "summary": "Functional testing skipped — dev environment did not come up (pnpm not found in runner)."}
```

`pr-review.yml` was installing Node `lts/*` and Playwright but never pnpm; consumer `dev-start.sh` scripts that called `pnpm install --frozen-lockfile` exited 127 → orchestrator wrote `strategy: skip` → no functional tester → no screenshots → no browser-driven UI validation. The failure was silent because the meta records `overall: PASS` for legitimate skips, so the run still shows green.

This adds a runner-level fallback so the silent-skip mode is harder to trip into. Consumers that pin their own version (the recommended path) keep working because `corepack enable` overrides the fallback.

Companion change on the qiv side: https://github.com/Panenco/qiv/pull/359 (adds `corepack enable` to that repo's `dev-start.sh` so it activates `pnpm@10.33.0` instead of relying on whatever the runner happens to provide).

## Test plan

- [ ] Re-trigger claude-review on Panenco/qiv PR #324 (after PR #359 merges or against this branch via `pipeline_ref`): `/tmp/functional-meta.json` should show `strategy: functional` with `overall: PASS`/`WARN` and the review body should include a screenshot gallery.
- [ ] Trigger claude-review on a pnpm-based consumer that does NOT have `corepack enable` in its `dev-start.sh` (simulates the silent-fail case before this fix): functional tester should still run because the runner provides pnpm@10 by default.
- [ ] No regression on non-JS consumers — the new step is gated on `steps.code_check.outputs.needs_build == 'true'`, same as the surrounding Node/Playwright setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the reusable workflow’s runtime environment by installing a package manager, which could affect downstream `dev-start.sh` behavior or mask version mismatches; changes are gated to code PRs and are otherwise straightforward.
> 
> **Overview**
> Adds a **runner-level pnpm fallback** to `.github/workflows/pr-review.yml` (SHA-pinned `pnpm/action-setup`, `version: 10`, no auto-install) so consumer `.github/claude-review/dev-start.sh` scripts that call `pnpm` don’t fail with command-not-found and inadvertently skip functional testing.
> 
> Updates `README.md` and `prompts/setup-review.md` to document that consumers should still **pin and activate their exact package-manager version** via `package.json#packageManager` + `corepack enable`, with the runner pnpm serving only as a safety net.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 707aa4f0cb44599a70cbe06d9c8ef5b2215ab486. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->