### PR TITLE
feat(review): expose GATE_* tuning knobs as workflow inputs

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -47,6 +47,46 @@ on:
         required: false
         type: number
         default: 200
+      gate_skip_label:
+        description: "Label that forces review_level=skip (respects an explicit human opt-out). See docs/review-plan.md."
+        required: false
+        type: string
+        default: "skip-review"
+      gate_deep_label:
+        description: "Label that forces review_level=full, overriding the promotion/oversized/small downgrades. Mirror of gate_skip_label; skip wins if both are present."
+        required: false
+        type: string
+        default: "deep-review"
+      gate_small_ceiling:
+        description: "Non-generated changed lines at/under which a runtime PR is `small` (single-judge `light` review, no functional). See docs/review-plan.md."
+        required: false
+        type: number
+        default: 300
+      gate_size_ceiling:
+        description: "Non-generated changed lines over which a PR is `oversized` (a lightweight single-judge pass — too big to debate well)."
+        required: false
+        type: number
+        default: 1500
+      gate_file_ceiling:
+        description: "Changed (non-generated) files over which a PR is `oversized`."
+        required: false
+        type: number
+        default: 40
+      gate_sensitive_globs:
+        description: "Space-separated path globs that force a `full` review even when the diff is small. Setting this REPLACES the default list, so include everything you want sensitive. A bare `auth/` dir is intentionally NOT in the default — see docs/review-plan.md."
+        required: false
+        type: string
+        default: "*auth.* */oauth/* oauth.* */authentication/* authentication/* */authorization/* authorization/* */security/* security/* */payments/* payments/* */payment/* payment/* */migrations/* migrations/* */migration/* migration/*"
+      gate_promotion_bases:
+        description: "Space-separated base branches treated as release targets for promotion detection."
+        required: false
+        type: string
+        default: "main master production prod"
+      gate_promotion_heads:
+        description: "Space-separated head branches treated as promotion sources (exact name or `<name>/*` prefix)."
+        required: false
+        type: string
+        default: "staging develop dev release hotfix"
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         # No longer strictly required: callers can supply CLAUDE_CODE_OAUTH_TOKENS
@@ -320,6 +360,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+          # Tuning knobs — the resolver reads these; defaults match scripts/review-plan.sh.
+          GATE_SKIP_LABEL: ${{ inputs.gate_skip_label }}
+          GATE_DEEP_LABEL: ${{ inputs.gate_deep_label }}
+          GATE_SMALL_CEILING: ${{ inputs.gate_small_ceiling }}
+          GATE_SIZE_CEILING: ${{ inputs.gate_size_ceiling }}
+          GATE_FILE_CEILING: ${{ inputs.gate_file_ceiling }}
+          GATE_SENSITIVE_GLOBS: ${{ inputs.gate_sensitive_globs }}
+          GATE_PROMOTION_BASES: ${{ inputs.gate_promotion_bases }}
+          GATE_PROMOTION_HEADS: ${{ inputs.gate_promotion_heads }}
         run: |
           set -uo pipefail
           PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \

--- a/docs/review-plan.md
+++ b/docs/review-plan.md
@@ -46,19 +46,19 @@ If both labels are on a PR, **`skip-review` wins**.
 
 ## Per-repo tuning
 
-Every knob is an environment variable with a safe default. Set it on the
-`env:` of the job that calls the reusable workflow to tune behavior per repo:
+Every knob is a `workflow_call` **input** with a safe default. Pass it in the
+`with:` block of the job that calls the reusable workflow to tune per repo:
 
-| variable | default | meaning |
-|----------|---------|---------|
-| `GATE_SMALL_CEILING` | `300` | non-generated lines at/under which a runtime PR is `small` (single judge) |
-| `GATE_SIZE_CEILING` | `1500` | non-generated lines over which a PR is `oversized` |
-| `GATE_FILE_CEILING` | `40` | changed files over which a PR is `oversized` |
-| `GATE_SENSITIVE_GLOBS` | auth.* / oauth / authentication / authorization / security / payments / migrations | path globs that force `full` even when small |
-| `GATE_DEEP_LABEL` | `deep-review` | label that forces a full review |
-| `GATE_SKIP_LABEL` | `skip-review` | label that skips review |
-| `GATE_PROMOTION_BASES` | `main master production prod` | base branches treated as release targets |
-| `GATE_PROMOTION_HEADS` | `staging develop dev release hotfix` | head branches treated as promotion sources |
+| input | default | meaning |
+|-------|---------|---------|
+| `gate_small_ceiling` | `300` | non-generated lines at/under which a runtime PR is `small` (single judge) |
+| `gate_size_ceiling` | `1500` | non-generated lines over which a PR is `oversized` |
+| `gate_file_ceiling` | `40` | changed files over which a PR is `oversized` |
+| `gate_sensitive_globs` | auth.* / oauth / authentication / authorization / security / payments / migrations | path globs that force `full` even when small |
+| `gate_deep_label` | `deep-review` | label that forces a full review |
+| `gate_skip_label` | `skip-review` | label that skips review |
+| `gate_promotion_bases` | `main master production prod` | base branches treated as release targets |
+| `gate_promotion_heads` | `staging develop dev release hotfix` | head branches treated as promotion sources |
 
 ### Sensitive paths and the `auth/` caveat
 
@@ -73,12 +73,14 @@ every frontend PR into a full review. The default matches auth *files*
 (`auth.*`) and unambiguous directories (`authentication/`, `oauth/`, …) instead.
 
 If your repo keeps real auth logic in an `auth/` directory, opt it back in.
-Note that setting the variable **replaces** the default list, so include
+Note that setting this input **replaces** the default list, so include
 everything you want treated as sensitive:
 
 ```yaml
-# in the env: of your caller workflow's job
-GATE_SENSITIVE_GLOBS: "*/auth/* */oauth/* */security/* */payments/* */migrations/*"
+# in the with: block of your caller job
+with:
+  pr_number: ${{ inputs.pr_number || '' }}
+  gate_sensitive_globs: "*/auth/* */oauth/* */security/* */payments/* */migrations/*"
 ```
 
 ## Examples


### PR DESCRIPTION
## What

The resolver (`scripts/review-plan.sh`) supports per-repo tuning via `GATE_*` env vars, but they were never exposed through the reusable workflow. Since reusable workflows **don't inherit the caller job's `env:`**, consumers had *no way* to override them — and `docs/review-plan.md` (from #51) wrongly told them to set `env:`, which silently no-ops.

- **`pr-review.yml`** — adds 8 `workflow_call` inputs (`gate_small_ceiling`, `gate_size_ceiling`, `gate_file_ceiling`, `gate_sensitive_globs`, `gate_deep_label`, `gate_skip_label`, `gate_promotion_bases`, `gate_promotion_heads`), each defaulting to the resolver's own default, and forwards them into the "Resolve review plan" step's `env:`.
- **`docs/review-plan.md`** — corrects the tuning section to use `with:` + the input names, with the opt-in shown in a real `with:` block.

Now a repo that keeps real auth logic in an `auth/` directory — which the default globs deliberately skip, to avoid frontend `views/auth/` false positives — can opt it back in:

```yaml
with:
  pr_number: ${{ inputs.pr_number || '' }}
  gate_sensitive_globs: "*/auth/* */oauth/* */security/* */payments/* */migrations/*"
```

## Why

Surfaced while canary-testing the risk-tiered pipeline on real consumer repos: a repo with auth logic under an `auth/` directory got `light` reviews on auth changes, with no wired way to fix it. This makes the per-repo tuning — and the docs — actually real.

Independent of #53 (both touch `pr-review.yml`, but in different regions — inputs/resolve-step vs orchestrate-step — so they merge cleanly in any order).

## Test plan

- [x] `actionlint .github/workflows/pr-review.yml` — no errors.
- [x] Each input default matches the resolver default in `scripts/review-plan.sh` (verified; `gate_sensitive_globs` diff = MATCH).
- [x] The override behavior is already covered by the resolver suite's `GATE_SENSITIVE_GLOBS` opt-in test (`tests/review_plan_test.sh`).
- Input→env wiring is YAML plumbing (not unit-testable); guarded by actionlint + the default-match check + a `# defaults match scripts/review-plan.sh` comment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow input wiring and documentation only; defaults unchanged and behavior matches the existing resolver.
> 
> **Overview**
> **Exposes review-plan tuning through the reusable workflow** so consumer repos can actually override thresholds, labels, promotion branches, and sensitive path globs—previously only documented as `GATE_*` env vars that **never reached** `review-plan.sh` because reusable workflows do not inherit the caller job’s `env:`.
> 
> Adds eight `workflow_call` inputs on `pr-review.yml` (`gate_skip_label`, `gate_deep_label`, `gate_small_ceiling`, `gate_size_ceiling`, `gate_file_ceiling`, `gate_sensitive_globs`, `gate_promotion_bases`, `gate_promotion_heads`), each defaulting to the same values as `scripts/review-plan.sh`, and wires them into the **Resolve review plan** step as `GATE_*` env vars.
> 
> Updates **`docs/review-plan.md`** to describe per-repo tuning via the caller’s `with:` block (including a concrete `gate_sensitive_globs` example for repos that keep auth logic under `auth/`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f0533adb1d693d0c0e7c13c94bfca129bdc3a6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->