### PR TITLE
chore: bump Playwright to 1.60.0

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -78,7 +78,7 @@ on:
 # @playwright/mcp's CHANGELOG for the matching `playwright` peer before
 # letting them drift apart.
 env:
-  PLAYWRIGHT_VERSION: "1.59.1"
+  PLAYWRIGHT_VERSION: "1.60.0"
   PLAYWRIGHT_MCP_VERSION: "0.0.75"
 
 jobs:


### PR DESCRIPTION
## Summary

Bumps `PLAYWRIGHT_VERSION` from `1.59.1` → `1.60.0` (current stable) — the Chromium binary the functional tester pre-installs. `PLAYWRIGHT_MCP_VERSION` stays at `0.0.75` (latest).

Single env var in [.github/workflows/pr-review.yml](.github/workflows/pr-review.yml#L81), the single source of truth for the Playwright stack.

## Compatibility note

The pinning comment asks us to keep `playwright` and `@playwright/mcp` peers in sync. `@playwright/mcp@0.0.75` currently depends on `playwright@1.61.0-alpha-1778188671000` — there is no stable 1.61.0 yet, so **1.60.0 is the closest stable match, not an exact peer**. This is strictly closer than the previous 1.59.1; the prior pin was already drifted by more.

Consequences (both low-risk, neither a hard break):
- **Chromium pre-warm is best-effort.** At runtime the subagent spawns `@playwright/mcp@0.0.75` → resolves its bundled `playwright@1.61.0-alpha` → wants that revision's Chromium. If it differs from the 1.60.0 binary we pre-install, the first functional run cold-downloads the browser (the existing warning path) and recovers.
- **Cache key rotates.** `PLAYWRIGHT_VERSION` is part of the browser-binary cache key, so the first run on each repo after this lands is a cache miss (expected for any bump).

## Test plan

- [ ] First PR with user-observable surface triggers the functional tester and Chromium launches (cold install acceptable on first run)
- [ ] Browser-binary cache repopulates under the new `1.60.0` key on the second run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single env var bump in CI tooling only; no app auth, data, or product code paths change.
> 
> **Overview**
> Bumps the workflow-level **`PLAYWRIGHT_VERSION`** pin from `1.59.1` to **`1.60.0`** in `.github/workflows/pr-review.yml` — the single source of truth for the Chromium binary the PR review pipeline pre-installs for the functional tester. **`PLAYWRIGHT_MCP_VERSION`** remains `0.0.75`.
> 
> That env var feeds the **Playwright asset cache key** and the `npx playwright@… install chromium` steps in both the main **review** job and **warm-cache**, so the first runs after merge will miss the old cache and repopulate under the new key. **`@playwright/mcp@0.0.75`** still peers toward a newer Playwright alpha at runtime; pre-warm may not match the MCP bundle’s Chromium exactly, with a possible one-time cold browser download on first functional use (existing graceful path).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a45d515307a67e8d862c7d0e23c0c5620215d895. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->