### PR TITLE
feat(review): risk-tier the review plan so small PRs get a single-judge pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Two practical wins. (1) **Native rate-limit fast-fail.** `anthropics/claude-code
 
 A single LLM judge can have a bad sample on any given run — miss something subtle, over-grade a defensive note, mis-route a finding to the wrong file. The orchestrator runs **two independent judges with different model strengths** (Opus for deep reasoning, Haiku for cheap broad-coverage finds) and reconciles them: if they agree, the review ships immediately; if they disagree, each judge sees the other's findings and either concedes the ones they missed or defends the ones the other dropped. This catches the long tail where one judge is wrong without paying for it on every PR — most reviews converge on the first round.
 
+> **Not every PR needs that depth.** A deterministic resolver classifies each PR up front and reserves the two-judge debate + functional run for substantial or sensitive changes; small, low-risk PRs take a lighter single-judge pass. See **[Review plan](docs/review-plan.md)** for the tiers, the `skip-review` / `deep-review` labels, and per-repo tuning — and [ADR 0001](docs/adr/0001-risk-tiered-review-depth.md) for why.
+
 ### Round 1 vs round 2
 
 The pipeline persists a small state artifact (`/tmp/review-state.json`) on every successful run — the deduped findings, verdict, head SHA reviewed, and the posted review's GitHub id. On the next push to the same PR, the next run downloads it, computes the diff since that SHA, and the round-2 thread classifier runs alongside the orchestrator. The verdict ladder gains a round-2 layer that's strictly **anti-downgrade**:

--- a/docs/adr/0001-risk-tiered-review-depth.md
+++ b/docs/adr/0001-risk-tiered-review-depth.md
@@ -1,0 +1,77 @@
+---
+status: accepted
+date: 2026-06-04
+---
+
+# 0001 — Risk-tiered review depth
+
+## Context
+
+The review pipeline ran the full treatment on every runtime PR: a dual-judge
+debate (Opus + Haiku, with up to two rebuttal rounds) plus a functional
+app-test. That depth is right for a substantial or risky change, but most PRs
+are small, and a single strong judge is enough for a small, focused diff.
+Running the full debate + functional on everything makes routine reviews slow
+and costly for no extra signal.
+
+## Decision
+
+Review depth scales with the PR. The deterministic resolver
+(`scripts/review-plan.sh`) classifies each PR before any model runs; a runtime
+PR takes one of two paths:
+
+- **small** — at or under `GATE_SMALL_CEILING` (default **300**) non-generated
+  changed lines, with no sensitive paths → a single-judge `light` pass, no
+  functional.
+- **full** — over the ceiling, **or** it touches a sensitive path → the
+  dual-judge debate + functional.
+
+Two overrides:
+
+- A **`deep-review`** label forces `full` on a PR that would otherwise be
+  downgraded (promotion / oversized / small). It mirrors the existing
+  `skip-review` label; if both are present, `skip-review` wins.
+- **Sensitive paths** (`GATE_SENSITIVE_GLOBS`) force `full` regardless of size —
+  `auth.*` files and `oauth` / `authentication` / `authorization` / `security` /
+  `payments` / `migrations` directories by default.
+
+### Why 300
+
+300 non-generated lines sits at the shoulder of the real PR-size distribution
+(most PRs are well under it) and below the common 400-line-per-PR guideline, so
+the debate is reserved for the larger and over-limit PRs, not routine changes.
+
+### Why a bare `auth/` directory is NOT sensitive by default
+
+It is tempting to treat any `auth/` directory as sensitive. But many frontends
+use `views/auth/` (or `pages/auth/`) as the *signed-in route group* — the entire
+authenticated area of the app lives under it. Flagging that would force almost
+every frontend PR into a full review, defeating the purpose. The default
+therefore matches auth *files* (`auth.*`) and unambiguous full-word directories;
+a repo whose `auth/` holds real auth logic opts it back in via
+`GATE_SENSITIVE_GLOBS`.
+
+## Considered options
+
+- **Keep the full debate on every PR.** Simplest, but leaves routine reviews
+  slow and costly — the problem being solved.
+- **Single judge on every PR.** Fastest, but drops the second perspective and
+  rebuttal on the large/sensitive changes where they matter most.
+- **Risk-tiered (chosen).** Single judge for small/safe PRs, full debate for
+  substantial or sensitive ones — fast where it's safe, deep where it counts.
+- **Auto-escalate** a single-judge pass to the full debate on a blocking
+  finding. Deferred — it adds two-phase orchestration; revisit only if real
+  misses appear. The `deep-review` label covers the manual case.
+
+## Consequences
+
+- Most PRs get a faster, cheaper single-judge review.
+- A small change to genuinely risky code (auth logic, payments, migrations,
+  security) still gets the full debate via the sensitive-path rule.
+- The classification is a pure, no-LLM function of the diff + branch + labels —
+  deterministic and unit-tested (`tests/review_plan_test.sh`).
+- It is *structural*, not *semantic*: it cannot tell that a 40-line change is
+  unusually risky unless its path says so. `deep-review` is the manual override.
+- Realized in two steps: the resolver classification (which also turns
+  functional off for `small`), then the orchestrator honoring `light` with a
+  single judge.

--- a/docs/review-plan.md
+++ b/docs/review-plan.md
@@ -1,0 +1,93 @@
+# Review plan — how much review a PR gets
+
+Before any model runs, claude-review classifies each PR with a deterministic,
+no-LLM resolver ([`scripts/review-plan.sh`](../scripts/review-plan.sh)) into a
+**review plan**. This keeps routine PRs fast and cheap while reserving the deep,
+two-judge review for substantial or risky changes.
+
+## The plan
+
+Each PR resolves to a `review_level`, whether functional app-testing runs, and a
+`gate` (the reason). The resolver checks these in order and stops at the first
+match:
+
+| # | gate | when | review_level | functional |
+|---|------|------|--------------|------------|
+| 1 | `label` | `skip-review` label present | `skip` | no |
+| 2 | `promotion` | release/promotion PR (e.g. `staging` → `main`) | `light` | no |
+| 3 | `oversized` | over the size ceiling (default 1500 lines / 40 files) | `light` | no |
+| 4 | `nonruntime` | only tests / docs / CI / lockfiles changed | `full` | no |
+| 5 | `small` | ≤ 300 non-generated lines, no sensitive paths | `light` | no |
+| 6 | `normal` | substantial, **or** touches a sensitive path | `full` | yes |
+
+- **`full`** — the dual-judge debate (Opus + Haiku, with rebuttal).
+- **`light`** — a single judge, no rebuttal, no functional. The fast path.
+- **`skip`** — no judges; the reason is posted as a note.
+
+> Generated files (lockfiles, snapshots, `dist/`, `*.min.*`, `*.generated.*`, …)
+> don't count toward the size — a big lockfile bump alone won't push a small PR
+> into `full`.
+
+A `deep-review` label (see below) flips rungs 2, 3, and 5 to `full`.
+
+> **Rollout:** the classification above — and turning functional off for `light` —
+> is live now. The orchestrator's single-judge handling for `light` lands alongside
+> it; until that ships, a `light` PR is classified correctly and skips functional but
+> still runs the two-judge debate. See [ADR 0001](adr/0001-risk-tiered-review-depth.md).
+
+## Labels
+
+| label | effect |
+|-------|--------|
+| `skip-review` | Skip the detailed review entirely (e.g. already reviewed elsewhere). Highest precedence. |
+| `deep-review` | Force a **full** review on a PR that would otherwise be downgraded (promotion / oversized / small). The mirror of `skip-review`. |
+
+If both labels are on a PR, **`skip-review` wins**.
+
+## Per-repo tuning
+
+Every knob is an environment variable with a safe default. Set it on the
+`env:` of the job that calls the reusable workflow to tune behavior per repo:
+
+| variable | default | meaning |
+|----------|---------|---------|
+| `GATE_SMALL_CEILING` | `300` | non-generated lines at/under which a runtime PR is `small` (single judge) |
+| `GATE_SIZE_CEILING` | `1500` | non-generated lines over which a PR is `oversized` |
+| `GATE_FILE_CEILING` | `40` | changed files over which a PR is `oversized` |
+| `GATE_SENSITIVE_GLOBS` | auth.* / oauth / authentication / authorization / security / payments / migrations | path globs that force `full` even when small |
+| `GATE_DEEP_LABEL` | `deep-review` | label that forces a full review |
+| `GATE_SKIP_LABEL` | `skip-review` | label that skips review |
+| `GATE_PROMOTION_BASES` | `main master production prod` | base branches treated as release targets |
+| `GATE_PROMOTION_HEADS` | `staging develop dev release hotfix` | head branches treated as promotion sources |
+
+### Sensitive paths and the `auth/` caveat
+
+Sensitive paths force a full review no matter how small the diff — for code
+where a single judge isn't enough (authentication logic, payments, DB
+migrations, security).
+
+A **bare `auth/` directory is deliberately not sensitive by default.** Many
+frontends use `views/auth/` (or `pages/auth/`) as the *signed-in route group* —
+the whole authenticated area of the app — so flagging it would force nearly
+every frontend PR into a full review. The default matches auth *files*
+(`auth.*`) and unambiguous directories (`authentication/`, `oauth/`, …) instead.
+
+If your repo keeps real auth logic in an `auth/` directory, opt it back in.
+Note that setting the variable **replaces** the default list, so include
+everything you want treated as sensitive:
+
+```yaml
+# in the env: of your caller workflow's job
+GATE_SENSITIVE_GLOBS: "*/auth/* */oauth/* */security/* */payments/* */migrations/*"
+```
+
+## Examples
+
+| PR | gate | what runs |
+|----|------|-----------|
+| 40-line bug fix in `src/` | `small` | single-judge `light`, fast |
+| 500-line feature | `normal` | full debate + functional |
+| 20-line change in `database/migrations/` | `normal` (sensitive) | full debate + functional |
+| `staging` → `main` release | `promotion` | single-judge `light` |
+| docs-only PR | `nonruntime` | judges run, no functional |
+| small but tricky PR you want fully reviewed | add `deep-review` | full debate + functional |

--- a/scripts/review-plan.sh
+++ b/scripts/review-plan.sh
@@ -8,7 +8,7 @@
 # Output (KEY=value lines on stdout, ready to append to $GITHUB_OUTPUT):
 #   review_level=full|light|skip
 #   run_functional=true|false
-#   gate=normal|nonruntime|oversized|promotion|label
+#   gate=normal|nonruntime|oversized|promotion|label|small
 #   reason=<human-readable, single line>
 #
 # review_level (consumed by review-orchestrator.md):
@@ -19,11 +19,14 @@
 # gate           — the classification that produced the decision (stable, for banners)
 #
 # Mapping:
-#   label      → skip  / functional off   (human opted out — respect it)
-#   promotion  → light / functional off   (source already reviewed; cheap insurance)
-#   oversized  → light / functional off   (too big for full; a single judge catches the worst)
-#   nonruntime → full  / functional off   (tests/docs/CI/locks — judges yes, no app-driving)
-#   normal     → full  / functional on
+#   label       → skip  / functional off   (human opted out — respect it; beats deep-review if both)
+#   deep-review → full  / functional on    (label; forces full — suppresses promotion/oversized/small.
+#                                           Does NOT turn functional on for an all-nonruntime PR.)
+#   promotion   → light / functional off   (source already reviewed; cheap insurance)
+#   oversized   → light / functional off   (too big for full; a single judge catches the worst)
+#   nonruntime  → full  / functional off   (tests/docs/CI/locks — judges yes, no app-driving)
+#   small       → light / functional off   (<= GATE_SMALL_CEILING non-gen lines, no sensitive paths)
+#   normal      → full  / functional on    (substantial, OR touches a sensitive path)
 #
 # Inputs (env; all optional — safe, review-biased defaults):
 #   GATE_FILES_TSV       one "path<TAB>additions<TAB>deletions" line per changed file
@@ -31,8 +34,15 @@
 #   GATE_HEAD_REF        PR head branch (e.g. staging)
 #   GATE_LABELS          newline-separated PR label names
 #   GATE_SKIP_LABEL      label that forces a skip (default: skip-review)
+#   GATE_DEEP_LABEL      label that forces a full review (default: deep-review)
 #   GATE_SIZE_CEILING    non-generated changed lines → oversized (default 1500)
 #   GATE_FILE_CEILING    non-generated changed files → oversized (default 40)
+#   GATE_SMALL_CEILING   non-gen lines at/under which a runtime PR → small/light (default 300)
+#   GATE_SENSITIVE_GLOBS space-separated path globs that force full even when small
+#                        (default: auth.* / oauth / authentication / authorization /
+#                        security / payments / migrations. A bare "auth/" dir is NOT
+#                        sensitive by default — frontends use views/auth/ as the signed-in
+#                        route group; add "*/auth/*" per-repo if yours holds auth logic.)
 #   GATE_PROMOTION_BASES space-separated release targets (default: main master production prod)
 #   GATE_PROMOTION_HEADS space-separated promotion sources, exact or "<name>/*" prefix
 #                        (default: staging develop dev release hotfix)
@@ -46,10 +56,13 @@ set -uo pipefail
 BASE_REF="${GATE_BASE_REF:-}"
 HEAD_REF="${GATE_HEAD_REF:-}"
 SKIP_LABEL="${GATE_SKIP_LABEL:-skip-review}"
+DEEP_LABEL="${GATE_DEEP_LABEL:-deep-review}"
 SIZE_CEILING="${GATE_SIZE_CEILING:-1500}"
 FILE_CEILING="${GATE_FILE_CEILING:-40}"
+SMALL_CEILING="${GATE_SMALL_CEILING:-300}"
 PROMO_BASES="${GATE_PROMOTION_BASES:-main master production prod}"
 PROMO_HEADS="${GATE_PROMOTION_HEADS:-staging develop dev release hotfix}"
+SENSITIVE_GLOBS="${GATE_SENSITIVE_GLOBS:-*auth.* */oauth/* oauth.* */authentication/* authentication/* */authorization/* authorization/* */security/* security/* */payments/* payments/* */payment/* payment/* */migrations/* migrations/* */migration/* migration/*}"
 
 emit() {
   # $1 review_level, $2 run_functional, $3 gate, $4 reason
@@ -61,6 +74,13 @@ lc() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
 if [ -n "${GATE_LABELS:-}" ] && printf '%s\n' "$GATE_LABELS" | grep -Fxq "$SKIP_LABEL"; then
   emit "skip" "false" "label" "Skipping detailed review — '$SKIP_LABEL' label present (reviewed elsewhere / opted out)."
   exit 0
+fi
+
+# ── 1b) deep-review label → force a full review (suppresses the light downgrades
+#        below). skip-review (above) wins if both labels are present. ──
+FORCE_FULL=false
+if [ -n "${GATE_LABELS:-}" ] && printf '%s\n' "$GATE_LABELS" | grep -Fxq "$DEEP_LABEL"; then
+  FORCE_FULL=true
 fi
 
 # ── 2) Promotion / release PR? base is a release target AND head is a promotion source ──
@@ -80,7 +100,7 @@ is_promotion() {
   done
   return 1
 }
-if is_promotion; then
+if [ "$FORCE_FULL" = false ] && is_promotion; then
   emit "light" "false" "promotion" "Release/promotion PR ($HEAD_REF → $BASE_REF): source changes were reviewed on their own PRs — lightweight pass only (single judge, no functional)."
   exit 0
 fi
@@ -106,8 +126,21 @@ is_nonruntime() {
     *) return 1 ;;
   esac
 }
+# Sensitive: high-risk runtime areas where a single judge isn't enough — these force
+# a full review even when the diff is small. Configurable via GATE_SENSITIVE_GLOBS.
+is_sensitive() {
+  [ -n "$SENSITIVE_GLOBS" ] || return 1
+  local p g; local -a globs
+  p=$(lc "$1")
+  read -ra globs <<< "$SENSITIVE_GLOBS"
+  for g in "${globs[@]}"; do
+    # shellcheck disable=SC2254  # $g is intentionally a glob pattern, not a literal
+    case "$p" in $g) return 0 ;; esac
+  done
+  return 1
+}
 
-ng_lines=0; ng_files=0; total_files=0; all_nonruntime=true
+ng_lines=0; ng_files=0; total_files=0; all_nonruntime=true; has_sensitive=false
 while IFS=$'\t' read -r path adds dels; do
   [ -z "$path" ] && continue
   total_files=$(( total_files + 1 ))
@@ -116,11 +149,12 @@ while IFS=$'\t' read -r path adds dels; do
     ng_files=$(( ng_files + 1 ))
     [[ "${adds:-}" =~ ^[0-9]+$ ]] && ng_lines=$(( ng_lines + adds ))
     [[ "${dels:-}" =~ ^[0-9]+$ ]] && ng_lines=$(( ng_lines + dels ))
+    is_sensitive "$path" && has_sensitive=true
   fi
 done <<< "${GATE_FILES_TSV:-}"
 
 # ── 3) Oversized (non-promotion)? Lightweight pass + a "split / label" note ──
-if [ "$ng_lines" -gt "$SIZE_CEILING" ] || [ "$ng_files" -gt "$FILE_CEILING" ]; then
+if [ "$FORCE_FULL" = false ] && { [ "$ng_lines" -gt "$SIZE_CEILING" ] || [ "$ng_files" -gt "$FILE_CEILING" ]; }; then
   emit "light" "false" "oversized" "PR too large for a full review (${ng_files} files, ${ng_lines} non-generated lines; ceiling ${FILE_CEILING} files / ${SIZE_CEILING} lines) — lightweight single-judge pass. Consider splitting (team limit: 400 lines), or add the '$SKIP_LABEL' label if this bundles already-reviewed work."
   exit 0
 fi
@@ -131,5 +165,12 @@ if [ "$total_files" -gt 0 ] && [ "$all_nonruntime" = true ]; then
   exit 0
 fi
 
-# ── 5) Normal — full review, functional eligible ──
+# ── 5) Small, non-sensitive runtime change? One judge is enough — skip the debate
+#       and functional. Sensitive paths / the deep-review label fall through to full. ──
+if [ "$total_files" -gt 0 ] && [ "$FORCE_FULL" = false ] && [ "$has_sensitive" = false ] && [ "$ng_lines" -le "$SMALL_CEILING" ]; then
+  emit "light" "false" "small" "Small runtime change (${ng_files} files, ${ng_lines} non-generated lines, at/under the ${SMALL_CEILING}-line small-PR ceiling; no sensitive paths) — lightweight single-judge pass. Add the '$DEEP_LABEL' label to force a full review."
+  exit 0
+fi
+
+# ── 6) Normal — full review, functional eligible (substantial, or sensitive paths) ──
 emit "full" "true" "normal" "Eligible for full review (${ng_files} runtime-relevant files, ${ng_lines} non-generated lines)."

--- a/scripts/review-plan.sh
+++ b/scripts/review-plan.sh
@@ -145,16 +145,25 @@ while IFS=$'\t' read -r path adds dels; do
   [ -z "$path" ] && continue
   total_files=$(( total_files + 1 ))
   is_nonruntime "$path" || all_nonruntime=false
+  # Sensitivity is a property of the path (generated or not): a touch under a
+  # sensitive glob forces a full review even if it doesn't count toward size.
+  is_sensitive "$path" && has_sensitive=true
   if ! is_generated "$path"; then
     ng_files=$(( ng_files + 1 ))
     [[ "${adds:-}" =~ ^[0-9]+$ ]] && ng_lines=$(( ng_lines + adds ))
     [[ "${dels:-}" =~ ^[0-9]+$ ]] && ng_lines=$(( ng_lines + dels ))
-    is_sensitive "$path" && has_sensitive=true
   fi
 done <<< "${GATE_FILES_TSV:-}"
 
-# ── 3) Oversized (non-promotion)? Lightweight pass + a "split / label" note ──
-if [ "$FORCE_FULL" = false ] && { [ "$ng_lines" -gt "$SIZE_CEILING" ] || [ "$ng_files" -gt "$FILE_CEILING" ]; }; then
+# Size verdict, precomputed so the guard below stays a simple check.
+oversized=false
+if [ "$ng_lines" -gt "$SIZE_CEILING" ] || [ "$ng_files" -gt "$FILE_CEILING" ]; then
+  oversized=true
+fi
+
+# ── 3) Oversized (non-promotion)? Lightweight pass + a "split / label" note.
+#       deep-review (FORCE_FULL) suppresses this downgrade. ──
+if [ "$FORCE_FULL" = false ] && [ "$oversized" = true ]; then
   emit "light" "false" "oversized" "PR too large for a full review (${ng_files} files, ${ng_lines} non-generated lines; ceiling ${FILE_CEILING} files / ${SIZE_CEILING} lines) — lightweight single-judge pass. Consider splitting (team limit: 400 lines), or add the '$SKIP_LABEL' label if this bundles already-reviewed work."
   exit 0
 fi
@@ -165,9 +174,10 @@ if [ "$total_files" -gt 0 ] && [ "$all_nonruntime" = true ]; then
   exit 0
 fi
 
-# ── 5) Small, non-sensitive runtime change? One judge is enough — skip the debate
-#       and functional. Sensitive paths / the deep-review label fall through to full. ──
-if [ "$total_files" -gt 0 ] && [ "$FORCE_FULL" = false ] && [ "$has_sensitive" = false ] && [ "$ng_lines" -le "$SMALL_CEILING" ]; then
+# ── 5) Small, non-sensitive runtime change with real (non-generated) source? One
+#       judge is enough — skip the debate and functional. All-generated diffs,
+#       sensitive paths, and the deep-review label fall through to full. ──
+if [ "$ng_files" -gt 0 ] && [ "$FORCE_FULL" = false ] && [ "$has_sensitive" = false ] && [ "$ng_lines" -le "$SMALL_CEILING" ]; then
   emit "light" "false" "small" "Small runtime change (${ng_files} files, ${ng_lines} non-generated lines, at/under the ${SMALL_CEILING}-line small-PR ceiling; no sensitive paths) — lightweight single-judge pass. Add the '$DEEP_LABEL' label to force a full review."
   exit 0
 fi

--- a/tests/review_plan_test.sh
+++ b/tests/review_plan_test.sh
@@ -8,7 +8,7 @@ set -uo pipefail
 # emitted plan as "review_level run_functional gate". No gh / no LLM key required.
 #
 # review_level: full | light | skip   ·   run_functional: true | false
-# gate: normal | nonruntime | oversized | promotion | label
+# gate: normal | nonruntime | oversized | promotion | label | small
 
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
 SCRIPT="$ROOT/scripts/review-plan.sh"
@@ -43,8 +43,8 @@ assert_plan "skip-review label" "skip false label" \
   GATE_FILES_TSV=$'src/app.ts\t40\t5'
 assert_plan "label beats oversized" "skip false label" \
   GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_LABELS=$'skip-review' GATE_FILES_TSV="$BIG_FILES"
-assert_plan "unrelated label only → normal" "full true normal" \
-  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_LABELS=$'enhancement' GATE_FILES_TSV=$'src/app.ts\t10\t2'
+assert_plan "unrelated label only → normal (large diff)" "full true normal" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_LABELS=$'enhancement' GATE_FILES_TSV=$'src/app.ts\t250\t100'
 
 # ── promotion → light (no functional) ──
 assert_plan "staging → main" "light false promotion" \
@@ -53,8 +53,8 @@ assert_plan "release/* → production" "light false promotion" \
   GATE_BASE_REF=production GATE_HEAD_REF=release/2026-06 GATE_FILES_TSV=$'a.ts\t5\t5'
 assert_plan "huge release PR (size irrelevant)" "light false promotion" \
   GATE_BASE_REF=main GATE_HEAD_REF=staging GATE_FILES_TSV="$BIG_FILES"
-assert_plan "feature → main is NOT a promotion" "full true normal" \
-  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'src/app.ts\t10\t2'
+assert_plan "feature → main is NOT a promotion (large diff)" "full true normal" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'src/app.ts\t250\t100'
 
 # ── oversized → light (no functional) ──
 assert_plan "45 runtime files" "light false oversized" \
@@ -72,13 +72,57 @@ assert_plan "docs-only" "full false nonruntime" \
 assert_plan "CI workflow only" "full false nonruntime" \
   GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'.github/workflows/deploy.yml\t6\t0'
 
-# ── normal → full + functional (incl. conservative ambiguous cases) ──
-assert_plan "runtime source" "full true normal" \
-  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'apps/web/src/page.tsx\t40\t5'
-assert_plan "mixed test + runtime" "full true normal" \
-  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'src/page.tsx\t10\t2\nsrc/page.test.ts\t20\t0'
-assert_plan "tsconfig.json (ambiguous → runtime)" "full true normal" \
+# ── normal → full + functional (substantial runtime, incl. ambiguous cases) ──
+assert_plan "runtime source (large)" "full true normal" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'apps/web/src/page.tsx\t250\t100'
+assert_plan "mixed test + runtime (large)" "full true normal" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'src/page.tsx\t250\t100\nsrc/page.test.ts\t20\t0'
+
+# ── small runtime change → light/small (single judge, no functional) [NEW] ──
+assert_plan "small runtime source" "light false small" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'src/util.ts\t40\t5'
+assert_plan "tsconfig (ambiguous → runtime, small)" "light false small" \
   GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'tsconfig.json\t3\t1'
+assert_plan "exactly at the 300 ceiling → still small" "light false small" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'src/a.ts\t200\t100'
+assert_plan "one line over the ceiling (301) → normal" "full true normal" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'src/a.ts\t200\t101'
+assert_plan "generated lines don't count toward the ceiling → small" "light false small" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'src/a.ts\t50\t10\npnpm-lock.yaml\t5000\t5000'
+
+# ── sensitive paths force a full review even when small [NEW] ──
+assert_plan "auth.* file → full" "full true normal" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'src/services/auth.service.ts\t10\t2'
+assert_plan "authentication/ dir → full" "full true normal" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'src/authentication/jwt.ts\t8\t1'
+assert_plan "oauth/ dir → full" "full true normal" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'src/oauth/google-callback.ts\t12\t0'
+assert_plan "small payments/ change → full" "full true normal" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'apps/api/src/payments/charge.ts\t8\t1'
+assert_plan "small DB migration → full" "full true normal" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'apps/api/database/migrations/2026_06_03_fk.php\t12\t0'
+# A bare auth/ dir is a route group (views/auth/ = the signed-in area), NOT auth logic
+# — it must NOT be force-full by default, else every frontend PR pays for it.
+assert_plan "bare views/auth/ route group → small (not sensitive)" "light false small" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'apps/web/src/views/auth/dossier/inpress.vue\t10\t2'
+assert_plan "'author.ts' is NOT sensitive (no false match)" "light false small" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'src/models/author.ts\t10\t2'
+# A repo whose auth/ holds real logic can opt it back in (and the env var overrides the default).
+assert_plan "opt-in '*/auth/*' via GATE_SENSITIVE_GLOBS → full" "full true normal" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_SENSITIVE_GLOBS='*/auth/*' \
+  GATE_FILES_TSV=$'apps/web/src/views/auth/dossier/inpress.vue\t10\t2'
+
+# ── deep-review label forces full (overrides the light downgrades) [NEW] ──
+assert_plan "deep-review on a small PR → full" "full true normal" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_LABELS=$'deep-review' GATE_FILES_TSV=$'src/util.ts\t10\t2'
+assert_plan "deep-review on a promotion → full" "full true normal" \
+  GATE_BASE_REF=main GATE_HEAD_REF=staging GATE_LABELS=$'deep-review' GATE_FILES_TSV=$'apps/web/x.ts\t10\t2'
+assert_plan "deep-review on an oversized PR → full" "full true normal" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_LABELS=$'deep-review' GATE_FILES_TSV="$BIG_FILES"
+assert_plan "deep-review on docs → still nonruntime (functional NOT forced)" "full false nonruntime" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_LABELS=$'deep-review' GATE_FILES_TSV=$'README.md\t10\t0'
+assert_plan "skip-review beats deep-review" "skip false label" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_LABELS=$'deep-review\nskip-review' GATE_FILES_TSV=$'src/util.ts\t10\t2'
 
 if [ "$fail" -eq 0 ]; then
   echo

--- a/tests/review_plan_test.sh
+++ b/tests/review_plan_test.sh
@@ -89,6 +89,9 @@ assert_plan "one line over the ceiling (301) → normal" "full true normal" \
   GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'src/a.ts\t200\t101'
 assert_plan "generated lines don't count toward the ceiling → small" "light false small" \
   GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'src/a.ts\t50\t10\npnpm-lock.yaml\t5000\t5000'
+# An all-generated diff has no reviewable (non-generated) source → NOT small.
+assert_plan "all-generated bundle → normal, not small" "full true normal" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'dist/app.min.js\t50\t10'
 
 # ── sensitive paths force a full review even when small [NEW] ──
 assert_plan "auth.* file → full" "full true normal" \
@@ -101,6 +104,10 @@ assert_plan "small payments/ change → full" "full true normal" \
   GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'apps/api/src/payments/charge.ts\t8\t1'
 assert_plan "small DB migration → full" "full true normal" \
   GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'apps/api/database/migrations/2026_06_03_fk.php\t12\t0'
+# Sensitivity is checked on every path, generated or not — a sensitive generated
+# file forces full even when the only non-generated change is small.
+assert_plan "sensitive path in a GENERATED file still forces full" "full true normal" \
+  GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'src/util.ts\t10\t2\nsrc/payments/api.generated.ts\t30\t0'
 # A bare auth/ dir is a route group (views/auth/ = the signed-in area), NOT auth logic
 # — it must NOT be force-full by default, else every frontend PR pays for it.
 assert_plan "bare views/auth/ route group → small (not sensitive)" "light false small" \

--- a/tests/round2_inherit_test.sh
+++ b/tests/round2_inherit_test.sh
@@ -158,6 +158,11 @@ assert_eq "U: gate=nonruntime waives smoke" \
   "true false" \
   "$(decide_smoke 1 skip PASS functional "" nonruntime)"
 
+# Case X: gate=small waives — the new small/light tier intentionally skips functional.
+assert_eq "X: gate=small waives smoke" \
+  "true false" \
+  "$(decide_smoke 1 skip PASS functional "" small)"
+
 # Case V: gate=normal does NOT waive — a planned-but-unran functional is a real
 #         gap and still withholds (unchanged from the no-gate behavior).
 assert_eq "V: gate=normal does NOT waive (real gap withholds)" \


### PR DESCRIPTION
## What

Risk-tiers the deterministic review-plan resolver (`scripts/review-plan.sh`) so review depth scales with the PR, instead of every runtime PR getting the full dual-judge debate + functional run.

The `normal` rung now splits by **size + path sensitivity**:

| condition | plan |
|---|---|
| `<= GATE_SMALL_CEILING` (300) non-generated lines, no sensitive paths | **`light` / `small`** -- single judge, no functional |
| `> 300` lines **or** touches a sensitive path | **`full`** -- dual-judge debate + functional |

Plus a new **`deep-review`** label (symmetric to `skip-review`) that forces a full review on a PR that would otherwise be downgraded (promotion / oversized / small). `skip-review` still wins if both labels are present.

**Sensitive paths** (configurable via `GATE_SENSITIVE_GLOBS`) default to `auth.*` files and `oauth` / `authentication` / `authorization` / `security` / `payments` / `migrations` directories. A bare `auth/` directory is deliberately **not** sensitive by default -- frontends commonly use `views/auth/` as the signed-in route group, which would otherwise force nearly every frontend PR into a full review. A repo whose `auth/` holds real auth logic can opt it back in via `GATE_SENSITIVE_GLOBS`.

## Why

Most PRs are small, and a single strong judge is enough for a small, non-sensitive diff. The expensive debate + functional run is reserved for substantial or sensitive changes.

This PR is the **classification** half. The functional-skip for `small` goes live immediately via the existing run-plan wiring; the orchestrator honoring `light` (single judge) follows in a separate PR. Changing only the classification keeps this safe and independently mergeable.

## Test plan

- [x] `tests/review_plan_test.sh` -- 33 cases: `small`, size boundary (300 vs 301), generated lines excluded, sensitive overrides, the `views/auth/` non-match, `GATE_SENSITIVE_GLOBS` opt-in, `deep-review` overrides, skip-beats-deep.
- [x] `tests/round2_inherit_test.sh` -- `gate=small` waives the technical-change smoke withhold (consistent with the other non-`normal` gates).
- [x] `shellcheck scripts/review-plan.sh` clean.
- [x] Classified a sample of recent real PRs through the resolver to confirm the split behaves as intended (and caught a `views/auth/` false positive before merge).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every PR is classified for review depth and functional runs (including security-related path rules); behavior is deterministic and heavily tested but mis-tuned globs could under-review risky small diffs until deep-review is used.
> 
> **Overview**
> **Risk-tiered review depth** is added to the deterministic `review-plan.sh` resolver so routine runtime PRs can take a **`light`** path (single judge, no functional) instead of always getting the dual-judge debate + app test.
> 
> A new **`small`** gate applies when non-generated changed lines are at or under **`GATE_SMALL_CEILING`** (default **300**) and no **sensitive** paths match configurable **`GATE_SENSITIVE_GLOBS`** (auth-related files/dirs, payments, migrations, etc., with a deliberate carve-out so bare `views/auth/` route groups are not treated as sensitive by default). Larger diffs or any sensitive touch still resolve to **`full`**. A **`deep-review`** label forces **`full`** on PRs that would otherwise be downgraded (promotion, oversized, or small); **`skip-review`** still wins if both labels are present.
> 
> Docs (**README**, **`docs/review-plan.md`**, **ADR 0001**) describe tiers, labels, and env tuning. **`tests/review_plan_test.sh`** and **`tests/round2_inherit_test.sh`** cover boundaries, sensitive overrides, and **`gate=small`** waiving the technical-change smoke withhold. **Rollout:** classification and skipping functional for `light`/`small` are in this PR; orchestrator single-judge behavior for `light` is documented as following separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bf8fa036b61d55c6b83a606e1c7aefa9a4a6821. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->