### PR TITLE
feat(review): gate functional testing via review-plan resolver (1b)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -309,6 +309,38 @@ jobs:
             echo "Pure docs PR — skipping build setup."
           fi
 
+      # Deterministic review-plan resolver (scripts/review-plan.sh). Classifies the
+      # PR from its changed files + branch refs + labels into a plan — review_level
+      # (full|light|skip) + run_functional — BEFORE any agent runs. Drives the
+      # functional-setup gating below and is passed to the orchestrator. Runs on
+      # every PR (incl docs). Pure/deterministic; unit-tested in tests/review_plan_test.sh.
+      - name: Resolve review plan
+        id: review_plan
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        run: |
+          set -uo pipefail
+          PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --json files,baseRefName,headRefName,labels)
+          GATE_FILES_TSV=$(jq -r '.files[] | "\(.path)\t\(.additions)\t\(.deletions)"' <<< "$PR_JSON")
+          GATE_BASE_REF=$(jq -r '.baseRefName // ""' <<< "$PR_JSON")
+          GATE_HEAD_REF=$(jq -r '.headRefName // ""' <<< "$PR_JSON")
+          GATE_LABELS=$(jq -r '.labels[].name' <<< "$PR_JSON")
+          export GATE_FILES_TSV GATE_BASE_REF GATE_HEAD_REF GATE_LABELS
+          PLAN=$(.review-scripts/review-plan.sh)
+          echo "Review plan:"; echo "$PLAN" | sed 's/^/  /'
+          # Forward to step outputs. review_level/run_functional/gate are simple
+          # tokens; reason is free text → emit via heredoc so spaces/special chars
+          # can't break the KEY=value file.
+          {
+            grep -E '^(review_level|run_functional|gate)=' <<< "$PLAN"
+            echo "reason<<__GATE_EOF__"
+            grep '^reason=' <<< "$PLAN" | cut -d= -f2-
+            echo "__GATE_EOF__"
+          } >> "$GITHUB_OUTPUT"
+
       # Node is installed at the default LTS so npx-based tooling (Playwright
       # install + @playwright/mcp pre-warm below) just works. The review
       # pipeline does NOT install the consumer's dependencies — build / lint
@@ -350,7 +382,7 @@ jobs:
       # mirrors the path the subagent's mcpServers config writes to.
       - name: Cache Playwright assets
         id: pw_cache
-        if: steps.code_check.outputs.needs_build == 'true'
+        if: steps.code_check.outputs.needs_build == 'true' && steps.review_plan.outputs.run_functional == 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
@@ -361,7 +393,7 @@ jobs:
             ${{ runner.os }}-pw-
 
       - name: Install Playwright + MCP
-        if: steps.code_check.outputs.needs_build == 'true'
+        if: steps.code_check.outputs.needs_build == 'true' && steps.review_plan.outputs.run_functional == 'true'
         shell: bash
         run: |
           # set -uo pipefail (no explicit -e) per .github/review-config.md +
@@ -852,7 +884,7 @@ jobs:
       # owning its own dependency install. Without it, no dev-env launches
       # and the functional tester runs in skip strategy.
       - name: Pre-start dev environment (background)
-        if: steps.code_check.outputs.needs_build == 'true' && hashFiles('.github/claude-review/dev-start.sh') != ''
+        if: steps.code_check.outputs.needs_build == 'true' && hashFiles('.github/claude-review/dev-start.sh') != '' && steps.review_plan.outputs.run_functional == 'true'
         id: dev_env_bg
         shell: bash
         env:
@@ -997,6 +1029,10 @@ jobs:
           GITHUB_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
           PRIOR_STATE_AVAILABLE: ${{ steps.prior_state.outputs.available || 'false' }}
+          # Review-plan gate (from the Resolve review plan step). build-review.sh
+          # waives the technical-change smoke withhold when functional was
+          # intentionally gated off (any gate other than 'normal').
+          GATE: ${{ steps.review_plan.outputs.gate }}
           # claude-code-action's JSONL conversation log. build-review.sh greps
           # it for `"error":"rate_limit"` / `hit your limit · resets …` so the
           # quota-specific error annotation fires (instead of a generic crash

--- a/scripts/build-review.sh
+++ b/scripts/build-review.sh
@@ -485,6 +485,20 @@ elif [ "$FUNCTIONAL_OVERALL" = "PASS" ] || [ "$FUNCTIONAL_OVERALL" = "WARN" ]; t
   SMOKE_OK=true
 fi
 
+# Review-plan guard. When the deterministic resolver (review-plan.sh) intentionally
+# gated functional off — any GATE other than 'normal' (promotion / oversized /
+# nonruntime / label) — a missing smoke result is BY DESIGN, not a coverage gap.
+# Waive the technical-change smoke withhold so the verdict reflects the resolver's
+# deliberate decision instead of dropping APPROVE→COMMENT for a smoke we chose not
+# to run. (A 'normal' PR where functional was planned but didn't land still
+# withholds — that's a real gap, not an intentional skip.)
+if [ -n "${GATE:-}" ] && [ "$GATE" != "normal" ]; then
+  if [ "$TECHNICAL_CHANGE" = "true" ] && [ "$SMOKE_OK" != "true" ]; then
+    echo "::notice::Technical-change smoke gate waived — review-plan gate '$GATE' intentionally skipped functional testing."
+  fi
+  SMOKE_OK=true
+fi
+
 # Judge-health safety gate. The orchestrator's degraded paths (both
 # judges crashed, or context-builder crashed) write `/tmp/all-findings.json
 # = []` and a meta with `judge_health.{opus,haiku,cb}` set to "failed"

--- a/tests/round2_inherit_test.sh
+++ b/tests/round2_inherit_test.sh
@@ -30,14 +30,17 @@ assert_eq() {
 }
 
 # decide_smoke <FUNCTIONAL_OK> <FUNCTIONAL_STRATEGY> <FUNCTIONAL_OVERALL> \
-#              <PLANNED_STRATEGY> <PRIOR_FUNCTIONAL_OVERALL>
-# Echoes "<SMOKE_OK> <SMOKE_INHERITED>". Mirrors build-review.sh:534-563.
+#              <PLANNED_STRATEGY> <PRIOR_FUNCTIONAL_OVERALL> [GATE]
+# Echoes "<SMOKE_OK> <SMOKE_INHERITED>". Mirrors build-review.sh's SMOKE_OK
+# block + the review-plan GATE waiver. GATE is optional (defaults empty →
+# no waiver), so the original 5-arg calls below are unaffected.
 decide_smoke() {
   local FUNCTIONAL_OK="$1"
   local FUNCTIONAL_STRATEGY="$2"
   local FUNCTIONAL_OVERALL="$3"
   local PLANNED_STRATEGY="$4"
   local PRIOR_FUNCTIONAL_OVERALL="$5"
+  local GATE="${6:-}"
   local SMOKE_OK=false
   local SMOKE_INHERITED=false
   if [ "${FUNCTIONAL_OK:-1}" -ne 1 ]; then
@@ -48,6 +51,11 @@ decide_smoke() {
       SMOKE_INHERITED=true
     fi
   elif [ "$FUNCTIONAL_OVERALL" = "PASS" ] || [ "$FUNCTIONAL_OVERALL" = "WARN" ]; then
+    SMOKE_OK=true
+  fi
+  # Review-plan guard: a non-'normal' gate (functional intentionally skipped)
+  # waives the smoke requirement. SMOKE_INHERITED stays as-is.
+  if [ -n "$GATE" ] && [ "$GATE" != "normal" ]; then
     SMOKE_OK=true
   fi
   echo "$SMOKE_OK $SMOKE_INHERITED"
@@ -128,6 +136,38 @@ assert_eq "I: functional FAIL — gate fails" \
 assert_eq "J: pipeline-self-test PASS" \
   "true false" \
   "$(decide_smoke 1 pipeline-self-test PASS pipeline-self-test "")"
+
+# ── Review-plan GATE waiver (1b) ──
+# A non-'normal' gate means the resolver intentionally skipped functional, so a
+# missing smoke result must NOT withhold APPROVE. These all use the degraded
+# shape (functional planned, strategy=skip, no inherit) that would otherwise be
+# "false false" — the gate flips SMOKE_OK to true.
+
+# Case S: gate=promotion waives the smoke requirement.
+assert_eq "S: gate=promotion waives smoke" \
+  "true false" \
+  "$(decide_smoke 1 skip PASS functional "" promotion)"
+
+# Case T: gate=oversized waives.
+assert_eq "T: gate=oversized waives smoke" \
+  "true false" \
+  "$(decide_smoke 1 skip PASS functional "" oversized)"
+
+# Case U: gate=nonruntime waives.
+assert_eq "U: gate=nonruntime waives smoke" \
+  "true false" \
+  "$(decide_smoke 1 skip PASS functional "" nonruntime)"
+
+# Case V: gate=normal does NOT waive — a planned-but-unran functional is a real
+#         gap and still withholds (unchanged from the no-gate behavior).
+assert_eq "V: gate=normal does NOT waive (real gap withholds)" \
+  "false false" \
+  "$(decide_smoke 1 skip PASS functional "" normal)"
+
+# Case W: gate empty (pre-1b / non-PR path) → unchanged behavior.
+assert_eq "W: empty gate — unchanged (no waiver)" \
+  "false false" \
+  "$(decide_smoke 1 skip PASS functional "")"
 
 echo
 echo "── Persistence decision ──"


### PR DESCRIPTION
## Summary

Wires the deterministic review-plan resolver (`scripts/review-plan.sh`, landed inert in #48) into the pipeline — the **functional-gate** half of the cost/time work. Targets the biggest per-run spikes: functional runs that fire when they shouldn't.

## What changed

- **`pr-review.yml`** — a new **Resolve review plan** step runs `review-plan.sh` over the PR's files + branch refs + labels and exposes `review_level` / `run_functional` / `gate`. The Playwright cache, Playwright install, and dev-env pre-start now also require `run_functional=true`.
- **`build-review.sh`** — waive the technical-change smoke withhold when the resolver intentionally gated functional off (`gate != normal`), so a gated behavior-preserving change doesn't drop APPROVE→COMMENT for a smoke we deliberately skipped.
- **`round2_inherit_test.sh`** — cover the GATE waiver (cases S–W).

## Effect

Because skipping the dev-env makes the orchestrator's functional dispatch (needs `WEB_READY`) no-op, functional is effectively gated off for promotion / oversized / non-runtime / label PRs — **no prompt change**. Validated against real PRs:

| PR | Shape | Plan |
|---|---|---|
| phill#80 | production release (staging→main) | `light` / no-functional / `promotion` — was a 21-min/$8.74 functional crash |
| qit#6409 | e2e test migration | no-functional / `nonruntime` — was a 10-min/$2.41 misfire |
| qit#6432 | real runtime feature | functional / `normal` ✓ |

The orchestrator judge-savings (`light`=single Sonnet, `skip`=early-return) follow in **1c**.

## Test plan

- [x] `review-plan.sh` classification validated on real PRs (above)
- [x] `bash tests/round2_inherit_test.sh` — green incl. new waiver cases S–W
- [x] `pr-review.yml` parses; `build-review.sh` `bash -n` clean
- [ ] CI shell-tests + dogfood self-review pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when expensive functional runs execute and when APPROVE is withheld for technical PRs without smoke; misclassification could skip needed UI tests or waive smoke incorrectly, though `gate=normal` still withholds on real gaps.
> 
> **Overview**
> Connects the deterministic **`review-plan.sh`** resolver into CI so functional work only runs when the plan says so.
> 
> The workflow adds **Resolve review plan** (files, branch refs, labels → `review_level`, `run_functional`, `gate`) and requires **`run_functional=true`** before Playwright cache/install and background **`dev-start.sh`**. **`build-review.sh`** gets **`GATE`** and **waives** the technical-change smoke withhold when `gate` is not `normal` (intentional functional skip), so gated PRs are not downgraded to COMMENT for missing smoke. **`round2_inherit_test.sh`** adds cases S–W for that waiver.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86c2e52b232ee23ad15731ab27ce5f10f4816ec3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->