### PR TITLE
review-judge: add impact test to false-positive self-check

### DIFF
--- a/skills/review-judge.md
+++ b/skills/review-judge.md
@@ -106,12 +106,13 @@ Inline comments anchor on (`path`, `line`, `side`) tuples that must exist in the
 
 ## False-positive self-check (MANDATORY)
 
-Before finalising ANY finding, verify all five:
+Before finalising ANY finding, verify all six:
 1. **Concrete evidence** — exact lines that are wrong. Speculation → drop it.
 2. **Refutation test** — could the author dismiss this in one sentence? If yes → drop it.
 3. **Senior-engineer test** — would an experienced engineer agree this is *objectively wrong*?
 4. **Exact reference** — for `spec-mismatch`, quote the exact rule. For `bug`, show the failure path. "Generally bad practice" is not evidence.
 5. **Artifact exists** — if the finding references a specific library/export, verify by Read (`package.json`, the package's `index.ts`, the source file that should contain the symbol). If you cannot verify by Read, drop the finding. Also Read `/tmp/user-replies-on-ours.json` when context.md flags it as non-empty: if a maintainer already rebutted the same issue as a false positive, do not re-flag unless you have new counter-evidence.
+6. **Impact test** — state the concrete bad outcome in one sentence (broken behavior, user-visible regression, correctness/security hole, real maintainability cost on code that will live). A bare convention/bugbot rule match without a stated outcome is noise, regardless of how clearly the rule is written — drop it. Process complaints about the PR description or follow-up tracking are not findings.
 
 A clean `[]` is a confident, valuable review. False positives waste more team time than a missed minor issue. When in doubt, drop the finding.
 


### PR DESCRIPTION
## Summary
- Adds a sixth self-check to `skills/review-judge.md`: every finding needs a one-sentence statement of the concrete bad outcome (broken behavior, user-visible regression, correctness/security hole, real maintainability cost).
- Calls out PR-description and follow-up-tracking complaints as explicitly not findings.
- Motivated by a real review (qiv #324) where ~11 of 13 findings were strict-by-the-book rule matches with no stated outcome — hook-size technicalities, `localeCompare` perf nits, "file a follow-up issue", screenshots in the PR description.

## Why this shape
- Single line, no carve-outs by file type — prototypes still get the same quality bar; the bar just stops accepting bare rule matches.
- Lands in the judge skill so it propagates to both Opus and Haiku judges in one place.

## Test plan
- [ ] Dogfood on the next qiv review: verify the strict nits drop while real bugs (e.g. duplicate-assignment via missing `patientIdsInRooms` plumbing) still surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that tightens review-judge guidance; no runtime code or production behavior is affected.
> 
> **Overview**
> Adds a new **"Impact test"** step to `skills/review-judge.md`’s false-positive self-check, requiring each finding to explicitly state the concrete negative outcome (e.g., broken behavior, security/correctness issue, or real maintainability cost).
> 
> Clarifies that process critiques (PR description quality or follow-up tracking requests) should not be emitted as findings, aiming to reduce rule-matching nits without user-facing impact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2c201d8d56ced0c74d6bbfe392561dba5b0432d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->