### PR TITLE
feat(metrics): per-run Claude cost + cost-snapshot tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,10 @@
 # Local Claude Code state — never commit
 .claude/scheduled_tasks.lock
 .claude/settings.local.json
+
+# Private cost/metrics artifacts — internal financial data.
+# This repo is PUBLIC; these contain real per-repo spend + PR costs. Never commit.
+docs/review-pipeline-snapshot.md
+docs/prds/review-cost-reduction.md
+docs/metrics/
+.metrics.env

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+# Convenience wrapper for the cost/metrics tooling (scripts/cost-snapshot.sh).
+#
+# Repo list and owner come from the environment or a local, git-ignored
+# `.metrics.env` — so NO private repo names live in this PUBLIC repo.
+#
+#   make metrics                 # use .metrics.env (REPOS=... etc.) — fast, no Claude $ recovery
+#   make metrics FULL_COST=1     # also recover Claude $ for pre-instrumentation runs (slow)
+#   make metrics REPOS=o/a,o/b   # ad-hoc repo list (overrides .metrics.env)
+#   make metrics OWNER=my-org    # discover an org's repos instead of listing them
+#   make metrics SINCE=30d       # window (default 7d)
+#
+# Output is written to docs/metrics/<date>.md, which is git-ignored (it holds
+# real per-repo spend — internal financial data). Never commit it.
+
+SINCE ?= 7d
+-include .metrics.env
+
+.PHONY: metrics
+metrics:
+	@bash scripts/cost-snapshot.sh \
+	  --since $(SINCE) \
+	  $(if $(REPOS),--repos $(REPOS)) \
+	  $(if $(OWNER),--owner $(OWNER)) \
+	  $(if $(FULL_COST),--full-cost) \
+	  --write docs/metrics/$$(date +%F).md
+	@echo "→ wrote docs/metrics/$$(date +%F).md (git-ignored — internal data)"

--- a/scripts/cost-snapshot.sh
+++ b/scripts/cost-snapshot.sh
@@ -105,7 +105,7 @@ to_iso_since() {
     echo "$input"
   fi
 }
-SINCE_ISO=$(to_iso_since "$SINCE")
+SINCE_ISO=$(to_iso_since "$SINCE") || exit 1   # propagate the subshell's exit (date failure)
 
 # ── repo list ──
 REPO_LIST=()
@@ -212,7 +212,8 @@ for repo in "${REPO_LIST[@]}"; do
   umap_start=$(date +%s)
   USAGE_MAP="$TMP/usage-${repo//\//_}.json"; echo '{}' > "$USAGE_MAP"
   arts=$(gh api --paginate "/repos/$repo/actions/artifacts?per_page=100&name=claude-review-usage" \
-          --jq '.artifacts[]? | select(.created_at >= "'"$SINCE_ISO"'") | {id, run_id: .workflow_run.id}' 2>/dev/null || true)
+          --jq '.artifacts[]? | select(.created_at >= "'"$SINCE_ISO"'") | {id, run_id: .workflow_run.id}' 2>/dev/null \
+          || { log "  ::warning::failed to list usage artifacts for $repo; continuing with empty usage map"; true; })
   uarts=()
   while IFS= read -r meta; do [ -n "$meta" ] && uarts+=("$meta"); done <<< "$arts"
   art_total=${#uarts[@]}

--- a/scripts/cost-snapshot.sh
+++ b/scripts/cost-snapshot.sh
@@ -1,0 +1,392 @@
+#!/usr/bin/env bash
+# cost-snapshot.sh — Measure what the Claude PR Review pipeline actually SPENDS
+# (GitHub Actions runner-minutes + Claude model $) and what it YIELDS (findings,
+# verdicts) across one or more consumer repos, over a time window.
+#
+# This is the before/after ruler: run it now to capture a baseline, make
+# pipeline changes, run it again with the same flags, and diff the two reports.
+#
+# Why it exists separately from usage-report.sh:
+#   usage-report.sh is ARTIFACT-centric — it reads the per-run `claude-review-usage`
+#   artifact, which is only uploaded on a SUCCESSFUL build. That misses every
+#   cancelled/failed run — and cancelled re-runs (a PR repushed 17 times in a
+#   week) are exactly where the Actions burn and the re-run amplification hide.
+#   This tool is RUN-centric: it enumerates the workflow's run history (including
+#   cancelled/failed), reads real wall-time from the timing API for Actions
+#   minutes, and JOINS the usage artifact for verdict/findings/Claude-$ where one
+#   exists.
+#
+# Spend sources:
+#   - Actions minutes  → /repos/{repo}/actions/runs/{id}/timing .run_duration_ms
+#                        (always available; billed = ceil(ms/60000) per run).
+#   - Claude $         → the usage artifact's `claude_cost_usd` field (recorded by
+#                        report-usage.sh). Runs from before that field shipped show
+#                        cost coverage < 100%; the report states the coverage so a
+#                        partial Claude-$ total is never mistaken for the full one.
+#
+# Usage:
+#   bash scripts/cost-snapshot.sh                                  # discover consumers, last 7d
+#   bash scripts/cost-snapshot.sh --repos owner/repo-a,owner/repo-b
+#   bash scripts/cost-snapshot.sh --owner my-org --since 30d --rate 0.008
+#   bash scripts/cost-snapshot.sh --since 7d --write ./review-cost-snapshot.md
+#   bash scripts/cost-snapshot.sh --json > baseline.jsonl         # raw per-run rows
+#   bash scripts/cost-snapshot.sh --full-cost                     # recover Claude $ now (slow)
+#
+# Note: the report contains per-repo spend figures — treat the output as
+# internal/financial data. Don't commit it into a public repo.
+#
+# --full-cost downloads the 7-day full artifact for any run whose usage record
+# lacks claude_cost_usd and greps the cost from it. Use it for a baseline taken
+# BEFORE the report-usage.sh instrumentation has shipped; omit it once consumers
+# are on a release that records claude_cost_usd (then the usage artifact alone
+# carries cost, for 90 days, at no download cost).
+#
+# Per-run fetches run in parallel (JOBS, default 12 — set JOBS=N to tune), so
+# even --full-cost across hundreds of runs is minutes, not tens of minutes.
+#
+# Requires: gh (authenticated, cross-org), jq. With --full-cost: also unzip.
+
+set -uo pipefail
+
+# ── defaults ──
+SINCE="7d"
+REPOS=""
+OWNER=""                       # optional: scope consumer-discovery to one org
+WORKFLOW="Claude PR Review"   # display name (consumer workflow's `name:`)
+RATE="0.008"                  # $/min, private ubuntu-latest 2-core (Mar-2025 list price)
+WRITE_PATH=""
+EMIT_JSON=false
+FULL_COST=false               # recover Claude $ from the 7-day full artifact when
+                              # the usage artifact lacks claude_cost_usd (slow)
+RUN_LIMIT=400                 # per-repo run cap; warns if hit
+
+print_help() { sed -n '2,/^set -uo pipefail$/p' "$0" | sed '$d' | sed 's/^# \{0,1\}//'; }
+
+require_value() {
+  local flag="$1" value="${2:-}"
+  if [ -z "$value" ] || [[ "$value" == -* ]]; then
+    echo "::error::$flag requires a value (e.g. $flag 7d)" >&2; exit 2
+  fi
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --since)    require_value --since "${2:-}";    SINCE="$2";    shift 2 ;;
+    --repos)    require_value --repos "${2:-}";    REPOS="$2";    shift 2 ;;
+    --owner)    require_value --owner "${2:-}";    OWNER="$2";    shift 2 ;;
+    --workflow) require_value --workflow "${2:-}"; WORKFLOW="$2"; shift 2 ;;
+    --rate)     require_value --rate "${2:-}";     RATE="$2";     shift 2 ;;
+    --limit)    require_value --limit "${2:-}";    RUN_LIMIT="$2";shift 2 ;;
+    --write)    require_value --write "${2:-}";    WRITE_PATH="$2";shift 2 ;;
+    --json)     EMIT_JSON=true; shift ;;
+    --full-cost) FULL_COST=true; shift ;;
+    -h|--help)  print_help; exit 0 ;;
+    *) echo "Unknown flag: $1" >&2; echo "Run with --help for usage." >&2; exit 2 ;;
+  esac
+done
+
+# ── prerequisites ──
+NEED=(gh jq)
+[ "$FULL_COST" = true ] && NEED+=(unzip)
+for bin in "${NEED[@]}"; do
+  command -v "$bin" >/dev/null 2>&1 || { echo "::error::missing dependency: $bin" >&2; exit 1; }
+done
+gh auth status >/dev/null 2>&1 || { echo "::error::gh is not authenticated — run 'gh auth login'" >&2; exit 1; }
+
+# ── since → absolute ISO-8601 (BSD date first, GNU fallback) ──
+to_iso_since() {
+  local input="$1"
+  if [[ "$input" =~ ^([0-9]+)d$ ]]; then
+    local n="${BASH_REMATCH[1]}"
+    date -u -v-"${n}"d +%Y-%m-%dT00:00:00Z 2>/dev/null \
+      || date -u -d "${n} days ago" +%Y-%m-%dT00:00:00Z 2>/dev/null \
+      || { echo "::error::cannot compute date for --since=$input" >&2; exit 1; }
+  else
+    echo "$input"
+  fi
+}
+SINCE_ISO=$(to_iso_since "$SINCE")
+
+# ── repo list ──
+REPO_LIST=()
+if [ -n "$REPOS" ]; then
+  IFS=',' read -r -a REPO_LIST <<< "$REPOS"
+else
+  # Discover repos that reference this action in a workflow file (same query
+  # usage-report.sh uses). `uses:` is a search qualifier, so match plain text.
+  # --owner is added only when set, so the default scans every accessible repo.
+  SEARCH_ARGS=(--json repository --jq '.[].repository.nameWithOwner' --limit 100)
+  [ -n "$OWNER" ] && SEARCH_ARGS+=(--owner "$OWNER")
+  while IFS= read -r r; do [ -n "$r" ] && REPO_LIST+=("$r"); done < <(
+    gh search code 'panenco/claude-review path:.github/workflows' "${SEARCH_ARGS[@]}" 2>/dev/null | sort -u
+  )
+fi
+if [ "${#REPO_LIST[@]}" -eq 0 ]; then
+  echo "::warning::no repos to scan — pass --repos owner/a,owner/b or --owner <org>" >&2
+  exit 0
+fi
+
+# ── collect per-run rows as JSONL ──
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+ROWS="$TMP/rows.jsonl"; : > "$ROWS"
+JOBS="${JOBS:-12}"   # parallel workers for the per-run timing/cost fan-out (env-tunable)
+
+# Timestamped progress to stderr (so a long run shows what it's doing + how long).
+log() { printf '[%s] %s\n' "$(date +%H:%M:%S)" "$1" >&2; }
+fmt_elapsed() { local s="$1"; if [ "$s" -ge 60 ]; then printf '%dm%02ds' "$((s/60))" "$((s%60))"; else printf '%ds' "$s"; fi; }
+RUN_START=$(date +%s)
+
+# Process ONE run → emit one JSON row to stdout: fetch timing (+ Claude $ via the
+# usage field, or with --full-cost the full artifact). Pure per-run work so it
+# runs concurrently — reads USAGE_MAP/FULL_COST/TMP as read-only globals.
+process_run() {
+  local repo="$1" rid="$2" ev="$3" concl="$4" branch="$5" created="$6"
+  local ms cost c faid fz
+  ms=$(gh api "/repos/$repo/actions/runs/$rid/timing" --jq '.run_duration_ms // 0' 2>/dev/null || echo 0)
+  [[ "$ms" =~ ^[0-9]+$ ]] || ms=0
+  cost=$(jq -r --arg rid "$rid" '.[$rid].claude_cost_usd // empty' "$USAGE_MAP" 2>/dev/null)
+  if [ -z "$cost" ] && [ "$FULL_COST" = true ] \
+     && { [ "$ev" = "pull_request" ] || [ "$ev" = "workflow_dispatch" ]; } \
+     && { [ "$concl" = "success" ] || [ "$concl" = "failure" ]; }; then
+    faid=$(gh api "/repos/$repo/actions/runs/$rid/artifacts" \
+             --jq '.artifacts[]? | select(.name|test("^claude-review-[0-9]+$")) | .id' 2>/dev/null | head -1)
+    if [ -n "$faid" ]; then
+      fz="$TMP/f-$rid.zip"
+      if gh api "/repos/$repo/actions/artifacts/$faid/zip" > "$fz" 2>/dev/null; then
+        c=$(unzip -p "$fz" 'tmp/orchestrator-output.txt' 2>/dev/null \
+              | grep -oE '"total_cost_usd"[[:space:]]*:[[:space:]]*[0-9]+(\.[0-9]+)?' \
+              | grep -oE '[0-9]+(\.[0-9]+)?$' | sort -g | tail -1)
+        [ -n "$c" ] && cost="$c"
+      fi
+      rm -f "$fz"
+    fi
+  fi
+  if [ -z "$cost" ] || ! printf '%s' "$cost" | grep -qE '^[0-9]+(\.[0-9]+)?$'; then cost="null"; fi
+  jq -nc \
+    --arg repo "$repo" --arg rid "$rid" --arg ev "$ev" --arg concl "$concl" \
+    --arg branch "$branch" --arg created "$created" --argjson ms "$ms" \
+    --argjson cost "$cost" \
+    --slurpfile umap "$USAGE_MAP" '
+    ($umap[0][$rid] // {}) as $u |
+    { repo: $repo, run_id: $rid, event: $ev, conclusion: $concl, branch: $branch,
+      created_at: $created, duration_ms: $ms,
+      billed_min: (if $ms > 0 then (($ms + 59999) / 60000 | floor) else 0 end),
+      verdict: ($u.verdict // null),
+      findings_count: ($u.findings_count // null),
+      functional_strategy: ($u.functional_strategy // null),
+      claude_cost_usd: $cost,
+      has_usage: ($u | has("verdict")) }'
+}
+
+# Download ONE usage artifact + extract its record → emit one {run_id, …} JSON
+# line to stdout. Pure per-artifact work, runs concurrently (no shared state —
+# the caller folds all lines into the map in a single jq pass afterwards).
+load_usage_artifact() {
+  local repo="$1" meta="$2"
+  local aid rid zip payload
+  aid=$(echo "$meta" | jq -r '.id'); rid=$(echo "$meta" | jq -r '.run_id')
+  [ -z "$aid" ] && return
+  zip="$TMP/u-$aid.zip"
+  gh api "/repos/$repo/actions/artifacts/$aid/zip" > "$zip" 2>/dev/null || { rm -f "$zip"; return; }
+  payload=$(unzip -p "$zip" usage.json 2>/dev/null) || { rm -f "$zip"; return; }
+  rm -f "$zip"
+  echo "$payload" | jq -c --arg rid "$rid" '{
+    run_id: $rid,
+    verdict: (.verdict // null),
+    findings_count: (.findings_count // 0),
+    functional_strategy: (.functional_strategy // null),
+    claude_cost_usd: (.claude_cost_usd // null),
+    round: (.round // null)
+  }' 2>/dev/null || true
+}
+
+for repo in "${REPO_LIST[@]}"; do
+  repo="${repo// /}"; [ -z "$repo" ] && continue
+  repo_start=$(date +%s)
+  log "→ $repo"
+
+  # 1) Build a run_id → usage-record map (verdict/findings/strategy/claude_cost).
+  #    Mirror usage-report.sh: list claude-review-usage artifacts, download the
+  #    inner usage.json. Keyed by run_id so the run-list join below is O(1).
+  log "  loading usage records…"
+  umap_start=$(date +%s)
+  USAGE_MAP="$TMP/usage-${repo//\//_}.json"; echo '{}' > "$USAGE_MAP"
+  arts=$(gh api --paginate "/repos/$repo/actions/artifacts?per_page=100&name=claude-review-usage" \
+          --jq '.artifacts[]? | select(.created_at >= "'"$SINCE_ISO"'") | {id, run_id: .workflow_run.id}' 2>/dev/null || true)
+  uarts=()
+  while IFS= read -r meta; do [ -n "$meta" ] && uarts+=("$meta"); done <<< "$arts"
+  art_total=${#uarts[@]}
+  # Download + extract in PARALLEL batches (each worker → one private record file),
+  # then fold them into the map with ONE jq pass below — no shared-state race.
+  rm -f "$TMP"/urow-*.json
+  ui=0
+  while [ "$ui" -lt "$art_total" ]; do
+    bend=$(( ui + JOBS )); [ "$bend" -gt "$art_total" ] && bend="$art_total"
+    k="$ui"
+    while [ "$k" -lt "$bend" ]; do
+      load_usage_artifact "$repo" "${uarts[$k]}" > "$TMP/urow-$k.json" &
+      k=$(( k + 1 ))
+    done
+    wait
+    ui="$bend"
+    printf '\r[%s]   [%s] usage %d/%d' "$(date +%H:%M:%S)" "$repo" "$ui" "$art_total" >&2
+  done
+  [ "$art_total" -gt 0 ] && printf '\n' >&2
+  if ls "$TMP"/urow-*.json >/dev/null 2>&1; then
+    cat "$TMP"/urow-*.json | jq -s 'reduce .[] as $r ({}; . + {($r.run_id): ($r | del(.run_id))})' \
+      > "$USAGE_MAP" 2>/dev/null || echo '{}' > "$USAGE_MAP"
+  fi
+  rm -f "$TMP"/urow-*.json
+  log "  $art_total usage records loaded ($(fmt_elapsed $(( $(date +%s) - umap_start ))))"
+
+  # 2) Enumerate ALL runs of this workflow in the window (incl cancelled/failed).
+  log "  listing runs…"
+  runs=$(gh run list --repo "$repo" --workflow "$WORKFLOW" --created ">=$SINCE_ISO" \
+           --limit "$RUN_LIMIT" \
+           --json databaseId,event,conclusion,status,headBranch,createdAt \
+           --jq '.[] | "\(.databaseId)\t\(.event)\t\(.conclusion // .status)\t\(.headBranch)\t\(.createdAt)"' 2>/dev/null || true)
+  rcount=$(printf '%s\n' "$runs" | grep -c . || true)
+  [ "$rcount" -ge "$RUN_LIMIT" ] && log "  ::warning:: hit --limit $RUN_LIMIT for $repo; raise --limit for a complete count"
+  log "  $rcount runs since $SINCE_ISO"
+
+  # 3) Fetch per-run timing (+ full-cost) in PARALLEL batches — the work is
+  #    network-bound and independent per run, so we fan out JOBS at a time
+  #    (~10–16× faster than serial). Each worker writes its row to a private
+  #    file (no shared-file interleaving); rows are collected after each batch,
+  #    and a live k/N counter prints so a long run never looks stuck.
+  tuples=()
+  while IFS= read -r line; do [ -n "$line" ] && tuples+=("$line"); done <<< "$runs"
+  total=${#tuples[@]}
+  [ "$total" -eq 0 ] && continue
+  rm -f "$TMP"/row-*.json
+  idx=0
+  while [ "$idx" -lt "$total" ]; do
+    batch_end=$(( idx + JOBS )); [ "$batch_end" -gt "$total" ] && batch_end="$total"
+    b="$idx"
+    while [ "$b" -lt "$batch_end" ]; do
+      IFS=$'\t' read -r rid ev concl branch created <<< "${tuples[$b]}"
+      [ -n "$rid" ] && process_run "$repo" "$rid" "$ev" "$concl" "$branch" "$created" > "$TMP/row-$b.json" &
+      b=$(( b + 1 ))
+    done
+    wait
+    idx="$batch_end"
+    printf '\r[%s]   [%s] %d/%d runs' "$(date +%H:%M:%S)" "$repo" "$idx" "$total" >&2
+  done
+  printf '\n' >&2
+  cat "$TMP"/row-*.json >> "$ROWS" 2>/dev/null
+  rm -f "$TMP"/row-*.json
+  log "  ✓ $repo done ($(fmt_elapsed $(( $(date +%s) - repo_start ))))"
+done
+log "✓ all repos done in $(fmt_elapsed $(( $(date +%s) - RUN_START )))"
+
+TOTAL=$(grep -c . "$ROWS" || true)
+if [ "$TOTAL" -eq 0 ]; then
+  echo "::warning::0 runs found across ${#REPO_LIST[@]} repo(s) since $SINCE_ISO." >&2
+  exit 0
+fi
+
+# ── emit raw ──
+if [ "$EMIT_JSON" = true ]; then cat "$ROWS"; exit 0; fi
+
+# ── render markdown ──
+render() {
+  local now_iso; now_iso=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  printf '# Claude Review — cost & yield snapshot\n\n'
+  printf -- '_Generated %s · window %s → %s · rate $%s/runner-min_\n\n' "$now_iso" "$SINCE_ISO" "$now_iso" "$RATE"
+
+  jq -s -r --argjson rate "$RATE" '
+    def money(x): "$" + (x * 100 | round / 100 | tostring);
+    {
+      runs: length,
+      review_runs: ([.[] | select(.event=="pull_request" or .event=="workflow_dispatch")] | length),
+      warm_runs:   ([.[] | select(.event=="pull_request_target")] | length),
+      billed_min:  ([.[] | .billed_min] | add // 0),
+      cancelled:   ([.[] | select(.conclusion=="cancelled")] | length),
+      with_usage:  ([.[] | select(.has_usage)] | length),
+      claude_known:([.[] | select(.claude_cost_usd != null)] | length),
+      claude_sum:  ([.[] | (.claude_cost_usd // 0)] | add // 0),
+      zero_find:   ([.[] | select(.has_usage and (.findings_count // 0) == 0)] | length),
+      tot_find:    ([.[] | (.findings_count // 0)] | add // 0),
+      functional:  ([.[] | select(.functional_strategy=="functional")] | length),
+      skip:        ([.[] | select(.functional_strategy=="skip")] | length)
+    }
+    | "## Spend\n"
+    + "- Runs: **\(.runs)** (\(.review_runs) review + \(.warm_runs) warm-cache; \(.cancelled) cancelled)\n"
+    + "- **Actions: \(.billed_min) runner-min ≈ \(money(.billed_min * $rate))**\n"
+    + "- **Claude: \(money(.claude_sum))** across \(.claude_known)/\(.runs) runs with cost data"
+    + (if .claude_known < .runs then "  ⚠️ partial — runs predate `claude_cost_usd` instrumentation" else "" end) + "\n"
+    + "- Combined (known): **\(money(.billed_min * $rate + .claude_sum))**\n\n"
+    + "## Yield\n"
+    + "- Runs with a usage record: \(.with_usage)\n"
+    + "- **Zero-findings runs: \(.zero_find)/\(.with_usage)" + (if .with_usage>0 then " (\(.zero_find*100/.with_usage|floor)%)" else "" end) + "**\n"
+    + "- Findings raised: \(.tot_find)\n"
+    + "- Strategy: functional \(.functional) · skip \(.skip)\n"
+  ' "$ROWS"
+
+  # Latency — wall-clock per REVIEW run. This is the "reviews take too long"
+  # metric (distinct from runner-min, which is aggregate spend). Tracks how
+  # long an author waits, and how many reviews blow past 10 min.
+  jq -s -r '
+    [.[] | select((.event=="pull_request" or .event=="workflow_dispatch") and ((.duration_ms // 0) > 0)) | (.duration_ms/60000)]
+    | sort as $d | ($d | length) as $n
+    | if $n == 0 then "## Review latency\n- (no completed review runs in window)\n"
+      else
+        ($d[($n*0.5|floor)]) as $med
+        | ($d[([$n-1,($n*0.9|floor)] | min)]) as $p90
+        | ($d[$n-1]) as $max
+        | "## Review latency (wall-clock per review)\n"
+        + "- median **\(($med*10|round)/10) min** · p90 **\(($p90*10|round)/10) min** · max **\(($max*10|round)/10) min**\n"
+        + "- reviews over 10 min: **\([$d[] | select(. > 10)] | length)/\($n)**\n"
+      end
+  ' "$ROWS"
+
+  printf '\n## Per-repo\n\n'
+  printf '%s\n' '| Repo | Runs | Cancelled | Runner-min | Actions $ | Claude $ | Zero-find | Findings |'
+  printf '%s\n' '|---|---:|---:|---:|---:|---:|---:|---:|'
+  jq -s -r --argjson rate "$RATE" '
+    def money(x): "$" + (x * 100 | round / 100 | tostring);
+    group_by(.repo) | map({
+      repo: .[0].repo, runs: length,
+      cancelled: ([.[]|select(.conclusion=="cancelled")]|length),
+      min: ([.[]|.billed_min]|add // 0),
+      claude: ([.[]|(.claude_cost_usd // 0)]|add // 0),
+      zero: ([.[]|select(.has_usage and (.findings_count//0)==0)]|length),
+      find: ([.[]|(.findings_count//0)]|add // 0)
+    }) | sort_by(-.min) | .[] |
+    "| \(.repo) | \(.runs) | \(.cancelled) | \(.min) | \(money(.min*$rate)) | \(money(.claude)) | \(.zero) | \(.find) |"
+  ' "$ROWS"
+
+  # A PR is re-reviewed once per push, so its true cost is the sum across all
+  # its runs. Group pull_request runs by branch (≈ one PR) and total the spend.
+  printf '\n## Most expensive PRs (Σ across all of a PR'\''s runs)\n\n'
+  printf '%s\n' '| Repo · branch | Runs | Σ runner-min | Σ Actions $ | Σ Claude $ |'
+  printf '%s\n' '|---|---:|---:|---:|---:|'
+  jq -s -r --argjson rate "$RATE" '
+    def money(x): "$" + (x * 100 | round / 100 | tostring);
+    [.[] | select(.event=="pull_request")] | group_by(.repo + " " + .branch)
+    | map({k: (.[0].repo + " · " + .[0].branch), n: length,
+           min: ([.[] | .billed_min] | add // 0),
+           claude: ([.[] | (.claude_cost_usd // 0)] | add // 0)})
+    | sort_by(-(.claude + .min * $rate)) | .[0:10][] |
+    "| \(.k) | \(.n) | \(.min) | \(money(.min * $rate)) | \(money(.claude)) |"
+  ' "$ROWS"
+
+  printf '\n## Re-run amplification (top branches by run count)\n\n'
+  printf '%s\n' '| Repo / branch | Runs in window |'
+  printf '%s\n' '|---|---:|'
+  jq -s -r '
+    [.[] | select(.event=="pull_request")] | group_by(.repo + " " + .branch)
+    | map({k: (.[0].repo + " · " + .[0].branch), n: length}) | sort_by(-.n) | .[0:10][] |
+    "| \(.k) | \(.n) |"
+  ' "$ROWS"
+  printf '\n'
+}
+
+if [ -n "$WRITE_PATH" ]; then
+  mkdir -p "$(dirname "$WRITE_PATH")"
+  render > "$WRITE_PATH"
+  echo "Wrote $WRITE_PATH" >&2
+  cat "$WRITE_PATH"
+else
+  render
+fi

--- a/scripts/report-usage.sh
+++ b/scripts/report-usage.sh
@@ -21,6 +21,10 @@
 #   ANALYZER_OUTCOME         — outcome of the analyzer step (success/failure/…)
 #   POSTER_OUTCOME           — outcome of the poster step
 #   PRIOR_STATE_AVAILABLE    — "true" iff this is round 2+
+#
+# Also reads (optional): /tmp/orchestrator-output.txt — the orchestrator's
+# claude-code-action conversation log, copied there by the build step. Used to
+# extract the run's total Claude spend (see CLAUDE_COST below).
 
 set +e
 
@@ -68,6 +72,24 @@ if [ -f /tmp/phase-summary.txt ]; then
   fi
 fi
 
+# Claude spend. The orchestrator's claude-code-action emits a stream-json
+# conversation log; the build step copies it to /tmp/orchestrator-output.txt.
+# Each result message carries a CUMULATIVE "total_cost_usd", and subagent Task
+# costs (the two judges, the functional tester) roll up into the parent run's
+# total — so the LARGEST value in the log is the run's full Claude spend. We
+# record it here so usage.json carries cost in the durable 90-day usage
+# artifact, instead of cost living only in the 7-day full artifact. Best-effort:
+# stays null when the log is absent (crash before the build step) or has no
+# cost line. `sort -g | tail -1` picks the max (final cumulative) value.
+CLAUDE_COST="null"
+if [ -f /tmp/orchestrator-output.txt ]; then
+  _c=$(grep -oE '"total_cost_usd"[[:space:]]*:[[:space:]]*[0-9]+(\.[0-9]+)?' /tmp/orchestrator-output.txt 2>/dev/null \
+        | grep -oE '[0-9]+(\.[0-9]+)?$' | sort -g | tail -1)
+  if [ -n "$_c" ] && printf '%s' "$_c" | grep -qE '^[0-9]+(\.[0-9]+)?$'; then
+    CLAUDE_COST="$_c"
+  fi
+fi
+
 RECORDED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
 
 OUT=/tmp/usage.json
@@ -82,6 +104,7 @@ jq -n \
   --arg poster_outcome "${POSTER_OUTCOME:-}" \
   --argjson round "$ROUND" \
   --argjson phases "$PHASES_JSON" \
+  --argjson claude_cost "$CLAUDE_COST" \
   --slurpfile rr "$RR_TMP" \
   --slurpfile fm "$FM_TMP" \
   '
@@ -107,6 +130,7 @@ jq -n \
                             // (($f.screenshots // []) | length)),
       analyzer_outcome: $analyzer_outcome,
       poster_outcome:   $poster_outcome,
+      claude_cost_usd: $claude_cost,
       phases: $phases
     }
   ' > "$OUT" 2>/dev/null

--- a/tests/report_usage_test.sh
+++ b/tests/report_usage_test.sh
@@ -28,9 +28,10 @@ trap 'rm -rf "$TMP"' EXIT
 USAGE_OUT=/tmp/usage.json
 PHASE_FILE=/tmp/phase-summary.txt
 FN_META=/tmp/functional-meta.json
+ORCH_FILE=/tmp/orchestrator-output.txt
 
 reset_global() {
-  rm -f "$USAGE_OUT" "$PHASE_FILE" "$FN_META"
+  rm -f "$USAGE_OUT" "$PHASE_FILE" "$FN_META" "$ORCH_FILE"
 }
 
 run_case() {
@@ -83,6 +84,7 @@ assert_field "  verdict defaults null"     '.verdict'               'null'
 assert_field "  findings_count defaults 0" '.findings_count'        '0'
 assert_field "  phases is object"          '.phases | type'         'object'
 assert_field "  technical_change=false"    '.technical_change'      'false'
+assert_field "  claude_cost_usd null"      '.claude_cost_usd'       'null'
 
 # ── Case 2: realistic inputs, round 1 ──
 WD2="$TMP/case2"
@@ -192,6 +194,34 @@ assert_field "  phases is object"           '.phases | type'         'object'
 assert_field "  phases.context-build=37"    '.phases."context-build"' '37'
 assert_field "  phases.analyze=120"         '.phases.analyze'         '120'
 assert_field "  phases has 2 keys"          '.phases | keys | length' '2'
+
+# ── Case 7: claude_cost_usd = MAX total_cost_usd in the orchestrator log ──
+# The orchestrator's stream-json log carries a cumulative total_cost_usd that
+# grows over the run; subagent (judge/functional) costs roll into it, so the
+# final/largest value is the run's total Claude spend. report-usage.sh greps
+# the max from /tmp/orchestrator-output.txt.
+WD7="$TMP/case7"
+mkdir -p "$WD7"
+reset_global
+cat > "$ORCH_FILE" <<'EOF'
+{"type":"assistant","message":{"usage":{"output_tokens":10}}}
+{"type":"result","subtype":"success","total_cost_usd":0.69}
+{"type":"result","subtype":"success","total_cost_usd":2.41}
+EOF
+run_case "claude_cost_usd = max total_cost_usd from orchestrator log" "$WD7" \
+  GITHUB_REPOSITORY=owner/repo \
+  || true
+assert_field "  claude_cost_usd=2.41"  '.claude_cost_usd'  '2.41'
+
+# ── Case 8: malformed/absent cost line → claude_cost_usd stays null ──
+WD8="$TMP/case8"
+mkdir -p "$WD8"
+reset_global
+echo '{"type":"result","subtype":"success","no_cost_here":true}' > "$ORCH_FILE"
+run_case "no total_cost_usd in log → claude_cost_usd null" "$WD8" \
+  GITHUB_REPOSITORY=owner/repo \
+  || true
+assert_field "  claude_cost_usd null"  '.claude_cost_usd'  'null'
 
 reset_global
 if [ "$fail" -eq 0 ]; then


### PR DESCRIPTION
## Summary

Measurement layer for an effort to cut the review pipeline's spend (GitHub Actions runner-minutes + Claude model $) and latency. It makes before/after comparisons exact.

**No change to review behavior** — `report-usage.sh` only records one extra best-effort field; everything else is new, local tooling.

## What changed

- **`report-usage.sh`** — record `claude_cost_usd` per run (max `total_cost_usd` from the orchestrator log) into the 90-day `claude-review-usage` artifact, so per-run Claude cost is durable instead of living only in the 7-day full artifact.
- **`cost-snapshot.sh`** (new) — run-centric spend/latency/yield report across consumer repos: Actions minutes (timing API), Claude $ (usage field, or `--full-cost` to recover from full artifacts), per-repo + per-PR rollups, re-run amplification, review latency. Parallel fan-out + timestamped progress.
- **`report_usage_test.sh`** — cover the new `claude_cost_usd` field.
- **`Makefile`** — `make metrics` wrapper; repo list comes from a git-ignored `.metrics.env` so no private repo names live in this public repo.
- **`.gitignore`** — keep generated cost reports out of this **public** repo (they contain internal spend figures).

## Test plan

- [x] `bash tests/report_usage_test.sh` — green (incl. new cost cases)
- [x] `cost-snapshot.sh` verified on a real repo: fast mode + `--full-cost` (Claude $ matches an independent full-artifact tally)
- [x] Only the 5 tooling files committed — no financial data
- [ ] CI shell-tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes (optional cost field + maintainer scripts); review pipeline behavior is unchanged and sensitive outputs are git-ignored.
> 
> **Overview**
> Adds a **measurement layer** so review pipeline spend (Actions minutes + Claude $) and yield can be compared before and after cost work—**without changing review behavior**.
> 
> **`report-usage.sh`** now best-effort records **`claude_cost_usd`** on each run (largest cumulative `total_cost_usd` from `/tmp/orchestrator-output.txt`) into the durable **`claude-review-usage`** artifact, so per-run Claude cost is available for ~90 days instead of only in short-lived full artifacts.
> 
> **`cost-snapshot.sh`** (new) produces run-centric markdown/JSON reports across consumer repos: timing API for runner-minutes (including cancelled/failed runs), join to usage artifacts for verdicts/findings/cost, optional **`--full-cost`** backfill from full artifacts, plus per-repo tables, expensive-PR rollups, re-run amplification, and review latency stats—with parallel **`gh`** fan-out.
> 
> **`make metrics`** wraps the snapshot into git-ignored **`docs/metrics/<date>.md`**; **`.gitignore`** also excludes **`.metrics.env`** and other internal cost docs so a public repo never commits real spend figures. Tests cover the new **`claude_cost_usd`** field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba11af574c62689b37288b0dd2129eace03719ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->