### PR TITLE
fix(review): skip pnpm fallback when consumer pins packageManager

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -329,8 +329,24 @@ jobs:
       # *pinned* version (typically via `corepack enable`, picked up from
       # the consumer's package.json#packageManager) — this is a safety
       # net so a missing preamble doesn't silently skip functional testing.
-      - name: Set up pnpm (default fallback)
+      #
+      # Skip the fallback when the consumer pins pnpm via `packageManager`:
+      # pnpm/action-setup@v6 errors out ("Multiple versions of pnpm specified")
+      # if both `version:` and `packageManager` are set. Consumers with a pin
+      # don't need the fallback — corepack will activate the pinned version.
+      - name: Detect consumer pnpm pin
+        id: pnpm_pin
         if: steps.code_check.outputs.needs_build == 'true'
+        shell: bash
+        run: |
+          if [ -f package.json ] && grep -q '"packageManager"[[:space:]]*:[[:space:]]*"pnpm@' package.json; then
+            echo "has_pin=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_pin=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up pnpm (default fallback)
+        if: steps.code_check.outputs.needs_build == 'true' && steps.pnpm_pin.outputs.has_pin == 'false'
         uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
         with:
           version: 10


### PR DESCRIPTION
## Summary

- `pnpm/action-setup@v6` errors with `Multiple versions of pnpm specified` when both `version:` is set on the step **and** `packageManager` is declared in the consumer's `package.json`. This kills the review job before any work runs.
- Real-world repro: every PR in `Panenco/qiv` currently fails the `review / In-Depth Review` check (it pins `pnpm@10.33.0` via `packageManager`). Example: https://github.com/Panenco/qiv/actions/runs/25721061129/job/75522099241.
- Fix: detect the consumer's `packageManager` pin and skip the fallback when present. Consumers with a pin don't need the fallback — corepack activates the pinned version. Consumers without a pin keep the current behaviour (default pnpm 10 on PATH).

## Behaviour matrix

| Consumer `package.json#packageManager` | Before | After |
| --- | --- | --- |
| `pnpm@X.Y.Z` set | ❌ action errors, job dies | ✅ step skipped, corepack activates pinned pnpm |
| not set | ✅ action installs pnpm 10 | ✅ action installs pnpm 10 (unchanged) |

## Test plan

- [ ] Re-run `Claude PR Review` on a Panenco/qiv PR (e.g. #331) against `@v2` after this lands + retag — expect green.
- [ ] Confirm a consumer without `packageManager` (none in the org currently — synthetic test via workflow_dispatch on a fork) still gets pnpm 10 on PATH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)