### PR TITLE
fix(review): stop AC references from auto-linking to unrelated issues/PRs

### DIFF
--- a/skills/review-context-builder.md
+++ b/skills/review-context-builder.md
@@ -299,6 +299,13 @@ Reviewers Read whichever of these are non-empty themselves.
 ### `## Acceptance criteria` (REQUIRED — the only synthesis you do)
 Extract criteria from the spec sources above. Look for: checkboxes, "should/must/needs to" statements, "Acceptance Criteria" sections, field definitions, validation rules, defaults.
 
+**Label each criterion `AC1`, `AC2`, … (no `#`).** Reviewers cite these labels back in their posted comments; a `#`-prefixed form like `AC #5` gets auto-linked by GitHub to issue/PR #5, producing a wrong cross-reference. Write them as a numbered list whose markers double as the labels, e.g.:
+
+```
+- **AC1** — API returns 400 for an underage user.
+- **AC2** — Adding a participant dispatches a CREATE sync message to external calendars.
+```
+
 **The PR body is usually MIXED, not all-or-nothing.** Bots APPEND their summary to the body without removing the human-written portion. The most common shape: a human types a description explaining the goal/scope/testing notes, then a bot (Cursor, Cursor Bugbot, CodeRabbit, Gemini Code Assist, Claude Code) appends a generated summary below. The HUMAN portion above the AI block is a valid spec source even though the body as a whole contains AI-generated content.
 
 **Strip AI-generated blocks before judging.** Identify and remove these segments from the body, then evaluate what remains:

--- a/skills/review-functional-tester.md
+++ b/skills/review-functional-tester.md
@@ -164,6 +164,8 @@ This is your highest-value check. Compare **every observable detail** against th
 
 **The goal is to catch details that no human reviewer would notice** — a human reviews code, but you actually run it and compare output against spec word-by-word.
 
+**Referencing acceptance criteria in posted text.** When a finding's `title`/`reasoning`/`expected` or the meta `summary` cites a criterion, use the `AC1`/`AC2` labels from context.md — **never** a `#`-prefixed form like `AC #5`. These fields are posted verbatim to GitHub (the `title` is the bold header of every inline comment), which auto-links `#5` to issue/PR #5 and produces a wrong cross-reference. Write `AC5`, not `AC #5`.
+
 ## Output
 
 Always write both files, even on partial completion.

--- a/skills/review-judge.md
+++ b/skills/review-judge.md
@@ -137,6 +137,8 @@ When a manual spec exists (linked issue, PRD, external issue, substantive PR-bod
 
 A PR that compiles cleanly but doesn't do what the spec says is worse than one with a style issue.
 
+**Referencing acceptance criteria in posted text.** When you cite a criterion in `verdict_summary` or in a finding's `title`/`reasoning`/`expected`, use the `AC1`/`AC2` labels from context.md — **never** a `#`-prefixed form like `AC #5`. These fields are posted verbatim to GitHub, which auto-links `#5` to issue/PR #5 and produces a wrong cross-reference. Write `AC5` (or `AC1 and AC2`), not `AC #5`.
+
 ## Rebuttal mode
 
 When the orchestrator launches you with `MODE=rebuttal` in the prompt and includes the **other judge's output** under `OTHER_JUDGE_OUTPUT_PATH`, you are NOT redoing the review from scratch. You are reconciling.


### PR DESCRIPTION
Review comments cited acceptance criteria as `AC #5`, and GitHub auto-links `#5` to issue/PR #5 — so posted comments pointed at unrelated issues and PRs. There was no instruction telling reviewers *how* to cite a criterion, so they reached for the natural `#`-prefixed shorthand.

This defines an `AC1`/`AC2` label convention in the context builder's acceptance-criteria section, and forbids the `#`-prefixed form in the judge's `verdict_summary`/findings and the functional-tester's findings/summary — the three places whose text is posted to GitHub verbatim.

Fixes #45

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to review agent skills; no runtime code, auth, or data paths.
> 
> **Overview**
> Review comments that cited acceptance criteria as `AC #5` were auto-linked by GitHub to unrelated issue/PR **#5**. This PR adds pipeline instructions so posted text uses stable **`AC1`/`AC2`** labels instead.
> 
> The **context builder** now requires labeling each extracted criterion as **`AC1`, `AC2`, …** (no `#`) in `## Acceptance criteria`, with a short example list. The **judge** and **functional tester** skills get matching rules: when citing criteria in fields that are posted verbatim (`verdict_summary`, finding `title`/`reasoning`/`expected`, functional meta `summary`), use **`AC5`** / **`AC1 and AC2`**, never **`AC #5`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75c8ffa29c12246461f6aef1b63d5272b1e194b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->