### PR TITLE
feat(review): deterministic review-plan resolver (1a)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,5 +58,8 @@ jobs:
       - name: Run crash_banner_marker_test.sh
         run: bash tests/crash_banner_marker_test.sh
 
+      - name: Run review_plan_test.sh
+        run: bash tests/review_plan_test.sh
+
       - name: Shellcheck scripts (error-level only)
         run: shellcheck --severity=error scripts/*.sh tests/*.sh

--- a/scripts/review-plan.sh
+++ b/scripts/review-plan.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# review-plan.sh — Deterministic PR-shape classifier (the "review-plan resolver").
+#
+# Decides, from a PR's changed files + branch refs + labels, HOW MUCH review the PR
+# warrants — BEFORE any LLM agent runs. Pure function of its inputs (no network, no
+# LLM) so it is unit-testable in isolation (see tests/review_plan_test.sh).
+#
+# Output (KEY=value lines on stdout, ready to append to $GITHUB_OUTPUT):
+#   review_level=full|light|skip
+#   run_functional=true|false
+#   gate=normal|nonruntime|oversized|promotion|label
+#   reason=<human-readable, single line>
+#
+# review_level (consumed by review-orchestrator.md):
+#   full   — dual-judge debate (+ rebuttal); functional per run_functional
+#   light  — single judge, no rebuttal, no functional (cheap pass)
+#   skip   — early-return: no judges; post the reason as a note
+# run_functional — drive the app via the functional tester (only meaningful at `full`)
+# gate           — the classification that produced the decision (stable, for banners)
+#
+# Mapping:
+#   label      → skip  / functional off   (human opted out — respect it)
+#   promotion  → light / functional off   (source already reviewed; cheap insurance)
+#   oversized  → light / functional off   (too big for full; a single judge catches the worst)
+#   nonruntime → full  / functional off   (tests/docs/CI/locks — judges yes, no app-driving)
+#   normal     → full  / functional on
+#
+# Inputs (env; all optional — safe, review-biased defaults):
+#   GATE_FILES_TSV       one "path<TAB>additions<TAB>deletions" line per changed file
+#   GATE_BASE_REF        PR base branch (e.g. main)
+#   GATE_HEAD_REF        PR head branch (e.g. staging)
+#   GATE_LABELS          newline-separated PR label names
+#   GATE_SKIP_LABEL      label that forces a skip (default: skip-review)
+#   GATE_SIZE_CEILING    non-generated changed lines → oversized (default 1500)
+#   GATE_FILE_CEILING    non-generated changed files → oversized (default 40)
+#   GATE_PROMOTION_BASES space-separated release targets (default: main master production prod)
+#   GATE_PROMOTION_HEADS space-separated promotion sources, exact or "<name>/*" prefix
+#                        (default: staging develop dev release hotfix)
+#
+# Design bias: a false-downgrade (miss a bug) is worse than a false-full-review
+# (waste), so anything ambiguous (tsconfig, build/app config, source) counts as
+# RUNTIME and gets a full review. The bot only downgrades when confident.
+
+set -uo pipefail
+
+BASE_REF="${GATE_BASE_REF:-}"
+HEAD_REF="${GATE_HEAD_REF:-}"
+SKIP_LABEL="${GATE_SKIP_LABEL:-skip-review}"
+SIZE_CEILING="${GATE_SIZE_CEILING:-1500}"
+FILE_CEILING="${GATE_FILE_CEILING:-40}"
+PROMO_BASES="${GATE_PROMOTION_BASES:-main master production prod}"
+PROMO_HEADS="${GATE_PROMOTION_HEADS:-staging develop dev release hotfix}"
+
+emit() {
+  # $1 review_level, $2 run_functional, $3 gate, $4 reason
+  printf 'review_level=%s\nrun_functional=%s\ngate=%s\nreason=%s\n' "$1" "$2" "$3" "$4"
+}
+lc() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
+
+# ── 1) Explicit human override: skip label present? (highest precedence) ──
+if [ -n "${GATE_LABELS:-}" ] && printf '%s\n' "$GATE_LABELS" | grep -Fxq "$SKIP_LABEL"; then
+  emit "skip" "false" "label" "Skipping detailed review — '$SKIP_LABEL' label present (reviewed elsewhere / opted out)."
+  exit 0
+fi
+
+# ── 2) Promotion / release PR? base is a release target AND head is a promotion source ──
+is_promotion() {
+  local base head h b ok=1
+  local -a bases heads
+  base=$(lc "$BASE_REF"); head=$(lc "$HEAD_REF")
+  [ -z "$base" ] && return 1
+  read -ra bases <<< "$PROMO_BASES"
+  read -ra heads <<< "$PROMO_HEADS"
+  for b in "${bases[@]}"; do [ "$base" = "$(lc "$b")" ] && ok=0 && break; done
+  [ "$ok" -ne 0 ] && return 1
+  for h in "${heads[@]}"; do
+    h=$(lc "$h")
+    [ "$head" = "$h" ] && return 0
+    case "$head" in "$h"/*) return 0 ;; esac
+  done
+  return 1
+}
+if is_promotion; then
+  emit "light" "false" "promotion" "Release/promotion PR ($HEAD_REF → $BASE_REF): source changes were reviewed on their own PRs — lightweight pass only (single judge, no functional)."
+  exit 0
+fi
+
+# ── File classification ──
+# Excluded from the SIZE count (presence doesn't make a PR "big"):
+is_generated() {
+  case "$1" in
+    *.lock|package-lock.json|pnpm-lock.yaml|*.snap) return 0 ;;
+    dist/*|*/dist/*|build/*|*/build/*|*.min.js|*.min.css|*.generated.*|*.pb.go|*_pb2.py) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+# Non-runtime: a file that cannot change app behavior → functional testing pointless.
+# Conservative: only clearly-non-runtime paths. Ambiguous (tsconfig, *.config.*, app
+# yaml/json, source) is treated as runtime.
+is_nonruntime() {
+  case "$1" in
+    *.spec.*|*.test.*|*_test.*|*.cy.*|*/e2e/*|e2e/*|*/cypress/*|cypress/*|*/__tests__/*|*/tests/*|tests/*|*/test/*|test/*) return 0 ;;
+    *.md|*.mdx|*.txt|docs/*|*/docs/*|LICENSE) return 0 ;;
+    .github/*) return 0 ;;
+    *.lock|package-lock.json|pnpm-lock.yaml|*.snap) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+ng_lines=0; ng_files=0; total_files=0; all_nonruntime=true
+while IFS=$'\t' read -r path adds dels; do
+  [ -z "$path" ] && continue
+  total_files=$(( total_files + 1 ))
+  is_nonruntime "$path" || all_nonruntime=false
+  if ! is_generated "$path"; then
+    ng_files=$(( ng_files + 1 ))
+    [[ "${adds:-}" =~ ^[0-9]+$ ]] && ng_lines=$(( ng_lines + adds ))
+    [[ "${dels:-}" =~ ^[0-9]+$ ]] && ng_lines=$(( ng_lines + dels ))
+  fi
+done <<< "${GATE_FILES_TSV:-}"
+
+# ── 3) Oversized (non-promotion)? Lightweight pass + a "split / label" note ──
+if [ "$ng_lines" -gt "$SIZE_CEILING" ] || [ "$ng_files" -gt "$FILE_CEILING" ]; then
+  emit "light" "false" "oversized" "PR too large for a full review (${ng_files} files, ${ng_lines} non-generated lines; ceiling ${FILE_CEILING} files / ${SIZE_CEILING} lines) — lightweight single-judge pass. Consider splitting (team limit: 400 lines), or add the '$SKIP_LABEL' label if this bundles already-reviewed work."
+  exit 0
+fi
+
+# ── 4) All changed files non-runtime? Full review, but don't drive the app ──
+if [ "$total_files" -gt 0 ] && [ "$all_nonruntime" = true ]; then
+  emit "full" "false" "nonruntime" "All ${total_files} changed files are non-runtime (tests / docs / CI / lockfiles); running the judges but skipping functional app-testing."
+  exit 0
+fi
+
+# ── 5) Normal — full review, functional eligible ──
+emit "full" "true" "normal" "Eligible for full review (${ng_files} runtime-relevant files, ${ng_lines} non-generated lines)."

--- a/tests/review_plan_test.sh
+++ b/tests/review_plan_test.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# review_plan_test.sh — fixture test for scripts/review-plan.sh.
+#
+# The gate is a pure function: (changed files + base/head refs + labels) → a
+# review plan, with no network or LLM. We feed inputs via env and assert the
+# emitted plan as "review_level run_functional gate". No gh / no LLM key required.
+#
+# review_level: full | light | skip   ·   run_functional: true | false
+# gate: normal | nonruntime | oversized | promotion | label
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+SCRIPT="$ROOT/scripts/review-plan.sh"
+fail=0
+
+# summary_of KEY=VAL... → "<review_level> <run_functional> <gate>"
+summary_of() {
+  env "$@" bash "$SCRIPT" | awk -F= '
+    /^review_level=/ {lvl=$2}
+    /^run_functional=/{fn=$2}
+    /^gate=/         {g=$2}
+    END {print lvl, fn, g}'
+}
+
+assert_plan() {
+  local label="$1" want="$2"; shift 2
+  local got; got=$(summary_of "$@")
+  if [ "$got" = "$want" ]; then
+    echo "OK:   $label → $got"
+  else
+    echo "FAIL: $label — want '$want' got '$got'"
+    fail=$((fail + 1))
+  fi
+}
+
+# A 45-file runtime diff (over the default 40-file ceiling), reused below.
+BIG_FILES=$(for i in $(seq 1 45); do printf 'src/f%d.ts\t10\t10\n' "$i"; done)
+
+# ── label → skip (highest precedence) ──
+assert_plan "skip-review label" "skip false label" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_LABELS=$'enhancement\nskip-review' \
+  GATE_FILES_TSV=$'src/app.ts\t40\t5'
+assert_plan "label beats oversized" "skip false label" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_LABELS=$'skip-review' GATE_FILES_TSV="$BIG_FILES"
+assert_plan "unrelated label only → normal" "full true normal" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_LABELS=$'enhancement' GATE_FILES_TSV=$'src/app.ts\t10\t2'
+
+# ── promotion → light (no functional) ──
+assert_plan "staging → main" "light false promotion" \
+  GATE_BASE_REF=main GATE_HEAD_REF=staging GATE_FILES_TSV=$'apps/web/x.ts\t10\t2'
+assert_plan "release/* → production" "light false promotion" \
+  GATE_BASE_REF=production GATE_HEAD_REF=release/2026-06 GATE_FILES_TSV=$'a.ts\t5\t5'
+assert_plan "huge release PR (size irrelevant)" "light false promotion" \
+  GATE_BASE_REF=main GATE_HEAD_REF=staging GATE_FILES_TSV="$BIG_FILES"
+assert_plan "feature → main is NOT a promotion" "full true normal" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'src/app.ts\t10\t2'
+
+# ── oversized → light (no functional) ──
+assert_plan "45 runtime files" "light false oversized" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV="$BIG_FILES"
+assert_plan "2100 changed lines" "light false oversized" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'src/big.ts\t1500\t600'
+assert_plan "huge lockfile ALONE → not oversized (generated excluded)" "full false nonruntime" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'pnpm-lock.yaml\t9000\t9000'
+
+# ── all non-runtime → full review, no functional ──
+assert_plan "test-only migration" "full false nonruntime" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'apps/web/e2e/trajectories.cy.ts\t89\t52'
+assert_plan "docs-only" "full false nonruntime" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'README.md\t10\t0'
+assert_plan "CI workflow only" "full false nonruntime" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'.github/workflows/deploy.yml\t6\t0'
+
+# ── normal → full + functional (incl. conservative ambiguous cases) ──
+assert_plan "runtime source" "full true normal" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'apps/web/src/page.tsx\t40\t5'
+assert_plan "mixed test + runtime" "full true normal" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'src/page.tsx\t10\t2\nsrc/page.test.ts\t20\t0'
+assert_plan "tsconfig.json (ambiguous → runtime)" "full true normal" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'tsconfig.json\t3\t1'
+
+if [ "$fail" -eq 0 ]; then
+  echo
+  echo "All review-plan tests passed."
+  exit 0
+else
+  echo
+  echo "$fail review-plan test assertion(s) failed."
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds `scripts/review-plan.sh` — a deterministic, unit-tested classifier that decides **how much review a PR warrants** from its changed files, branch refs, and labels, *before* any LLM agent runs. This is the decision core for cutting review cost/time (gating the functional tester, light passes, early-skips).

**No behavior change yet** — nothing calls the resolver. The orchestrator + workflow wiring (and the technical-change smoke-gate reconciliation) land in a follow-up PR; this is the tested logic on its own, per a deliberate logic-then-wiring split.

## The plan it emits

`review_level` (full|light|skip) + `run_functional` (true|false) + `gate` + `reason`:

| gate | review_level | functional |
|---|---|---|
| `label` (`skip-review` label) | skip | off |
| `promotion` (staging/release → main) | light | off |
| `oversized` (>40 files / >1500 non-generated lines) | light | off |
| `nonruntime` (tests/docs/CI/lockfiles) | full | off |
| `normal` | full | on |

**Design bias:** anything ambiguous (tsconfig, build/app config, source) counts as runtime → full review. A false-downgrade (miss a bug) is worse than a false-full-review (waste). All thresholds, branch patterns, and the label name are env-configurable.

## Test plan

- [x] `bash tests/review_plan_test.sh` — 16 cases, green (wired into the tests workflow)
- [x] `shellcheck --severity=error` clean
- [ ] CI shell-tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New script and tests only; no production review workflow behavior changes until follow-up wiring.
> 
> **Overview**
> Introduces **`scripts/review-plan.sh`**, a deterministic classifier that maps PR inputs (changed-file TSV, base/head refs, labels) to a review plan **before** any LLM runs: `review_level` (full/light/skip), `run_functional`, `gate`, and `reason`. Precedence is skip label → promotion branches → oversized (non-generated file/line ceilings) → all-non-runtime → normal full review with functional on. Generated paths are excluded from size; ambiguous paths stay “runtime.”
> 
> Adds **`tests/review_plan_test.sh`** with fixture cases for each gate and wires it into **`.github/workflows/tests.yml`**. **Nothing in the repo calls the resolver yet**—orchestrator/workflow integration is deferred.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b172f2209e1b87b8b77f6a8aacc1191b3edec9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->