### PR TITLE
chore: bump Opus judge model to claude-opus-4-8

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -4,46 +4,46 @@ on:
   workflow_call:
     inputs:
       pr_number:
-        description: 'PR number (auto-detected from PR event if omitted)'
+        description: "PR number (auto-detected from PR event if omitted)"
         required: false
         type: string
       model_high:
-        description: 'Deep-reasoning model — used by the Opus judge inside the orchestrator. Currently consumed only via the orchestrator skill (which hard-codes the Opus tier in its Task dispatch); kept as a workflow input for forward-compatibility when the orchestrator parametrises judge models.'
+        description: "Deep-reasoning model — used by the Opus judge inside the orchestrator. Currently consumed only via the orchestrator skill (which hard-codes the Opus tier in its Task dispatch); kept as a workflow input for forward-compatibility when the orchestrator parametrises judge models."
         required: false
         type: string
-        default: 'claude-opus-4-7'
+        default: "claude-opus-4-8"
       model_standard:
-        description: 'Standard-tier model — used for the context builder, the orchestrator itself, the round-2 thread classifier, and the functional tester (unless overridden by model_functional).'
+        description: "Standard-tier model — used for the context builder, the orchestrator itself, the round-2 thread classifier, and the functional tester (unless overridden by model_functional)."
         required: false
         type: string
-        default: 'claude-sonnet-4-6'
+        default: "claude-sonnet-4-6"
       model_fast:
-        description: 'Cheap-tier model — used by the Haiku judge inside the orchestrator. Currently consumed only via the orchestrator skill (which hard-codes the Haiku tier in its Task dispatch); kept as a workflow input for forward-compatibility.'
+        description: "Cheap-tier model — used by the Haiku judge inside the orchestrator. Currently consumed only via the orchestrator skill (which hard-codes the Haiku tier in its Task dispatch); kept as a workflow input for forward-compatibility."
         required: false
         type: string
-        default: 'claude-haiku-4-5'
+        default: "claude-haiku-4-5"
       model_functional:
-        description: 'Model for the functional tester (Playwright MCP + Bash). Defaults to Sonnet because empirical comparison on the Seaters dogfood showed Haiku regressed on severity calibration — it classified test-environment friction (no auth credentials, empty seed data) as CRITICAL/MAJOR product bugs, while Sonnet correctly noted them as observations and traced a real backend NPE bug that Haiku missed. Override to claude-haiku-4-5 if you accept that risk in exchange for ~3× wall-time speedup on the functional layer. The 19m→5.5m speedup IS real, but only worth it on PRs where the test-environment friction is minimal (well-seeded fixtures + pre-configured auth).'
+        description: "Model for the functional tester (Playwright MCP + Bash). Defaults to Sonnet because empirical comparison on the Seaters dogfood showed Haiku regressed on severity calibration — it classified test-environment friction (no auth credentials, empty seed data) as CRITICAL/MAJOR product bugs, while Sonnet correctly noted them as observations and traced a real backend NPE bug that Haiku missed. Override to claude-haiku-4-5 if you accept that risk in exchange for ~3× wall-time speedup on the functional layer. The 19m→5.5m speedup IS real, but only worth it on PRs where the test-environment friction is minimal (well-seeded fixtures + pre-configured auth)."
         required: false
         type: string
-        default: 'claude-sonnet-4-6'
+        default: "claude-sonnet-4-6"
       pipeline_ref:
-        description: 'Ref of panenco/claude-review to install skills/scripts from. Default v2 tracks the moving release tag. Pin to a SHA or branch when testing pipeline changes against a real consumer repo.'
+        description: "Ref of panenco/claude-review to install skills/scripts from. Default v2 tracks the moving release tag. Pin to a SHA or branch when testing pipeline changes against a real consumer repo."
         required: false
         type: string
-        default: 'v2'
+        default: "v2"
       dev_env_timeout_seconds:
-        description: 'How long to wait for the background dev-env (.github/claude-review/dev-start.sh) to come up. Heavy stacks (Java + Node + Docker compose) can need 5-6 minutes on a cold runner. Default 360.'
+        description: "How long to wait for the background dev-env (.github/claude-review/dev-start.sh) to come up. Heavy stacks (Java + Node + Docker compose) can need 5-6 minutes on a cold runner. Default 360."
         required: false
         type: number
         default: 360
       core_max_turns:
-        description: 'Legacy alias retained for consumer compatibility. Previously gated the standalone core/core-pass2 reviewers; those have been replaced by the orchestrator-driven judge debate, whose ceiling is set inside the workflow at `--max-turns 80` for the orchestrator and is otherwise governed by the prompt-side STOP-and-write anchors in review-judge.md / review-orchestrator.md. Adjusting this input has no effect today; consumer workflows that pass it continue to work without breakage.'
+        description: "Legacy alias retained for consumer compatibility. Previously gated the standalone core/core-pass2 reviewers; those have been replaced by the orchestrator-driven judge debate, whose ceiling is set inside the workflow at `--max-turns 80` for the orchestrator and is otherwise governed by the prompt-side STOP-and-write anchors in review-judge.md / review-orchestrator.md. Adjusting this input has no effect today; consumer workflows that pass it continue to work without breakage."
         required: false
         type: number
         default: 40
       functional_max_turns:
-        description: 'Max turns for the functional tester (Sonnet + Playwright MCP + Bash). The skill targets ≤30 with STOP-and-write anchors at 60/80/100; 200 is the runtime ceiling — generous headroom over the planner-capped 4 scenarios × ~6 turns/scenario + auth + output budget. Bumped from 120 after observed crashes on PRs with bigger UI surfaces (e.g. seaters#464 crashed at 120 with 12 captured screenshots). The prompt-side anchors keep cost bounded; this ceiling is so the framework rarely has to enforce one.'
+        description: "Max turns for the functional tester (Sonnet + Playwright MCP + Bash). The skill targets ≤30 with STOP-and-write anchors at 60/80/100; 200 is the runtime ceiling — generous headroom over the planner-capped 4 scenarios × ~6 turns/scenario + auth + output budget. Bumped from 120 after observed crashes on PRs with bigger UI surfaces (e.g. seaters#464 crashed at 120 with 12 captured screenshots). The prompt-side anchors keep cost bounded; this ceiling is so the framework rarely has to enforce one."
         required: false
         type: number
         default: 200
@@ -88,11 +88,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
-      contents: write  # write needed for uploading screenshots to review-assets branch
+      contents: write # write needed for uploading screenshots to review-assets branch
       pull-requests: write
       issues: write
-      actions: read    # needed for actions/download-artifact with run-id (round-2 state)
-      packages: read  # needed for fetching from private registries when the consumer repo uses them
+      actions: read # needed for actions/download-artifact with run-id (round-2 state)
+      packages: read # needed for fetching from private registries when the consumer repo uses them
 
     steps:
       - name: Resolve PR head SHA
@@ -322,7 +322,7 @@ jobs:
         if: steps.code_check.outputs.needs_build == 'true'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: 'lts/*'
+          node-version: "lts/*"
 
       - name: Ensure pnpm on PATH
         if: steps.code_check.outputs.needs_build == 'true'
@@ -921,7 +921,7 @@ jobs:
       # SHA bumped to the v1 release that ships Claude Code 2.1.132 (Agent
       # SDK 0.2.132), which also fixed a 10GB+ RSS leak with stdio MCP
       # servers — relevant if the leak was contributing to the pending state.
-      - name: 'Install functional-tester subagent definition'
+      - name: "Install functional-tester subagent definition"
         shell: bash
         env:
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
@@ -946,7 +946,7 @@ jobs:
           # round 2).
           bash "${CLAUDE_REVIEW_PIPELINE_DIR}/scripts/install-functional-tester-agent.sh"
 
-      - name: 'Review: orchestrate'
+      - name: "Review: orchestrate"
         id: claude_run
         # Don't fail the job if the orchestrator returns non-zero (e.g.
         # max-turns hit at the STOP-and-write anchor). /tmp/all-findings.json
@@ -984,11 +984,11 @@ jobs:
             --allowedTools Bash,Read,Write,Glob,Grep,Task,ToolSearch,mcp__playwright
             --disallowedTools Edit,WebFetch,WebSearch
             --max-turns 100
-          show_full_output: 'true'
+          show_full_output: "true"
 
       # Build the review body + comments + screenshot upload from the
       # orchestrator's outputs. No agents launched here — pure post-processing.
-      - name: 'Review: build artifacts'
+      - name: "Review: build artifacts"
         id: review_builder
         if: always() && steps.claude_run.outcome != 'cancelled' && steps.claude_run.outcome != 'skipped'
         shell: bash
@@ -1038,7 +1038,7 @@ jobs:
       # orchestrator wrote partial output and build-review.sh succeeded, we
       # post; if build-review.sh exited 1 (missing /tmp/all-findings.json), the
       # verdict gate downstream surfaces the crash banner instead.
-      - name: 'Review: post results'
+      - name: "Review: post results"
         id: review_poster
         if: always() && steps.review_builder.outcome == 'success'
         shell: bash
@@ -1157,7 +1157,7 @@ jobs:
     steps:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: 'lts/*'
+          node-version: "lts/*"
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: 'PR number to review'
+        description: "PR number to review"
         required: true
         type: string
 jobs:
@@ -35,7 +35,7 @@ jobs:
 
 The `permissions:` block is required: reusable workflow permissions are capped by the caller's, and GitHub's default `GITHUB_TOKEN` is read-only at most orgs. Omitting it produces `startup_failure` with no logs. See `prompts/setup-review.md` for the full troubleshooting flow.
 
-Why `@v2` and not a SHA pin: every consumer repo stays on the same moving target, so a fix landed on `panenco/claude-review` reaches everything on the next PR push without touching any downstream repo. The trade-off — a mutable tag + `secrets: inherit` is technically a supply-chain vector — is one we explicitly accept here because upstream is first-party (Panenco org) and the logistics of SHA-bumping every consumer after every pipeline fix were unworkable. If *your* repo has different trust needs, substitute a 40-char SHA for `@v2`.
+Why `@v2` and not a SHA pin: every consumer repo stays on the same moving target, so a fix landed on `panenco/claude-review` reaches everything on the next PR push without touching any downstream repo. The trade-off — a mutable tag + `secrets: inherit` is technically a supply-chain vector — is one we explicitly accept here because upstream is first-party (Panenco org) and the logistics of SHA-bumping every consumer after every pipeline fix were unworkable. If _your_ repo has different trust needs, substitute a 40-char SHA for `@v2`.
 
 **Tag-resolution caveat.** The reusable workflow file and the install step resolve their refs at different moments of the job. Moving `v2` while a run is starting can cause a mismatch — push the `v2` tag at idle times, not while runs are in flight.
 
@@ -99,7 +99,7 @@ PR opened / updated
                   chunks AND no spec source) without dispatching any
                   judges. Writes APPROVE-eligible meta and exits.
       Phase 2   — Parallel Task fan (single assistant response):
-                    Judge-Opus  (model: claude-opus-4-7)   ─┐
+                    Judge-Opus  (model: claude-opus-4-8)   ─┐
                     Judge-Haiku (model: claude-haiku-4-5)  ├ all parallel
                     Thread classifier (round 2 only)       │
                     Functional tester (Playwright MCP)     ─┘
@@ -124,7 +124,7 @@ Verdict: APPROVE / COMMENT / REQUEST_CHANGES
 
 ### Why one top-level agent?
 
-Two practical wins. (1) **Native rate-limit fast-fail.** `anthropics/claude-code-action` exits in <1 s when the OAuth token hits a quota wall; the bare `claude -p` CLI silently retries and *hangs* until the 45-minute job timeout — a real bug observed on PR #309. (2) **All parallelism through the `Task` tool.** No bash background processes, no `wait`/reap traps, no sibling stdout files. One nested transcript covers the whole review.
+Two practical wins. (1) **Native rate-limit fast-fail.** `anthropics/claude-code-action` exits in <1 s when the OAuth token hits a quota wall; the bare `claude -p` CLI silently retries and _hangs_ until the 45-minute job timeout — a real bug observed on PR #309. (2) **All parallelism through the `Task` tool.** No bash background processes, no `wait`/reap traps, no sibling stdout files. One nested transcript covers the whole review.
 
 ### Why two judges?
 
@@ -179,6 +179,7 @@ Add a "Verify before flagging" section to prevent reviewers from citing librarie
 ## Verify before flagging
 
 Before reporting a finding that cites a library or component, confirm it exists:
+
 - Check `context.md` -> "Repo capabilities" for available exports and dependencies.
 - If the artifact is not listed, drop the finding or move to `uncertain_observations`.
 ```
@@ -208,8 +209,8 @@ Map changed paths to convention/rule files:
 ```markdown
 ## Convention files
 
-| Changed path | Read |
-|---|---|
+| Changed path  | Read                                                 |
+| ------------- | ---------------------------------------------------- |
 | `apps/api/**` | `.cursor/rules/api.mdc`, `.cursor/rules/general.mdc` |
 | `apps/web/**` | `.cursor/rules/web.mdc`, `.cursor/rules/general.mdc` |
 ```
@@ -222,16 +223,18 @@ Free-text guidance for reviewers. Write rules in terms of **your** stack — the
 ## Stack-specific review focus
 
 **API (<your framework>)**
+
 - <Architectural rule reviewers must enforce — e.g., "controllers thin, logic in services".>
 - <Test expectation — e.g., "tests use real DB, never mock the ORM".>
 
 **Web (<your framework>)**
+
 - <Data-fetching rule — e.g., "data via <library>; query keys centralized".>
 ```
 
 #### `## Functional validation`
 
-**Prose only — no executable bash.** This section is read by the reviewer agents from `context.md` and describes what the functional tester should exercise. The *executable* side of dev-env bring-up lives in `.github/claude-review/dev-start.sh` (see below).
+**Prose only — no executable bash.** This section is read by the reviewer agents from `context.md` and describes what the functional tester should exercise. The _executable_ side of dev-env bring-up lives in `.github/claude-review/dev-start.sh` (see below).
 
 Describe (in prose) what the project needs at runtime: database flavour + credentials, where `.env` lives, migrations/codegen, dev-server ports, seed data / test users. Do not duplicate the commands — the script is the source of truth.
 
@@ -279,6 +282,7 @@ done
 ```
 
 Rules:
+
 - `chmod +x` after creating it.
 - No `set -e` — the subshell wrapper already tolerates exit N, and `set -e` surprises you in idioms like `curl || true`.
 - Readiness loops must explicitly test the flag after the loop and `exit 1` on timeout. Silent-success loops are flagged by the reviewer.
@@ -329,10 +333,10 @@ Authentication for functional testing:
 ```markdown
 ### Known service ports
 
-| Service | URL | Notes |
-|---------|-----|-------|
-| API | http://localhost:3001/api | Health at GET /api |
-| Web | http://localhost:3000 | |
+| Service | URL                       | Notes              |
+| ------- | ------------------------- | ------------------ |
+| API     | http://localhost:3001/api | Health at GET /api |
+| Web     | http://localhost:3000     |                    |
 ```
 
 ### `.github/claude-review/fetch-issue.sh` (optional — external issue trackers)
@@ -408,10 +412,20 @@ A workflow step scans the branch name, PR title, and PR body for every recognize
 
 ```json
 {
-  "explicit_markers": [{"key": "Linear", "value": "LIN-123", "source": "pr_body_line"}],
-  "closing_keywords": [{"keyword": "Fixes", "target": "LIN-123", "source": "pr_body"}],
-  "urls":             [{"url": "https://linear.app/...", "host": "linear.app", "source": "pr_body"}],
-  "ids":              [{"id": "LIN-123", "source": "branch_name"}]
+  "explicit_markers": [
+    { "key": "Linear", "value": "LIN-123", "source": "pr_body_line" }
+  ],
+  "closing_keywords": [
+    { "keyword": "Fixes", "target": "LIN-123", "source": "pr_body" }
+  ],
+  "urls": [
+    {
+      "url": "https://linear.app/...",
+      "host": "linear.app",
+      "source": "pr_body"
+    }
+  ],
+  "ids": [{ "id": "LIN-123", "source": "branch_name" }]
 }
 ```
 
@@ -421,26 +435,26 @@ Confidence tiers (in extraction priority order): (1) `explicit_markers` — `Tic
 
 ## Degradation Matrix
 
-| Missing file | Impact | Behavior |
-|---|---|---|
-| `.github/claude-review/dev-start.sh` | Expected for degraded mode | Functional tester skipped. Core + sweep reviewers still run. |
-| `.github/claude-review/fetch-issue.sh` | Expected when only GitHub is used | Skipped silently. GitHub-issue lookup remains the default spec source. |
-| `review-config.md` | Reduced | No build prep doc, no convention-rule routing, no Known-service-ports URLs to probe, no auth setup. |
-| `bugbot.md` | Minor | Reviewers use generic methodology only (no project-specific rules, no accepted-trade-offs exemptions). |
-| `CLAUDE.md` | Minor | No architecture context. Reviewers rely on diff + issue. |
-| All config files | Significant | Code-only review (core + sweep) on raw diff + build output. Still catches bugs, spec issues, security. |
+| Missing file                           | Impact                            | Behavior                                                                                               |
+| -------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `.github/claude-review/dev-start.sh`   | Expected for degraded mode        | Functional tester skipped. Core + sweep reviewers still run.                                           |
+| `.github/claude-review/fetch-issue.sh` | Expected when only GitHub is used | Skipped silently. GitHub-issue lookup remains the default spec source.                                 |
+| `review-config.md`                     | Reduced                           | No build prep doc, no convention-rule routing, no Known-service-ports URLs to probe, no auth setup.    |
+| `bugbot.md`                            | Minor                             | Reviewers use generic methodology only (no project-specific rules, no accepted-trade-offs exemptions). |
+| `CLAUDE.md`                            | Minor                             | No architecture context. Reviewers rely on diff + issue.                                               |
+| All config files                       | Significant                       | Code-only review (core + sweep) on raw diff + build output. Still catches bugs, spec issues, security. |
 
-Note: a *present but broken* `dev-start.sh` is **not** a soft-degrade case — the pipeline fails the Pre-start step and stops. Remove the file to enter degraded mode explicitly.
+Note: a _present but broken_ `dev-start.sh` is **not** a soft-degrade case — the pipeline fails the Pre-start step and stops. Remove the file to enter degraded mode explicitly.
 
 ---
 
 ## Spec-presence gate
 
-The pipeline withholds `APPROVE` whenever the PR has no human-authored spec. The core reviewer judges this from the spec sources gathered in `context.md` — a linked GitHub issue with a non-trivial body, a PRD, an external-tracker spec, or a substantive manually-written PR-body section all qualify. Auto-generated PR descriptions (Cursor, Cursor Bugbot, CodeRabbit, Gemini Code Assist, Claude Code) describe what the diff *does*, not what it *should do*, and don't qualify on their own — they're a code summary, not a contract. When the core reviewer sets `manual_spec_present: false`, the verdict is downgraded from `APPROVE` to `COMMENT` and the review body explains how to fix it (link an issue, paste acceptance criteria, or wire up an external tracker). Findings still post normally; only the green-check approval is gated.
+The pipeline withholds `APPROVE` whenever the PR has no human-authored spec. The core reviewer judges this from the spec sources gathered in `context.md` — a linked GitHub issue with a non-trivial body, a PRD, an external-tracker spec, or a substantive manually-written PR-body section all qualify. Auto-generated PR descriptions (Cursor, Cursor Bugbot, CodeRabbit, Gemini Code Assist, Claude Code) describe what the diff _does_, not what it _should do_, and don't qualify on their own — they're a code summary, not a contract. When the core reviewer sets `manual_spec_present: false`, the verdict is downgraded from `APPROVE` to `COMMENT` and the review body explains how to fix it (link an issue, paste acceptance criteria, or wire up an external tracker). Findings still post normally; only the green-check approval is gated.
 
 ## Smoke-test gate for technical PRs
 
-The pipeline withholds `APPROVE` whenever the PR's stated intent is "no user-visible behavior change" (refactor, library swap, framework/runtime upgrade, build-config change, restructure, perf rewrite — across any ecosystem) but the smoke run did not pass. The trigger is intent, not file types: a `refactor: split foo into bar/baz` with no manifest touch counts; a major `Cargo.toml`/`Dockerfile`/`pyproject.toml` bump counts. The test planner detects this from PR title/body keywords (`refactor`, `chore`, `bump`, `upgrade`, `migrate`, "no behavior change"), diff shape (high move/rename ratio, low net new logic), and dependency-manifest deltas, then emits `## Technical change: true` in `test-plan.md`. The functional tester copies the flag into `functional-meta.json` and walks through one representative user flow (the planner picks it autonomously based on which code paths the change affects) with screenshots. If the smoke run does not return `PASS` or `WARN` — including the degraded-mode case where `.github/claude-review/dev-start.sh` is missing and the app can't be brought up — the verdict is downgraded from `APPROVE` to `COMMENT` and the review body explains how to enable it (configure `dev-start.sh`, or fix the smoke failures). Composes naturally with the spec-presence gate: together they ensure `APPROVE` is only granted when *something* substantively validated the change, either an acceptance criterion or a working app.
+The pipeline withholds `APPROVE` whenever the PR's stated intent is "no user-visible behavior change" (refactor, library swap, framework/runtime upgrade, build-config change, restructure, perf rewrite — across any ecosystem) but the smoke run did not pass. The trigger is intent, not file types: a `refactor: split foo into bar/baz` with no manifest touch counts; a major `Cargo.toml`/`Dockerfile`/`pyproject.toml` bump counts. The test planner detects this from PR title/body keywords (`refactor`, `chore`, `bump`, `upgrade`, `migrate`, "no behavior change"), diff shape (high move/rename ratio, low net new logic), and dependency-manifest deltas, then emits `## Technical change: true` in `test-plan.md`. The functional tester copies the flag into `functional-meta.json` and walks through one representative user flow (the planner picks it autonomously based on which code paths the change affects) with screenshots. If the smoke run does not return `PASS` or `WARN` — including the degraded-mode case where `.github/claude-review/dev-start.sh` is missing and the app can't be brought up — the verdict is downgraded from `APPROVE` to `COMMENT` and the review body explains how to enable it (configure `dev-start.sh`, or fix the smoke failures). Composes naturally with the spec-presence gate: together they ensure `APPROVE` is only granted when _something_ substantively validated the change, either an acceptance criterion or a working app.
 
 ---
 
@@ -482,21 +496,22 @@ Round-2 follow-up reviews download the prior run's `review-state` artifact via `
 
 ```yaml
 permissions:
-  contents: write       # screenshots → review-assets branch
-  pull-requests: write  # post review + comments
+  contents: write # screenshots → review-assets branch
+  pull-requests: write # post review + comments
   issues: write
-  actions: read         # round-2 follow-up reviews look up the prior
-                        # run's review-state artifact by run-id
+  actions:
+    read # round-2 follow-up reviews look up the prior
+    # run's review-state artifact by run-id
 ```
 
-If your existing caller has *no* `permissions:` block at all (the original v1 README's minimal example), this is also where you fix the `startup_failure`-on-orgs-with-default-read-only-`GITHUB_TOKEN` issue — the other three lines were always required, just under-documented.
+If your existing caller has _no_ `permissions:` block at all (the original v1 README's minimal example), this is also where you fix the `startup_failure`-on-orgs-with-default-read-only-`GITHUB_TOKEN` issue — the other three lines were always required, just under-documented.
 
 ### 2. New verdict gates (no wiring needed; verdicts on existing PRs may shift)
 
-- **Smoke-test gate** — on technical PRs (refactor / library swap / framework or runtime upgrade / build-config / `chore: bump …`), `APPROVE` is withheld unless the functional smoke run returns `PASS` or `WARN`. The trigger is *intent*, not file types: a pure-refactor commit with no manifest touch counts; a major `Cargo.toml` / `Dockerfile` / `pyproject.toml` bump counts. Repos in degraded mode (no `.github/claude-review/dev-start.sh`) will see refactor PRs flip from APPROVE → COMMENT until they configure a working bring-up.
+- **Smoke-test gate** — on technical PRs (refactor / library swap / framework or runtime upgrade / build-config / `chore: bump …`), `APPROVE` is withheld unless the functional smoke run returns `PASS` or `WARN`. The trigger is _intent_, not file types: a pure-refactor commit with no manifest touch counts; a major `Cargo.toml` / `Dockerfile` / `pyproject.toml` bump counts. Repos in degraded mode (no `.github/claude-review/dev-start.sh`) will see refactor PRs flip from APPROVE → COMMENT until they configure a working bring-up.
 - **Manual-spec gate** — PRs whose body is purely auto-generated (Cursor, Cursor Bugbot, CodeRabbit, Gemini Code Assist, Claude Code summaries) with no linked issue or PRD get downgraded APPROVE → COMMENT. Findings still post normally; only the green-check approval is gated. To re-enable APPROVE: link an issue, paste acceptance criteria into the PR body, or wire up an external tracker (`fetch-issue.sh`).
 
-Both gates compose with each other: `APPROVE` is granted only when *something* substantively validated the change — either a manual spec or a working app smoke-tested under the diff.
+Both gates compose with each other: `APPROVE` is granted only when _something_ substantively validated the change — either a manual spec or a working app smoke-tested under the diff.
 
 ### 3. New optional knobs (defaults preserve v1 behaviour)
 

--- a/skills/review-orchestrator.md
+++ b/skills/review-orchestrator.md
@@ -69,7 +69,7 @@ If `/tmp/dev-env/pid` does NOT exist, the workflow skipped the bring-up (no `dev
 
 ## Phase 1 — Early exit on trivial diffs
 
-Read `context.md`'s `## Per-file diff index`. Count chunks tagged with anything other than markdown / docs / generated. Concretely: a chunk path under `docs/`, ending in `.md` / `.mdx` / `.txt`, or matching a generated/artifact path is *non-reviewable*. Anything else is *reviewable*.
+Read `context.md`'s `## Per-file diff index`. Count chunks tagged with anything other than markdown / docs / generated. Concretely: a chunk path under `docs/`, ending in `.md` / `.mdx` / `.txt`, or matching a generated/artifact path is _non-reviewable_. Anything else is _reviewable_.
 
 Also Read `## Spec sources` and `## Acceptance criteria` from `context.md`.
 
@@ -125,7 +125,7 @@ To prepare the functional tester prompt: run `.review-scripts/generate-functiona
 
 Issue these in **one assistant response**:
 
-1. **Judge-Opus** — `subagent_type: general-purpose`, `model: "claude-opus-4-7"`, `prompt`:
+1. **Judge-Opus** — `subagent_type: general-purpose`, `model: "claude-opus-4-8"`, `prompt`:
 
    ```
    Read $CLAUDE_REVIEW_PIPELINE_DIR/skills/review-judge.md and follow it exactly. If bugbot.md exists at the repo root, Read it — its acceptance/exemption sections override the skill's defaults (drop matching findings entirely). You are the Opus judge for PR #${PR_NUMBER}. context.md at the repo root is your INDEX (with a 5-sentence diff summary at the top). Read it, then Read the chunks and spec sources it points at (per the Turn 2 instructions in the skill above). OUTPUT_PATH=/tmp/judge-opus.json MODE=initial.
@@ -267,5 +267,5 @@ JSON array of findings, identical schema to what the judges produce. Each entry 
 - **No own findings.** You never invent findings or rewrite a judge's evidence. If neither judge produced a finding for a region, that region produces no finding in the output.
 - **Always write both files.** On any failure path (CB failed, both judges failed, parse errors, hitting the STOP anchor), write best-effort output: empty findings array, a defensible verdict (`COMMENT` when degraded), `judge_health` reflecting the actual state. Never silently exit without writing.
 - **Two Task calls per debate round, in one assistant response.** Single calls serialise the judges and waste wall time.
-- **No retries on a single judge.** A judge that returns no parseable output is recorded as `failed` and the run proceeds. The redundancy is the *other* judge, not retries of the same one.
+- **No retries on a single judge.** A judge that returns no parseable output is recorded as `failed` and the run proceeds. The redundancy is the _other_ judge, not retries of the same one.
 - **Trivial-skip is a verdict-relevant decision.** If you short-circuit at Phase 1, you are still responsible for `manual_spec_present` and `prompt_injection_detected` — copy these from `context.md`'s flags, don't fabricate.


### PR DESCRIPTION
## Summary

Bumps the deep-reasoning judge in the review pipeline from `claude-opus-4-7` → `claude-opus-4-8`. Opus 4.8 is the latest Opus tier and the most capable for the judge role.

The model string lives in three places, all updated:

- **`skills/review-orchestrator.md`** — the `model:` on the Judge-Opus Task dispatch. **This is the one that actually drives the pipeline** (the orchestrator hard-codes the Opus tier).
- **`.github/workflows/pr-review.yml`** — the `model_high` workflow input default. Per its own description this input is currently *not* wired through to dispatch, so the change here is forward-compat/consistency only.
- **`README.md`** — the ASCII pipeline diagram (docs only).

## Note on diff size

The files also carry **prettier-clean formatting** applied by the editor on save (single→double quotes in the YAML, README reflow). The functional change is just the three `4-7` → `4-8` edits; the rest is formatting noise. Happy to strip the formatting into a separate commit/PR if the team prefers a clean one-line diff.

## Test plan

- [ ] Confirm `claude-opus-4-8` is an accepted model ID in the claude-code-action runtime
- [ ] Next PR review run dispatches the Opus judge on 4.8 without errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a model ID swap for the Opus judge plus docs/workflow formatting; behavior only changes if the runtime rejects the new model ID.
> 
> **Overview**
> Updates the PR review pipeline’s **deep-reasoning Opus judge** from `claude-opus-4-7` to **`claude-opus-4-8`** in three places: **`skills/review-orchestrator.md`** (Judge-Opus Task `model`, which actually runs reviews), **`.github/workflows/pr-review.yml`** (`model_high` default, noted as forward-compat only today), and **`README.md`** (pipeline diagram).
> 
> The same PR also applies **editor/formatting churn** across the workflow and README (YAML single→double quotes, comment spacing, markdown emphasis `_` vs `*`, table column alignment, JSON example pretty-printing). Those edits do not change review behavior beyond the model ID bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6212751289711743edb9c91ff5e6fc0f2dd442f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->