### PR TITLE
docs: risk-tiered review depth (ADR + review-plan guide)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Two practical wins. (1) **Native rate-limit fast-fail.** `anthropics/claude-code
 
 A single LLM judge can have a bad sample on any given run — miss something subtle, over-grade a defensive note, mis-route a finding to the wrong file. The orchestrator runs **two independent judges with different model strengths** (Opus for deep reasoning, Haiku for cheap broad-coverage finds) and reconciles them: if they agree, the review ships immediately; if they disagree, each judge sees the other's findings and either concedes the ones they missed or defends the ones the other dropped. This catches the long tail where one judge is wrong without paying for it on every PR — most reviews converge on the first round.
 
+> **Not every PR needs that depth.** A deterministic resolver classifies each PR up front and reserves the two-judge debate + functional run for substantial or sensitive changes; small, low-risk PRs take a lighter single-judge pass. See **[Review plan](docs/review-plan.md)** for the tiers, the `skip-review` / `deep-review` labels, and per-repo tuning — and [ADR 0001](docs/adr/0001-risk-tiered-review-depth.md) for why.
+
 ### Round 1 vs round 2
 
 The pipeline persists a small state artifact (`/tmp/review-state.json`) on every successful run — the deduped findings, verdict, head SHA reviewed, and the posted review's GitHub id. On the next push to the same PR, the next run downloads it, computes the diff since that SHA, and the round-2 thread classifier runs alongside the orchestrator. The verdict ladder gains a round-2 layer that's strictly **anti-downgrade**:

--- a/docs/adr/0001-risk-tiered-review-depth.md
+++ b/docs/adr/0001-risk-tiered-review-depth.md
@@ -1,0 +1,77 @@
+---
+status: accepted
+date: 2026-06-04
+---
+
+# 0001 — Risk-tiered review depth
+
+## Context
+
+The review pipeline ran the full treatment on every runtime PR: a dual-judge
+debate (Opus + Haiku, with up to two rebuttal rounds) plus a functional
+app-test. That depth is right for a substantial or risky change, but most PRs
+are small, and a single strong judge is enough for a small, focused diff.
+Running the full debate + functional on everything makes routine reviews slow
+and costly for no extra signal.
+
+## Decision
+
+Review depth scales with the PR. The deterministic resolver
+(`scripts/review-plan.sh`) classifies each PR before any model runs; a runtime
+PR takes one of two paths:
+
+- **small** — at or under `GATE_SMALL_CEILING` (default **300**) non-generated
+  changed lines, with no sensitive paths → a single-judge `light` pass, no
+  functional.
+- **full** — over the ceiling, **or** it touches a sensitive path → the
+  dual-judge debate + functional.
+
+Two overrides:
+
+- A **`deep-review`** label forces `full` on a PR that would otherwise be
+  downgraded (promotion / oversized / small). It mirrors the existing
+  `skip-review` label; if both are present, `skip-review` wins.
+- **Sensitive paths** (`GATE_SENSITIVE_GLOBS`) force `full` regardless of size —
+  `auth.*` files and `oauth` / `authentication` / `authorization` / `security` /
+  `payments` / `migrations` directories by default.
+
+### Why 300
+
+300 non-generated lines sits at the shoulder of the real PR-size distribution
+(most PRs are well under it) and below the common 400-line-per-PR guideline, so
+the debate is reserved for the larger and over-limit PRs, not routine changes.
+
+### Why a bare `auth/` directory is NOT sensitive by default
+
+It is tempting to treat any `auth/` directory as sensitive. But many frontends
+use `views/auth/` (or `pages/auth/`) as the *signed-in route group* — the entire
+authenticated area of the app lives under it. Flagging that would force almost
+every frontend PR into a full review, defeating the purpose. The default
+therefore matches auth *files* (`auth.*`) and unambiguous full-word directories;
+a repo whose `auth/` holds real auth logic opts it back in via
+`GATE_SENSITIVE_GLOBS`.
+
+## Considered options
+
+- **Keep the full debate on every PR.** Simplest, but leaves routine reviews
+  slow and costly — the problem being solved.
+- **Single judge on every PR.** Fastest, but drops the second perspective and
+  rebuttal on the large/sensitive changes where they matter most.
+- **Risk-tiered (chosen).** Single judge for small/safe PRs, full debate for
+  substantial or sensitive ones — fast where it's safe, deep where it counts.
+- **Auto-escalate** a single-judge pass to the full debate on a blocking
+  finding. Deferred — it adds two-phase orchestration; revisit only if real
+  misses appear. The `deep-review` label covers the manual case.
+
+## Consequences
+
+- Most PRs get a faster, cheaper single-judge review.
+- A small change to genuinely risky code (auth logic, payments, migrations,
+  security) still gets the full debate via the sensitive-path rule.
+- The classification is a pure, no-LLM function of the diff + branch + labels —
+  deterministic and unit-tested (`tests/review_plan_test.sh`).
+- It is *structural*, not *semantic*: it cannot tell that a 40-line change is
+  unusually risky unless its path says so. `deep-review` is the manual override.
+- Realized in two steps: the resolver classification (which also turns
+  functional off for `small`), then the orchestrator honoring `light` with a
+  single judge.

--- a/docs/review-plan.md
+++ b/docs/review-plan.md
@@ -1,0 +1,88 @@
+# Review plan — how much review a PR gets
+
+Before any model runs, claude-review classifies each PR with a deterministic,
+no-LLM resolver ([`scripts/review-plan.sh`](../scripts/review-plan.sh)) into a
+**review plan**. This keeps routine PRs fast and cheap while reserving the deep,
+two-judge review for substantial or risky changes.
+
+## The plan
+
+Each PR resolves to a `review_level`, whether functional app-testing runs, and a
+`gate` (the reason). The resolver checks these in order and stops at the first
+match:
+
+| # | gate | when | review_level | functional |
+|---|------|------|--------------|------------|
+| 1 | `label` | `skip-review` label present | `skip` | no |
+| 2 | `promotion` | release/promotion PR (e.g. `staging` → `main`) | `light` | no |
+| 3 | `oversized` | over the size ceiling (default 1500 lines / 40 files) | `light` | no |
+| 4 | `nonruntime` | only tests / docs / CI / lockfiles changed | `full` | no |
+| 5 | `small` | ≤ 300 non-generated lines, no sensitive paths | `light` | no |
+| 6 | `normal` | substantial, **or** touches a sensitive path | `full` | yes |
+
+- **`full`** — the dual-judge debate (Opus + Haiku, with rebuttal).
+- **`light`** — a single judge, no rebuttal, no functional. The fast path.
+- **`skip`** — no judges; the reason is posted as a note.
+
+> Generated files (lockfiles, snapshots, `dist/`, `*.min.*`, `*.generated.*`, …)
+> don't count toward the size — a big lockfile bump alone won't push a small PR
+> into `full`.
+
+A `deep-review` label (see below) flips rungs 2, 3, and 5 to `full`.
+
+## Labels
+
+| label | effect |
+|-------|--------|
+| `skip-review` | Skip the detailed review entirely (e.g. already reviewed elsewhere). Highest precedence. |
+| `deep-review` | Force a **full** review on a PR that would otherwise be downgraded (promotion / oversized / small). The mirror of `skip-review`. |
+
+If both labels are on a PR, **`skip-review` wins**.
+
+## Per-repo tuning
+
+Every knob is an environment variable with a safe default. Set it on the
+`env:` of the job that calls the reusable workflow to tune behavior per repo:
+
+| variable | default | meaning |
+|----------|---------|---------|
+| `GATE_SMALL_CEILING` | `300` | non-generated lines at/under which a runtime PR is `small` (single judge) |
+| `GATE_SIZE_CEILING` | `1500` | non-generated lines over which a PR is `oversized` |
+| `GATE_FILE_CEILING` | `40` | changed files over which a PR is `oversized` |
+| `GATE_SENSITIVE_GLOBS` | auth.* / oauth / authentication / authorization / security / payments / migrations | path globs that force `full` even when small |
+| `GATE_DEEP_LABEL` | `deep-review` | label that forces a full review |
+| `GATE_SKIP_LABEL` | `skip-review` | label that skips review |
+| `GATE_PROMOTION_BASES` | `main master production prod` | base branches treated as release targets |
+| `GATE_PROMOTION_HEADS` | `staging develop dev release hotfix` | head branches treated as promotion sources |
+
+### Sensitive paths and the `auth/` caveat
+
+Sensitive paths force a full review no matter how small the diff — for code
+where a single judge isn't enough (authentication logic, payments, DB
+migrations, security).
+
+A **bare `auth/` directory is deliberately not sensitive by default.** Many
+frontends use `views/auth/` (or `pages/auth/`) as the *signed-in route group* —
+the whole authenticated area of the app — so flagging it would force nearly
+every frontend PR into a full review. The default matches auth *files*
+(`auth.*`) and unambiguous directories (`authentication/`, `oauth/`, …) instead.
+
+If your repo keeps real auth logic in an `auth/` directory, opt it back in.
+Note that setting the variable **replaces** the default list, so include
+everything you want treated as sensitive:
+
+```yaml
+# in the env: of your caller workflow's job
+GATE_SENSITIVE_GLOBS: "*/auth/* */oauth/* */security/* */payments/* */migrations/*"
+```
+
+## Examples
+
+| PR | gate | what runs |
+|----|------|-----------|
+| 40-line bug fix in `src/` | `small` | single-judge `light`, fast |
+| 500-line feature | `normal` | full debate + functional |
+| 20-line change in `database/migrations/` | `normal` (sensitive) | full debate + functional |
+| `staging` → `main` release | `promotion` | single-judge `light` |
+| docs-only PR | `nonruntime` | judges run, no functional |
+| small but tricky PR you want fully reviewed | add `deep-review` | full debate + functional |


### PR DESCRIPTION
## What

Documents the risk-tiered review depth from #51 (and the orchestrator follow-up).

- **ADR 0001** (`docs/adr/0001-risk-tiered-review-depth.md`) — the decision record: why depth scales with the PR, the 300-line cutoff, the `deep-review` label, and why a bare `auth/` directory is deliberately *not* sensitive by default. Records the considered alternatives (keep-full / single-judge-always / auto-escalate).
- **Review plan guide** (`docs/review-plan.md`) — consumer-facing reference: the six gates and what each runs, the `skip-review` / `deep-review` labels, and the per-repo `GATE_*` tuning knobs (including how to opt an `auth/` dir back in).
- **README** — a pointer from the "Why two judges?" section to both.

Docs only — no behavior change. Public-safe (no internal spend/repo data).

## Test plan

- [x] Defaults in the guide match `scripts/review-plan.sh` (300 / 1500 / 40 / `deep-review`).
- [x] No private data committed (no repo names, spend, or internal context).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only additions and a README cross-link; no workflow, resolver, or orchestrator changes.
> 
> **Overview**
> This PR adds **documentation only** for the risk-tiered review depth already implemented in `scripts/review-plan.sh` — no pipeline behavior changes.
> 
> **README** — Under “Why two judges?”, a short note explains that not every PR gets the dual-judge debate; small/low-risk PRs use a lighter path, with links to the new guide and ADR.
> 
> **ADR 0001** — Records why review depth scales with PR size (300-line default, sensitive-path forcing, `deep-review` / `skip-review` precedence), why bare `auth/` dirs are excluded from sensitive globs, alternatives considered, and consequences (deterministic resolver, structural vs semantic limits).
> 
> **`docs/review-plan.md`** — Consumer-facing reference: ordered gate table (`skip` → `promotion` → `oversized` → `nonruntime` → `small` → `normal`), `light` vs `full` vs `skip`, label overrides, and `GATE_*` env tuning with an example for opting `auth/` back into sensitive globs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d788a5108e989cb4b589608db83cec72503b6bc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->