### PR TITLE
chore(release): add release.sh and document the release process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,11 @@
 SINCE ?= 7d
 -include .metrics.env
 
+.PHONY: release
+release:
+	@test -n "$(VERSION)" || { echo "usage: make release VERSION=vX.Y.Z"; exit 1; }
+	@bash scripts/release.sh $(VERSION)
+
 .PHONY: metrics
 metrics:
 	@bash scripts/cost-snapshot.sh \

--- a/README.md
+++ b/README.md
@@ -484,6 +484,31 @@ The script uses your local `gh` auth (already cross-org), discovers repos via `g
 - `@v1` — frozen at the final v1 release (`b8223a98`, Apr 21 2026). No new fixes are backported here. Repos still on `@v1` continue to work; bump to `@v2` to receive new pipeline fixes (see [Migration: v1 → v2](#migration-v1--v2)).
 - Breaking changes (input/output format changes, new required permissions, verdict-gate additions) bump the major version.
 
+### Releasing a new version (maintainers)
+
+There is **no release automation** — merging to `main` does not publish anything. Consumers pin the floating major tag (`@v2`), so a release is two steps: cut an immutable `vX.Y.Z` rollback anchor at the current `origin/main` tip, then move the floating major tag onto the same commit. Use the script:
+
+```bash
+scripts/release.sh v2.2.0            # publish (or: make release VERSION=v2.2.0)
+scripts/release.sh v2.2.0 --dry-run  # preview the four git commands without pushing
+```
+
+It runs, in this order (immutable tag **first**, so the new tip keeps a stable name even if `v2` is later reverted):
+
+```bash
+git tag v2.2.0 origin/main      # immutable rollback anchor
+git tag -f v2 origin/main       # point floating major at the same tip
+git push origin v2.2.0
+git push origin v2 --force
+```
+
+**Choosing the number:** bump the **minor** for a new capability or config-affecting change, the **patch** for a pure fix. A breaking change bumps the **major** (`v3`) — never force-move the existing major onto a breaking change, since every consumer floats it.
+
+**Before you publish:**
+
+- **Push at idle.** Don't move the major tag while reviews are running — see the **Tag-resolution caveat** near the top of this README (the workflow file and the install step resolve their refs at different moments; moving mid-run can split versions). The script tags `origin/main`, not your local checkout, so a stale local `main` is harmless.
+- **For model changes, confirm the dogfood gate.** This repo self-reviews its own PRs, so the PR's own "In-Depth Review" run exercises the change. Confirm that run reported `judge_health.opus == "ok"` (no silent failover to Haiku) before publishing.
+
 ---
 
 ## Migration: v1 → v2

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -46,7 +46,12 @@ TIP="$(git rev-parse origin/main)"
 # at a DIFFERENT commit than this tip — the real "never re-point a release" rule.
 # Already published at this exact tip → proceed and converge. Local-only (never
 # pushed) → no remote sha, overwritten by the -f cut below.
-REMOTE_VERSION_SHA="$(git ls-remote --tags origin "refs/tags/$VERSION" | cut -f1)"
+#
+# Resolve to the COMMIT, not the ref object: for an annotated tag ls-remote's
+# plain ref is the tag object, so we also request the peeled `^{}` ref and take
+# the last line (the commit). A lightweight tag has no peel and yields the
+# commit directly; an absent tag yields nothing.
+REMOTE_VERSION_SHA="$(git ls-remote origin "refs/tags/$VERSION" "refs/tags/$VERSION^{}" | tail -n1 | cut -f1)"
 if [ -n "$REMOTE_VERSION_SHA" ] && [ "$REMOTE_VERSION_SHA" != "$TIP" ]; then
   echo "error: $VERSION already published at ${REMOTE_VERSION_SHA:0:12}, not origin/main (${TIP:0:12})." >&2
   echo "       Immutable tags are never re-pointed — pick a new version." >&2

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -38,21 +38,29 @@ run() {
 
 git fetch origin --tags --quiet || { echo "error: git fetch failed" >&2; exit 1; }
 
-# Reject only if the immutable tag is already PUBLISHED on the remote — that is
-# the real "never reuse a release" condition. A local-only tag is a leftover
-# from an aborted prior run (e.g. a push that failed after the tag was cut) and
-# must not block a retry, so we check the remote here, not local refs.
-if git ls-remote --tags --exit-code origin "refs/tags/$VERSION" >/dev/null 2>&1; then
-  echo "error: $VERSION already published — immutable tags are never reused." >&2
+TIP="$(git rev-parse origin/main)"
+
+# The script is idempotent: re-running it FINISHES a partially-applied release
+# (e.g. the immutable tag pushed but the major-tag move then failed) instead of
+# dead-ending. Reuse is rejected ONLY when the immutable tag is already published
+# at a DIFFERENT commit than this tip — the real "never re-point a release" rule.
+# Already published at this exact tip → proceed and converge. Local-only (never
+# pushed) → no remote sha, overwritten by the -f cut below.
+REMOTE_VERSION_SHA="$(git ls-remote --tags origin "refs/tags/$VERSION" | cut -f1)"
+if [ -n "$REMOTE_VERSION_SHA" ] && [ "$REMOTE_VERSION_SHA" != "$TIP" ]; then
+  echo "error: $VERSION already published at ${REMOTE_VERSION_SHA:0:12}, not origin/main (${TIP:0:12})." >&2
+  echo "       Immutable tags are never re-pointed — pick a new version." >&2
   exit 1
 fi
 
-echo "→ publishing origin/main tip: $(git --no-pager log --oneline -1 origin/main)"
+echo "→ publishing origin/main tip: $(git --no-pager log --oneline -1 "$TIP")"
 
-# -f only ever overwrites a stale local leftover from an aborted prior run
-# (we proved above the tag is not published), so a retry cuts cleanly.
-run git tag -f "$VERSION" origin/main   # immutable rollback anchor (cut FIRST)
-run git tag -f "$MAJOR" origin/main     # point floating major at the same tip
+# -f makes each step re-runnable: it overwrites a stale local leftover, or
+# re-points to the same already-published tip on a retry — both no-op on the
+# remote (the immutable push is then "up to date"). The major-tag push always
+# runs, so a re-run completes a move that failed the first time.
+run git tag -f "$VERSION" "$TIP"   # immutable rollback anchor (cut FIRST)
+run git tag -f "$MAJOR" "$TIP"     # point floating major at the same tip
 run git push origin "$VERSION"
 run git push origin "$MAJOR" --force
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# release.sh — publish a pipeline change to consumer repos.
+#
+# Two steps: cut an immutable `vX.Y.Z` rollback anchor at the current
+# origin/main tip, then point the floating major tag (`v2`) at the same commit.
+# Consumers pin the floating major; the immutable tag is a known-good rollback
+# point. (Tags origin/main, NOT your local HEAD, which may be stale.)
+#
+#   scripts/release.sh v2.2.0            # publish
+#   scripts/release.sh v2.2.0 --dry-run  # print the commands without pushing
+
+VERSION=""
+DRY_RUN=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    v*)        if [ -n "$VERSION" ]; then echo "error: unexpected extra arg: $arg" >&2; exit 1; fi; VERSION="$arg" ;;
+    *)         echo "error: unknown arg: $arg (usage: scripts/release.sh vX.Y.Z [--dry-run])" >&2; exit 1 ;;
+  esac
+done
+
+[ -n "$VERSION" ] || { echo "usage: scripts/release.sh vX.Y.Z [--dry-run]" >&2; exit 1; }
+[[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "error: version must look like vX.Y.Z (got: $VERSION)" >&2; exit 1; }
+MAJOR="${VERSION%%.*}"   # v2.2.0 -> v2
+
+# run() executes a command, or just prints it in --dry-run mode.
+run() { if [ "$DRY_RUN" -eq 1 ]; then echo "  [dry-run] $*"; else "$@"; fi; }
+
+git fetch origin --tags --quiet
+
+if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+  echo "error: $VERSION already exists — immutable tags are never reused." >&2
+  exit 1
+fi
+
+echo "→ publishing origin/main tip: $(git --no-pager log --oneline -1 origin/main)"
+
+run git tag "$VERSION" origin/main      # immutable rollback anchor (cut FIRST)
+run git tag -f "$MAJOR" origin/main     # point floating major at the same tip
+run git push origin "$VERSION"
+run git push origin "$MAJOR" --force
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "→ dry-run — nothing pushed."
+else
+  echo "→ published $VERSION; $MAJOR now points at $(git --no-pager log --oneline -1 "$VERSION")"
+fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -26,7 +26,10 @@ done
 MAJOR="${VERSION%%.*}"   # v2.2.0 -> v2
 
 # run() executes a command, or just prints it in --dry-run mode.
-run() { if [ "$DRY_RUN" -eq 1 ]; then echo "  [dry-run] $*"; else "$@"; fi; }
+run() {
+  if [ "$DRY_RUN" -eq 1 ]; then echo "  [dry-run] $*"; return; fi
+  "$@"
+}
 
 git fetch origin --tags --quiet
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -38,14 +38,20 @@ run() {
 
 git fetch origin --tags --quiet || { echo "error: git fetch failed" >&2; exit 1; }
 
-if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
-  echo "error: $VERSION already exists — immutable tags are never reused." >&2
+# Reject only if the immutable tag is already PUBLISHED on the remote — that is
+# the real "never reuse a release" condition. A local-only tag is a leftover
+# from an aborted prior run (e.g. a push that failed after the tag was cut) and
+# must not block a retry, so we check the remote here, not local refs.
+if git ls-remote --tags --exit-code origin "refs/tags/$VERSION" >/dev/null 2>&1; then
+  echo "error: $VERSION already published — immutable tags are never reused." >&2
   exit 1
 fi
 
 echo "→ publishing origin/main tip: $(git --no-pager log --oneline -1 origin/main)"
 
-run git tag "$VERSION" origin/main      # immutable rollback anchor (cut FIRST)
+# -f only ever overwrites a stale local leftover from an aborted prior run
+# (we proved above the tag is not published), so a retry cuts cleanly.
+run git tag -f "$VERSION" origin/main   # immutable rollback anchor (cut FIRST)
 run git tag -f "$MAJOR" origin/main     # point floating major at the same tip
 run git push origin "$VERSION"
 run git push origin "$MAJOR" --force

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -27,8 +27,10 @@ done
 [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "error: version must look like vX.Y.Z (got: $VERSION)" >&2; exit 1; }
 MAJOR="${VERSION%%.*}"   # v2.2.0 -> v2
 
-# run() executes a command, or just prints it in --dry-run mode. A failed
-# command aborts the release so a half-applied tag set is never pushed.
+# run CMD... — the --dry-run gate for every side-effecting (tag/push) command.
+# Normal run: executes CMD and aborts the release on failure, so a half-applied
+# tag set is never pushed. --dry-run: prints CMD prefixed with [dry-run] and
+# does nothing. Read-only git queries are called directly, not through run().
 run() {
   if [ "$DRY_RUN" -eq 1 ]; then echo "  [dry-run] $*"; return; fi
   "$@" || { echo "error: command failed: $*" >&2; exit 1; }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-set -euo pipefail
+# No `set -e`: this script fails fast via explicit `|| exit 1` (see run() and
+# the fetch below) so a failed git step never silently continues to a push.
+set -uo pipefail
 
 # release.sh — publish a pipeline change to consumer repos.
 #
@@ -25,13 +27,14 @@ done
 [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "error: version must look like vX.Y.Z (got: $VERSION)" >&2; exit 1; }
 MAJOR="${VERSION%%.*}"   # v2.2.0 -> v2
 
-# run() executes a command, or just prints it in --dry-run mode.
+# run() executes a command, or just prints it in --dry-run mode. A failed
+# command aborts the release so a half-applied tag set is never pushed.
 run() {
   if [ "$DRY_RUN" -eq 1 ]; then echo "  [dry-run] $*"; return; fi
-  "$@"
+  "$@" || { echo "error: command failed: $*" >&2; exit 1; }
 }
 
-git fetch origin --tags --quiet
+git fetch origin --tags --quiet || { echo "error: git fetch failed" >&2; exit 1; }
 
 if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
   echo "error: $VERSION already exists — immutable tags are never reused." >&2


### PR DESCRIPTION
## Summary

Publishing a pipeline change was a manual five-command tag dance that lived only in tribal knowledge. This wraps it in a script and documents the maintainer how-to so anyone can cut a release.

- **`scripts/release.sh vX.Y.Z`** — cuts the immutable `vX.Y.Z` rollback anchor **first**, then force-moves the floating major tag (`v2`) onto the same `origin/main` commit. Tags `origin/main` (not local `HEAD`, which can be stale), refuses to clobber an existing immutable tag, and supports `--dry-run` to preview the commands without pushing.
- **`make release VERSION=vX.Y.Z`** — convenience wrapper matching the existing `make metrics` target.
- **README** — new "Releasing a new version (maintainers)" subsection under `## Versioning`: the two-step model, how to pick minor/patch/major, and the push-at-idle + `judge_health` pre-flight gates.

No behavior change to the pipeline itself — this is release tooling + docs only.

## Test plan

- [x] `shellcheck scripts/release.sh` — clean
- [x] `bash -n scripts/release.sh` — syntax ok
- [x] `scripts/release.sh v2.2.0 --dry-run` — prints the four commands, pushes nothing
- [x] Guard paths fire: bad version format, existing-tag clobber, missing arg
- [ ] First real use will be `v2.2.0` (the actual `v2` move is still a manual, gated decision)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release tooling and documentation only; no pipeline or consumer workflow behavior changes, though maintainers still force-push the floating major tag by design.
> 
> **Overview**
> Adds **maintainer release tooling** so publishing a pipeline version is scripted and documented instead of a manual tag/push sequence.
> 
> **`scripts/release.sh`** tags the current **`origin/main`** tip (not local `HEAD`): creates the immutable **`vX.Y.Z`** tag first, then force-moves the floating major tag (e.g. **`v2`**) to the same commit, and pushes both. It validates semver, supports **`--dry-run`**, refuses to repoint an immutable tag already on a different remote commit, and is written to be **idempotent** on partial failures (peeled `ls-remote` for annotated tags).
> 
> **`make release VERSION=vX.Y.Z`** wraps the script like the existing **`make metrics`** target.
> 
> **README** gains a **"Releasing a new version (maintainers)"** subsection: no CI auto-release, semver bump guidance, **push at idle** (tag-resolution caveat), and **`judge_health.opus == "ok"`** before model-related releases.
> 
> No changes to the review pipeline runtime—docs and release automation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b1ba4f55ec0ad61dec7cb6cfc8ff487a8c49c7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->