### PR TITLE
chore: prettier-clean inline comment on pull_request_target trigger

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -3,7 +3,7 @@ name: Claude PR Review
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  pull_request_target:  # warms Playwright cache in main scope
+  pull_request_target: # warms Playwright cache in main scope
   workflow_dispatch:
     inputs:
       pr_number:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ name: Claude PR Review
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  pull_request_target:  # warms Playwright cache in main scope
+  pull_request_target: # warms Playwright cache in main scope
   workflow_dispatch:
     inputs:
       pr_number:

--- a/prompts/setup-review.md
+++ b/prompts/setup-review.md
@@ -36,7 +36,7 @@ name: Claude PR Review
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  pull_request_target:  # warms Playwright cache in main scope
+  pull_request_target: # warms Playwright cache in main scope
   workflow_dispatch:
     inputs:
       pr_number:


### PR DESCRIPTION
## Summary
Drop one space before the inline comment on the `pull_request_target:` trigger across the three places consumers copy from (local caller, setup-review.md, README.md).

```diff
-  pull_request_target:  # warms Playwright cache in main scope
+  pull_request_target: # warms Playwright cache in main scope
```

## Why
Prettier's YAML rule wants a single space before the inline `#`. Consumer repos that run `prettier --check .github` failed lint after applying the new caller template: qiv#377 and spendfuse#40 both surfaced this when I rolled `pull_request_target:` out to every consumer (8 consumer PRs + mycc + Panenco/.github template, all already patched). Without this upstream fix, the next consumer pasting from `setup-review.md` hits the same lint failure.

## Test plan
- [ ] `prettier --check .github/workflows/claude-review.yml` passes locally.
- [ ] Dogfood review on this PR still runs (this caller is the one the dogfood uses).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk formatting-only change to workflow/docs templates; no behavioral changes to CI triggers or permissions.
> 
> **Overview**
> Normalizes the `pull_request_target:` inline comment spacing (single space before `#`) in the caller workflow template and the two copied examples (`README.md` and `prompts/setup-review.md`) so YAML formatters like Prettier don’t fail on the pasted snippet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c4c3013f46845758850383d8ce39cf97e2fc646. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->