### PR TITLE
fix(review): unblock pnpm + warm Playwright cache on main

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -3,7 +3,7 @@ name: Claude PR Review
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  pull_request_target:  # warms Playwright cache in main scope (no PR code is run)
+  pull_request_target:  # warms Playwright cache in main scope
   workflow_dispatch:
     inputs:
       pr_number:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -3,6 +3,7 @@ name: Claude PR Review
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  pull_request_target:  # warms Playwright cache in main scope (no PR code is run)
   workflow_dispatch:
     inputs:
       pr_number:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -3,6 +3,8 @@ name: Claude PR Review
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main]  # warms the Playwright cache on main scope
   workflow_dispatch:
     inputs:
       pr_number:
@@ -21,7 +23,7 @@ jobs:
     # Skip drafts to avoid burning review budget on in-progress work. The
     # pipeline still re-runs automatically on `ready_for_review`. Manual
     # dispatch is always allowed.
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     # This repo IS panenco/claude-review, so we call the reusable workflow
     # via its local path rather than `panenco/claude-review/.github/workflows/
     # pr-review.yml@v2`. Two reasons:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -14,7 +14,7 @@ on:
 # Cancel superseded review runs when a PR branch is repushed. Manual dispatch
 # gets a per-invocation group so it never cancels concurrent PR runs.
 concurrency:
-  group: claude-review-${{ github.event.pull_request.number || github.run_id }}
+  group: claude-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -3,8 +3,6 @@ name: Claude PR Review
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  push:
-    branches: [main]  # warms the Playwright cache on main scope
   workflow_dispatch:
     inputs:
       pr_number:
@@ -23,7 +21,7 @@ jobs:
     # Skip drafts to avoid burning review budget on in-progress work. The
     # pipeline still re-runs automatically on `ready_for_review`. Manual
     # dispatch is always allowed.
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     # This repo IS panenco/claude-review, so we call the reusable workflow
     # via its local path rather than `panenco/claude-review/.github/workflows/
     # pr-review.yml@v2`. Two reasons:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -84,7 +84,6 @@ env:
 jobs:
   review:
     name: In-Depth Review
-    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -1148,22 +1147,3 @@ jobs:
             /tmp/*-meta.invalid.json
           if-no-files-found: ignore
           retention-days: 7
-
-  warm-cache:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: 'lts/*'
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cache/ms-playwright
-            ~/.npm/_npx
-          key: ${{ runner.os }}-pw-${{ env.PLAYWRIGHT_VERSION }}-mcp-${{ env.PLAYWRIGHT_MCP_VERSION }}
-          restore-keys: |
-            ${{ runner.os }}-pw-
-      - run: |
-          npx --yes "playwright@${PLAYWRIGHT_VERSION}" install chromium --with-deps
-          npx --yes -p "@playwright/mcp@${PLAYWRIGHT_MCP_VERSION}" -- node -e 0

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1149,9 +1149,7 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-  # Runs in base-branch context (GITHUB_REF = refs/heads/main) so cache
-  # writes land in main scope — readable by every PR. No PR checkout, no
-  # PR-supplied scripts: safe to run with pull_request_target's secrets.
+  # pull_request_target writes cache to main scope. Keep this job PR-code-free.
   warm-cache:
     if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -84,6 +84,7 @@ env:
 jobs:
   review:
     name: In-Depth Review
+    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -1147,3 +1148,26 @@ jobs:
             /tmp/*-meta.invalid.json
           if-no-files-found: ignore
           retention-days: 7
+
+  # Runs in base-branch context (GITHUB_REF = refs/heads/main) so cache
+  # writes land in main scope — readable by every PR. No PR checkout, no
+  # PR-supplied scripts: safe to run with pull_request_target's secrets.
+  warm-cache:
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 'lts/*'
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/.npm/_npx
+          key: ${{ runner.os }}-pw-${{ env.PLAYWRIGHT_VERSION }}-mcp-${{ env.PLAYWRIGHT_MCP_VERSION }}
+          restore-keys: |
+            ${{ runner.os }}-pw-
+      - run: |
+          npx --yes "playwright@${PLAYWRIGHT_VERSION}" install chromium --with-deps
+          npx --yes -p "@playwright/mcp@${PLAYWRIGHT_MCP_VERSION}" -- node -e 0

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -48,7 +48,7 @@ on:
         type: number
         default: 200
       warm_cache_only:
-        description: 'When true, skip the review job and run only the Playwright cache warmer. Consumers wire this to `push: main` triggers so the Playwright stack is populated on `refs/heads/main` scope — the only scope every PR run can read. Without this, every brand-new PR pays a cold cache miss because GH Actions cache is branch-scoped and sibling PR refs are unreachable.'
+        description: 'Skip review; only run the Playwright cache warmer. Wire from `push: main` to populate the main-scoped cache that PR runs fall back to.'
         required: false
         type: boolean
         default: false
@@ -329,44 +329,18 @@ jobs:
         with:
           node-version: 'lts/*'
 
-      # Put a pnpm on PATH so consumer dev-start.sh scripts that shell out
-      # to `pnpm install` work without a corepack preamble. The contract
-      # still expects dev-start.sh to activate the project's *pinned*
-      # version (typically via `corepack enable`, picked up from
-      # package.json#packageManager) — this is a safety net so a missing
-      # preamble doesn't silently skip functional testing.
-      #
-      # pnpm/action-setup v6 refuses to run when BOTH a `version:` input
-      # AND a `packageManager` field are present (ERR_PNPM_BAD_PM_VERSION,
-      # "Multiple versions of pnpm specified"). Detect the field first
-      # and pick the right invocation:
-      #   - has packageManager → install that pinned version (no input).
-      #   - no packageManager  → install a sane default (version: 10).
-      # Consumers that don't use pnpm at all just see both steps skipped.
-      - name: Detect pnpm in package.json
-        id: pkg_mgr
+      - name: Ensure pnpm on PATH
         if: steps.code_check.outputs.needs_build == 'true'
         shell: bash
         run: |
-          set -uo pipefail
-          has_pnpm=false
-          if [ -f package.json ] && jq -e '(.packageManager // "") | startswith("pnpm@")' package.json >/dev/null 2>&1; then
-            has_pnpm=true
+          if command -v pnpm >/dev/null 2>&1; then
+            echo "pnpm already present: $(pnpm --version)"
+          elif corepack enable pnpm 2>/dev/null && command -v pnpm >/dev/null 2>&1; then
+            echo "pnpm via corepack: $(pnpm --version)"
+          else
+            npm install -g pnpm
+            echo "pnpm via npm: $(pnpm --version)"
           fi
-          echo "has_pnpm=$has_pnpm" >> "$GITHUB_OUTPUT"
-
-      - name: Set up pnpm (from packageManager)
-        if: steps.code_check.outputs.needs_build == 'true' && steps.pkg_mgr.outputs.has_pnpm == 'true'
-        uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
-        with:
-          run_install: false
-
-      - name: Set up pnpm (default fallback)
-        if: steps.code_check.outputs.needs_build == 'true' && steps.pkg_mgr.outputs.has_pnpm == 'false'
-        uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
-        with:
-          version: 10
-          run_install: false
 
       # Cache the Playwright stack the review pipeline drives independently
       # of the consumer repo: Chromium binaries (~/.cache/ms-playwright) plus
@@ -1178,17 +1152,9 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-  # Populate the Playwright cache on `refs/heads/main` scope so every PR run
-  # can fall back to it. GH Actions cache scoping: a PR run reads caches
-  # scoped to its own merge ref OR the default branch — never sibling PR
-  # refs. Before this job existed, the cache only got written from PR
-  # branches (`refs/pull/N/merge`), siloed per-PR; new PRs found nothing on
-  # their first run and either paid a ~2-3min cold install or hung entirely
-  # under `--with-deps` apt lock waits.
-  #
-  # Consumers wire this via `push: branches: [main]` + `warm_cache_only:
-  # ${{ github.event_name == 'push' }}` in their caller workflow. See
-  # README.md → 'Add the caller workflow' for the full snippet.
+  # Writes the Playwright cache on `refs/heads/main` scope so PR runs (which
+  # only see their own ref + default branch) can hit it. Consumers trigger
+  # this from `push: main` — see README.md.
   warm-cache:
     name: Warm Playwright cache
     if: ${{ inputs.warm_cache_only }}

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1152,39 +1152,16 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-  # Writes the Playwright cache on `refs/heads/main` scope so PR runs (which
-  # only see their own ref + default branch) can hit it. Consumers trigger
-  # this from `push: main` — see README.md.
   warm-cache:
-    name: Warm Playwright cache
     if: ${{ inputs.warm_cache_only }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    permissions:
-      contents: read
     steps:
-      - name: Set up Node
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 'lts/*'
-
-      - name: Cache Playwright assets
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: |
-            ~/.cache/ms-playwright
-            ~/.npm/_npx
+          path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-pw-${{ env.PLAYWRIGHT_VERSION }}-mcp-${{ env.PLAYWRIGHT_MCP_VERSION }}
-
-      - name: Install Playwright + MCP
-        shell: bash
-        run: |
-          set -uo pipefail
-          mkdir -p /tmp/screenshots
-          npx --yes "playwright@${PLAYWRIGHT_VERSION}" install chromium --with-deps 2>&1 | tail -5
-          if npx --yes -p "@playwright/mcp@${PLAYWRIGHT_MCP_VERSION}" -- node -e 'process.exit(0)' >/dev/null 2>&1; then
-            echo "@playwright/mcp@${PLAYWRIGHT_MCP_VERSION} tarball cached for the subagent's spawn path."
-          else
-            echo "::warning::@playwright/mcp@${PLAYWRIGHT_MCP_VERSION} pre-warm failed — functional tester will cold-install on first call (~10-20s)."
-          fi
-          echo "Playwright ${PLAYWRIGHT_VERSION} + @playwright/mcp ${PLAYWRIGHT_MCP_VERSION} ready"
+      - run: npx --yes "playwright@${PLAYWRIGHT_VERSION}" install chromium --with-deps

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -47,11 +47,6 @@ on:
         required: false
         type: number
         default: 200
-      warm_cache_only:
-        description: 'Skip review; only run the Playwright cache warmer. Wire from `push: main` to populate the main-scoped cache that PR runs fall back to.'
-        required: false
-        type: boolean
-        default: false
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         # No longer strictly required: callers can supply CLAUDE_CODE_OAUTH_TOKENS
@@ -89,7 +84,7 @@ env:
 jobs:
   review:
     name: In-Depth Review
-    if: ${{ !inputs.warm_cache_only }}
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -1153,7 +1148,6 @@ jobs:
           retention-days: 7
 
   warm-cache:
-    if: ${{ inputs.warm_cache_only }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -1162,6 +1156,10 @@ jobs:
           node-version: 'lts/*'
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: ~/.cache/ms-playwright
+          path: |
+            ~/.cache/ms-playwright
+            ~/.npm/_npx
           key: ${{ runner.os }}-pw-${{ env.PLAYWRIGHT_VERSION }}-mcp-${{ env.PLAYWRIGHT_MCP_VERSION }}
-      - run: npx --yes "playwright@${PLAYWRIGHT_VERSION}" install chromium --with-deps
+      - run: |
+          npx --yes "playwright@${PLAYWRIGHT_VERSION}" install chromium --with-deps
+          npx --yes -p "@playwright/mcp@${PLAYWRIGHT_MCP_VERSION}" -- node -e 0

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -47,6 +47,11 @@ on:
         required: false
         type: number
         default: 200
+      warm_cache_only:
+        description: 'When true, skip the review job and run only the Playwright cache warmer. Consumers wire this to `push: main` triggers so the Playwright stack is populated on `refs/heads/main` scope — the only scope every PR run can read. Without this, every brand-new PR pays a cold cache miss because GH Actions cache is branch-scoped and sibling PR refs are unreachable.'
+        required: false
+        type: boolean
+        default: false
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         # No longer strictly required: callers can supply CLAUDE_CODE_OAUTH_TOKENS
@@ -84,6 +89,7 @@ env:
 jobs:
   review:
     name: In-Depth Review
+    if: ${{ !inputs.warm_cache_only }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -323,14 +329,40 @@ jobs:
         with:
           node-version: 'lts/*'
 
-      # Put a default pnpm on PATH so consumer dev-start.sh scripts that
-      # shell out to `pnpm install` work without a corepack preamble. The
-      # contract still expects dev-start.sh to activate the project's
-      # *pinned* version (typically via `corepack enable`, picked up from
-      # the consumer's package.json#packageManager) — this is a safety
-      # net so a missing preamble doesn't silently skip functional testing.
-      - name: Set up pnpm (default fallback)
+      # Put a pnpm on PATH so consumer dev-start.sh scripts that shell out
+      # to `pnpm install` work without a corepack preamble. The contract
+      # still expects dev-start.sh to activate the project's *pinned*
+      # version (typically via `corepack enable`, picked up from
+      # package.json#packageManager) — this is a safety net so a missing
+      # preamble doesn't silently skip functional testing.
+      #
+      # pnpm/action-setup v6 refuses to run when BOTH a `version:` input
+      # AND a `packageManager` field are present (ERR_PNPM_BAD_PM_VERSION,
+      # "Multiple versions of pnpm specified"). Detect the field first
+      # and pick the right invocation:
+      #   - has packageManager → install that pinned version (no input).
+      #   - no packageManager  → install a sane default (version: 10).
+      # Consumers that don't use pnpm at all just see both steps skipped.
+      - name: Detect pnpm in package.json
+        id: pkg_mgr
         if: steps.code_check.outputs.needs_build == 'true'
+        shell: bash
+        run: |
+          set -uo pipefail
+          has_pnpm=false
+          if [ -f package.json ] && jq -e '(.packageManager // "") | startswith("pnpm@")' package.json >/dev/null 2>&1; then
+            has_pnpm=true
+          fi
+          echo "has_pnpm=$has_pnpm" >> "$GITHUB_OUTPUT"
+
+      - name: Set up pnpm (from packageManager)
+        if: steps.code_check.outputs.needs_build == 'true' && steps.pkg_mgr.outputs.has_pnpm == 'true'
+        uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
+        with:
+          run_install: false
+
+      - name: Set up pnpm (default fallback)
+        if: steps.code_check.outputs.needs_build == 'true' && steps.pkg_mgr.outputs.has_pnpm == 'false'
         uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
         with:
           version: 10
@@ -1145,3 +1177,48 @@ jobs:
             /tmp/*-meta.invalid.json
           if-no-files-found: ignore
           retention-days: 7
+
+  # Populate the Playwright cache on `refs/heads/main` scope so every PR run
+  # can fall back to it. GH Actions cache scoping: a PR run reads caches
+  # scoped to its own merge ref OR the default branch — never sibling PR
+  # refs. Before this job existed, the cache only got written from PR
+  # branches (`refs/pull/N/merge`), siloed per-PR; new PRs found nothing on
+  # their first run and either paid a ~2-3min cold install or hung entirely
+  # under `--with-deps` apt lock waits.
+  #
+  # Consumers wire this via `push: branches: [main]` + `warm_cache_only:
+  # ${{ github.event_name == 'push' }}` in their caller workflow. See
+  # README.md → 'Add the caller workflow' for the full snippet.
+  warm-cache:
+    name: Warm Playwright cache
+    if: ${{ inputs.warm_cache_only }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Set up Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 'lts/*'
+
+      - name: Cache Playwright assets
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/.npm/_npx
+          key: ${{ runner.os }}-pw-${{ env.PLAYWRIGHT_VERSION }}-mcp-${{ env.PLAYWRIGHT_MCP_VERSION }}
+
+      - name: Install Playwright + MCP
+        shell: bash
+        run: |
+          set -uo pipefail
+          mkdir -p /tmp/screenshots
+          npx --yes "playwright@${PLAYWRIGHT_VERSION}" install chromium --with-deps 2>&1 | tail -5
+          if npx --yes -p "@playwright/mcp@${PLAYWRIGHT_MCP_VERSION}" -- node -e 'process.exit(0)' >/dev/null 2>&1; then
+            echo "@playwright/mcp@${PLAYWRIGHT_MCP_VERSION} tarball cached for the subagent's spawn path."
+          else
+            echo "::warning::@playwright/mcp@${PLAYWRIGHT_MCP_VERSION} pre-warm failed — functional tester will cold-install on first call (~10-20s)."
+          fi
+          echo "Playwright ${PLAYWRIGHT_VERSION} + @playwright/mcp ${PLAYWRIGHT_MCP_VERSION} ready"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -357,6 +357,8 @@ jobs:
             ~/.cache/ms-playwright
             ~/.npm/_npx
           key: ${{ runner.os }}-pw-${{ env.PLAYWRIGHT_VERSION }}-mcp-${{ env.PLAYWRIGHT_MCP_VERSION }}
+          restore-keys: |
+            ${{ runner.os }}-pw-
 
       - name: Install Playwright + MCP
         if: steps.code_check.outputs.needs_build == 'true'
@@ -1160,6 +1162,8 @@ jobs:
             ~/.cache/ms-playwright
             ~/.npm/_npx
           key: ${{ runner.os }}-pw-${{ env.PLAYWRIGHT_VERSION }}-mcp-${{ env.PLAYWRIGHT_MCP_VERSION }}
+          restore-keys: |
+            ${{ runner.os }}-pw-
       - run: |
           npx --yes "playwright@${PLAYWRIGHT_VERSION}" install chromium --with-deps
           npx --yes -p "@playwright/mcp@${PLAYWRIGHT_MCP_VERSION}" -- node -e 0

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ name: Claude PR Review
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  # Push-to-main warms the Playwright cache on `refs/heads/main` scope, the
+  # only scope PR runs can read across branches. Without this, every new
+  # PR pays a cold install on its first run.
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -30,6 +35,7 @@ jobs:
                             # run's review-state artifact by run-id
     with:
       pr_number: ${{ inputs.pr_number || '' }}
+      warm_cache_only: ${{ github.event_name == 'push' }}
     secrets: inherit
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,8 @@ name: Claude PR Review
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  # Push-to-main warms the Playwright cache on `refs/heads/main` scope, the
-  # only scope PR runs can read across branches. Without this, every new
-  # PR pays a cold install on its first run.
   push:
-    branches: [main]
+    branches: [main]  # warms the Playwright cache
   workflow_dispatch:
     inputs:
       pr_number:
@@ -28,11 +25,10 @@ jobs:
   review:
     uses: panenco/claude-review/.github/workflows/pr-review.yml@v2
     permissions:
-      contents: write       # screenshots → review-assets branch
-      pull-requests: write  # post review + comments
+      contents: write
+      pull-requests: write
       issues: write
-      actions: read         # round-2 follow-up reviews look up the prior
-                            # run's review-state artifact by run-id
+      actions: read
     with:
       pr_number: ${{ inputs.pr_number || '' }}
       warm_cache_only: ${{ github.event_name == 'push' }}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ name: Claude PR Review
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  pull_request_target:  # warms Playwright cache in main scope (no PR code is run)
+  pull_request_target:  # warms Playwright cache in main scope
   workflow_dispatch:
     inputs:
       pr_number:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ name: Claude PR Review
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  pull_request_target:  # warms Playwright cache in main scope (no PR code is run)
   workflow_dispatch:
     inputs:
       pr_number:

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ name: Claude PR Review
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  push:
-    branches: [main]  # warms the Playwright cache
   workflow_dispatch:
     inputs:
       pr_number:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ jobs:
       actions: read
     with:
       pr_number: ${{ inputs.pr_number || '' }}
-      warm_cache_only: ${{ github.event_name == 'push' }}
     secrets: inherit
 ```
 

--- a/prompts/setup-review.md
+++ b/prompts/setup-review.md
@@ -36,15 +36,8 @@ name: Claude PR Review
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  # Push-to-main warms the Playwright cache on `refs/heads/main` scope, the
-  # only cache scope every PR run can read. Without this, the first run of
-  # every new PR finds nothing in cache (sibling PR refs are unreachable
-  # by GH cache rules) and pays a full cold install of Chromium + apt deps,
-  # which can hang for many minutes when the runner's apt mirror or the
-  # Playwright CDN is unhealthy. The warmer invocation skips the review
-  # work entirely — it only runs Set up Node + Cache + Install Playwright.
   push:
-    branches: [main]
+    branches: [main]  # warms the Playwright cache on main scope
   workflow_dispatch:
     inputs:
       pr_number:
@@ -52,36 +45,14 @@ on:
         required: true
         type: string
 
-# Cancel superseded review runs when a PR branch is repushed. Manual dispatch
-# gets a per-invocation group so it never cancels concurrent PR runs. Push
-# events use github.run_id so concurrent main pushes warm the cache
-# independently rather than cancelling each other.
 concurrency:
   group: claude-review-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   review:
-    # Skip drafts to avoid burning review budget on in-progress work. The
-    # pipeline still re-runs automatically on `ready_for_review`. Manual
-    # dispatch + push-to-main (cache warmer) are always allowed.
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event.pull_request.draft == false
-    # Track the v2 floating tag so pipeline fixes propagate automatically to
-    # every consumer repo. Supply-chain acceptance is declared in bugbot.md
-    # under "Accepted supply-chain trade-offs" so the reviewer does not
-    # re-flag `@v2 + secrets: inherit` on every PR.
     uses: panenco/claude-review/.github/workflows/pr-review.yml@v2
-    # Grant the reusable workflow the write scopes it needs. Reusable
-    # workflows cannot elevate permissions above the caller, and GitHub's
-    # default `GITHUB_TOKEN` since 2023 is read-only at both org and repo
-    # level. Without this block the run fails at startup with `startup_failure`,
-    # zero jobs, and no downloadable logs — extremely painful to debug.
-    # Required scopes: `contents: write` (push screenshots to the
-    # review-assets branch), `pull-requests: write` + `issues: write`
-    # (post reviews and comments), `actions: read` (round-2 follow-up
-    # reviews look up the prior run's review-state artifact by run-id —
-    # omitting this means follow-up reviews silently degrade to a full
-    # re-review on every push).
     permissions:
       contents: write
       pull-requests: write
@@ -89,9 +60,6 @@ jobs:
       actions: read
     with:
       pr_number: ${{ inputs.pr_number || '' }}
-      # On push-to-main, run only the warm-cache job inside the reusable
-      # workflow — no PR exists to review, the goal is to populate the
-      # main-scoped Playwright cache so PRs find it on first run.
       warm_cache_only: ${{ github.event_name == 'push' }}
     secrets: inherit
 ```

--- a/prompts/setup-review.md
+++ b/prompts/setup-review.md
@@ -36,8 +36,6 @@ name: Claude PR Review
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  push:
-    branches: [main]  # warms the Playwright cache on main scope
   workflow_dispatch:
     inputs:
       pr_number:
@@ -51,7 +49,7 @@ concurrency:
 
 jobs:
   review:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     uses: panenco/claude-review/.github/workflows/pr-review.yml@v2
     permissions:
       contents: write
@@ -374,7 +372,7 @@ Before committing, re-read your own `.github/review-config.md` and `.github/clau
 - [ ] Sign-in line starts with one of: `Sign in:`, `Sign-in:`, `Signin:`, `Log in:`, `Log-in:`, `Login:`.
 - [ ] Auth `Method:` is one of `cookie`, `bearer`, `header`, `none`.
 - [ ] The caller workflow tracks `@v2` AND `bugbot.md` contains an "Accepted supply-chain trade-offs" section that names `panenco/claude-review@v2 + secrets: inherit` as accepted. Both are needed — the @v2 for auto-propagation, the bugbot note so the reviewer doesn't re-flag it.
-- [ ] The caller workflow has a `concurrency:` block (`group: claude-review-${{ github.event.pull_request.number || github.run_id }}`, `cancel-in-progress: true`) AND a draft guard (`if: github.event_name != 'pull_request' || github.event.pull_request.draft == false`). Missing either is reviewer noise every PR.
+- [ ] The caller workflow has a `concurrency:` block (`group: claude-review-${{ github.event.pull_request.number || github.run_id }}`, `cancel-in-progress: true`) AND a draft guard (`if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false`). Missing either is reviewer noise every PR.
 
 If any check fails, fix before committing. The pipeline's reviewer will catch these on the first PR and block merge with `REQUEST_CHANGES`.
 

--- a/prompts/setup-review.md
+++ b/prompts/setup-review.md
@@ -36,7 +36,7 @@ name: Claude PR Review
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  pull_request_target:  # warms Playwright cache in main scope (no PR code is run)
+  pull_request_target:  # warms Playwright cache in main scope
   workflow_dispatch:
     inputs:
       pr_number:

--- a/prompts/setup-review.md
+++ b/prompts/setup-review.md
@@ -36,6 +36,7 @@ name: Claude PR Review
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  pull_request_target:  # warms Playwright cache in main scope (no PR code is run)
   workflow_dispatch:
     inputs:
       pr_number:

--- a/prompts/setup-review.md
+++ b/prompts/setup-review.md
@@ -51,7 +51,7 @@ concurrency:
 
 jobs:
   review:
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event.pull_request.draft == false
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     uses: panenco/claude-review/.github/workflows/pr-review.yml@v2
     permissions:
       contents: write
@@ -60,7 +60,6 @@ jobs:
       actions: read
     with:
       pr_number: ${{ inputs.pr_number || '' }}
-      warm_cache_only: ${{ github.event_name == 'push' }}
     secrets: inherit
 ```
 
@@ -375,7 +374,7 @@ Before committing, re-read your own `.github/review-config.md` and `.github/clau
 - [ ] Sign-in line starts with one of: `Sign in:`, `Sign-in:`, `Signin:`, `Log in:`, `Log-in:`, `Login:`.
 - [ ] Auth `Method:` is one of `cookie`, `bearer`, `header`, `none`.
 - [ ] The caller workflow tracks `@v2` AND `bugbot.md` contains an "Accepted supply-chain trade-offs" section that names `panenco/claude-review@v2 + secrets: inherit` as accepted. Both are needed — the @v2 for auto-propagation, the bugbot note so the reviewer doesn't re-flag it.
-- [ ] The caller workflow has a `concurrency:` block (`group: claude-review-${{ github.event.pull_request.number || github.run_id }}`, `cancel-in-progress: true`) AND a draft guard (`if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event.pull_request.draft == false`). Missing either is reviewer noise every PR. The `push` clause in the guard is required so `push: main` invocations of the cache warmer aren't filtered out (they have no `event.pull_request`, so the draft check would evaluate falsy and skip the job).
+- [ ] The caller workflow has a `concurrency:` block (`group: claude-review-${{ github.event.pull_request.number || github.run_id }}`, `cancel-in-progress: true`) AND a draft guard (`if: github.event_name != 'pull_request' || github.event.pull_request.draft == false`). Missing either is reviewer noise every PR.
 
 If any check fails, fix before committing. The pipeline's reviewer will catch these on the first PR and block merge with `REQUEST_CHANGES`.
 

--- a/prompts/setup-review.md
+++ b/prompts/setup-review.md
@@ -36,6 +36,15 @@ name: Claude PR Review
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  # Push-to-main warms the Playwright cache on `refs/heads/main` scope, the
+  # only cache scope every PR run can read. Without this, the first run of
+  # every new PR finds nothing in cache (sibling PR refs are unreachable
+  # by GH cache rules) and pays a full cold install of Chromium + apt deps,
+  # which can hang for many minutes when the runner's apt mirror or the
+  # Playwright CDN is unhealthy. The warmer invocation skips the review
+  # work entirely — it only runs Set up Node + Cache + Install Playwright.
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -44,7 +53,9 @@ on:
         type: string
 
 # Cancel superseded review runs when a PR branch is repushed. Manual dispatch
-# gets a per-invocation group so it never cancels concurrent PR runs.
+# gets a per-invocation group so it never cancels concurrent PR runs. Push
+# events use github.run_id so concurrent main pushes warm the cache
+# independently rather than cancelling each other.
 concurrency:
   group: claude-review-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
@@ -53,8 +64,8 @@ jobs:
   review:
     # Skip drafts to avoid burning review budget on in-progress work. The
     # pipeline still re-runs automatically on `ready_for_review`. Manual
-    # dispatch is always allowed.
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    # dispatch + push-to-main (cache warmer) are always allowed.
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event.pull_request.draft == false
     # Track the v2 floating tag so pipeline fixes propagate automatically to
     # every consumer repo. Supply-chain acceptance is declared in bugbot.md
     # under "Accepted supply-chain trade-offs" so the reviewer does not
@@ -78,6 +89,10 @@ jobs:
       actions: read
     with:
       pr_number: ${{ inputs.pr_number || '' }}
+      # On push-to-main, run only the warm-cache job inside the reusable
+      # workflow — no PR exists to review, the goal is to populate the
+      # main-scoped Playwright cache so PRs find it on first run.
+      warm_cache_only: ${{ github.event_name == 'push' }}
     secrets: inherit
 ```
 
@@ -392,7 +407,7 @@ Before committing, re-read your own `.github/review-config.md` and `.github/clau
 - [ ] Sign-in line starts with one of: `Sign in:`, `Sign-in:`, `Signin:`, `Log in:`, `Log-in:`, `Login:`.
 - [ ] Auth `Method:` is one of `cookie`, `bearer`, `header`, `none`.
 - [ ] The caller workflow tracks `@v2` AND `bugbot.md` contains an "Accepted supply-chain trade-offs" section that names `panenco/claude-review@v2 + secrets: inherit` as accepted. Both are needed — the @v2 for auto-propagation, the bugbot note so the reviewer doesn't re-flag it.
-- [ ] The caller workflow has a `concurrency:` block (`group: claude-review-${{ github.event.pull_request.number || github.run_id }}`, `cancel-in-progress: true`) AND a draft guard (`if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false`). Missing either is reviewer noise every PR.
+- [ ] The caller workflow has a `concurrency:` block (`group: claude-review-${{ github.event.pull_request.number || github.run_id }}`, `cancel-in-progress: true`) AND a draft guard (`if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event.pull_request.draft == false`). Missing either is reviewer noise every PR. The `push` clause in the guard is required so `push: main` invocations of the cache warmer aren't filtered out (they have no `event.pull_request`, so the draft check would evaluate falsy and skip the job).
 
 If any check fails, fix before committing. The pipeline's reviewer will catch these on the first PR and block merge with `REQUEST_CHANGES`.
 

--- a/prompts/setup-review.md
+++ b/prompts/setup-review.md
@@ -45,7 +45,7 @@ on:
         type: string
 
 concurrency:
-  group: claude-review-${{ github.event.pull_request.number || github.run_id }}
+  group: claude-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -373,7 +373,7 @@ Before committing, re-read your own `.github/review-config.md` and `.github/clau
 - [ ] Sign-in line starts with one of: `Sign in:`, `Sign-in:`, `Signin:`, `Log in:`, `Log-in:`, `Login:`.
 - [ ] Auth `Method:` is one of `cookie`, `bearer`, `header`, `none`.
 - [ ] The caller workflow tracks `@v2` AND `bugbot.md` contains an "Accepted supply-chain trade-offs" section that names `panenco/claude-review@v2 + secrets: inherit` as accepted. Both are needed — the @v2 for auto-propagation, the bugbot note so the reviewer doesn't re-flag it.
-- [ ] The caller workflow has a `concurrency:` block (`group: claude-review-${{ github.event.pull_request.number || github.run_id }}`, `cancel-in-progress: true`) AND a draft guard (`if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false`). Missing either is reviewer noise every PR.
+- [ ] The caller workflow has a `concurrency:` block (`group: claude-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}`, `cancel-in-progress: true`) AND a draft guard (`if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false`). Missing either is reviewer noise every PR. `github.event_name` in the group key keeps `pull_request` and `pull_request_target` in separate groups so the warm-cache run doesn't cancel the review (or vice versa).
 
 If any check fails, fix before committing. The pipeline's reviewer will catch these on the first PR and block merge with `REQUEST_CHANGES`.
 


### PR DESCRIPTION
## Summary

Two related CI breakages from yesterday's pnpm fallback work — fixed in one PR because they hit consumers together.

- **pnpm step bombs on `packageManager` repos.** `pnpm/action-setup@v6.0.7` errors with \`ERR_PNPM_BAD_PM_VERSION\` ("Multiple versions of pnpm specified") whenever the consumer pins \`packageManager: pnpm@X\` in package.json AND we pass \`version: 10\` to the action. Repro: [Panenco/qiv#357 run 25718781002](https://github.com/Panenco/qiv/actions/runs/25718781002/job/75514647860?pr=357). Fix detects the field first, then picks the right invocation: drop the version input when packageManager is pinned, keep the default-10 fallback for repos without one.
- **Playwright cache never lands on main scope.** GH Actions cache is branch-scoped — a PR run reads its own merge-ref + the default branch, never sibling PR refs. The cache key \`Linux-pw-1.59.1-mcp-0.0.75\` exists on \`refs/pull/357/merge\` and \`refs/pull/324/merge\` (where the qiv runs that warmed it lived) but nothing on \`refs/heads/main\`, so every new PR's first run pays a cold install. PR #359's run wedged for 30+ minutes on \`npx playwright install --with-deps\` because of this. Adds a \`warm_cache_only\` input that runs a stripped-down job (Set up Node + Cache + Install Playwright), wired from \`push: main\` in the consumer workflow so the main-scope cache stays warm.

## Test plan

- [ ] Merge this PR; the workflow CI run on this branch exercises the gated \`review\` job path with \`warm_cache_only: false\` and confirms the new pnpm detector branches as expected (the dogfood self-review will pick a pnpm path).
- [ ] After merge: bump \`v2\` tag → push a no-op to qiv main → confirm a \`warm-cache\` job runs and the cache action reports a new \`refs/heads/main\` entry with key \`Linux-pw-1.59.1-mcp-0.0.75\`.
- [ ] Verify next PR opened in qiv (post-warm) shows \`Cache Playwright assets\` as a hit and \`Install Playwright + MCP\` completes in <60s.
- [ ] Verify qiv #357's next push runs through the new \`Detect pnpm in package.json\` step → \`Set up pnpm (from packageManager)\` step and proceeds past the install (previously failed at the same step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes GitHub Actions triggers/concurrency and introduces a new `pull_request_target` job; misconfiguration could waste CI time or create unintended execution paths, though the PR explicitly keeps the target-triggered job PR-code-free.
> 
> **Overview**
> Enables Playwright cache warming in the default-branch cache scope by adding a `pull_request_target` trigger and a new `warm-cache` job that only restores/populates the Playwright/@playwright/mcp caches, while explicitly skipping the main `review` job on `pull_request_target`.
> 
> Hardens the Node build bootstrap by replacing `pnpm/action-setup` with a bash `Ensure pnpm on PATH` step (prefer existing pnpm, then `corepack`, then `npm -g`) and broadens the Playwright cache restore with a `restore-keys` prefix.
> 
> Updates the caller-workflow/docs (`README.md`, `prompts/setup-review.md`) to include `pull_request_target` and adjusts concurrency grouping to include `github.event_name` so warm-cache runs don’t cancel review runs (and vice versa).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2d2060eb9d8eeb65e87465e9870aad3c59076e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->