### PR TITLE
fix(review): degrade a failed light single-judge review (don't silently pass)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,5 +61,8 @@ jobs:
       - name: Run review_plan_test.sh
         run: bash tests/review_plan_test.sh
 
+      - name: Run judge_health_gate_test.sh
+        run: bash tests/judge_health_gate_test.sh
+
       - name: Shellcheck scripts (error-level only)
         run: shellcheck --severity=error scripts/*.sh tests/*.sh

--- a/scripts/build-review.sh
+++ b/scripts/build-review.sh
@@ -505,9 +505,11 @@ fi
 # / `*_failed: true`. With an empty findings array, the per-PR ladder
 # below would otherwise reach APPROVE — contradicting the "Both judges
 # failed" banner the body renders. Force COMMENT here so the verdict
-# matches the banner. Single-judge failure is NOT downgraded — the
-# orchestrator already proceeded with the surviving judge's output, and
-# that's a legitimate review.
+# matches the banner. In a FULL run a single failed judge is NOT downgraded
+# — the orchestrator proceeds with the surviving judge, a legitimate review.
+# But at REVIEW_LEVEL=light there is only ONE judge (`single_judge: true`);
+# if it (`sonnet`) failed there is no surviving output, so that IS a total
+# failure and must degrade too.
 JUDGES_BOTH_FAILED=$(echo "$CORE_META" | jq -r '
   # Strict-equality predicates throughout. jq treats any non-false/non-null
   # value as truthy in `or`, so an LLM emitting `"both_failed": "false"`
@@ -521,6 +523,7 @@ JUDGES_BOTH_FAILED=$(echo "$CORE_META" | jq -r '
       is_true_bool("both_failed")
       or is_true_bool("cb_failed")
       or (is_failed_str("opus") and is_failed_str("haiku"))
+      or (is_true_bool("single_judge") and is_failed_str("sonnet"))
     )
   else false end')
 

--- a/tests/judge_health_gate_test.sh
+++ b/tests/judge_health_gate_test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# judge_health_gate_test.sh — fixture test for the JUDGES_BOTH_FAILED safety gate
+# in build-review.sh (~line 511). Mirrors the embedded jq and asserts which
+# judge_health shapes force the degraded COMMENT (so an empty-findings run can't
+# reach APPROVE while the body renders a "review failed" banner).
+#
+# Key case (the fix): at REVIEW_LEVEL=light there is ONE judge; if it (sonnet)
+# failed there is no surviving output → it MUST trip the gate. A full run with
+# one of two judges failed must NOT trip (the surviving judge is legitimate).
+# No LLM key required.
+
+cd "$(dirname "$0")/.."
+fail=0
+
+# Mirrors scripts/build-review.sh's JUDGES_BOTH_FAILED jq. Keep in sync.
+judges_failed() {
+  jq -r '
+    def is_failed_str(field): if has(field) then (.[field] == "failed") else false end;
+    def is_true_bool(field): if has(field) then (.[field] == true) else false end;
+    if (type == "object" and (.judge_health // null | type == "object")) then
+      (.judge_health |
+        is_true_bool("both_failed")
+        or is_true_bool("cb_failed")
+        or (is_failed_str("opus") and is_failed_str("haiku"))
+        or (is_true_bool("single_judge") and is_failed_str("sonnet"))
+      )
+    else false end' <<< "$1"
+}
+
+assert() {
+  local label="$1" want="$2" meta="$3" got
+  got=$(judges_failed "$meta")
+  if [ "$got" = "$want" ]; then
+    echo "OK:   $label → $got"
+  else
+    echo "FAIL: $label — want '$want' got '$got'"
+    fail=$((fail + 1))
+  fi
+}
+
+# ── trips the gate → degrade to COMMENT ──
+assert "both_failed:true (full)" true '{"judge_health":{"both_failed":true}}'
+assert "cb_failed:true" true '{"judge_health":{"cb_failed":true}}'
+assert "opus+haiku both failed (full)" true '{"judge_health":{"opus":"failed","haiku":"failed"}}'
+assert "light sole judge failed (single_judge+sonnet failed)" true \
+  '{"judge_health":{"sonnet":"failed","single_judge":true}}'
+
+# ── does NOT trip → legitimate review ──
+assert "light sole judge OK" false \
+  '{"judge_health":{"sonnet":"ok","single_judge":true,"agreed_at":"single"}}'
+assert "full: one of two failed (survivor stands)" false '{"judge_health":{"opus":"failed","haiku":"ok"}}'
+assert "full: both judges ok" false '{"judge_health":{"opus":"ok","haiku":"ok"}}'
+assert "string \"false\" is not truthy" false '{"judge_health":{"both_failed":"false"}}'
+assert "no judge_health" false '{"verdict":"COMMENT"}'
+
+if [ "$fail" -eq 0 ]; then
+  echo
+  echo "All judge-health gate tests passed."
+  exit 0
+else
+  echo
+  echo "$fail judge-health gate assertion(s) failed."
+  exit 1
+fi


### PR DESCRIPTION
## What

The judge-health safety gate in `build-review.sh` forces a degraded `COMMENT` (matching the "review failed" banner) when the judges crash, so an empty-findings run can't reach `APPROVE`. It recognized `both_failed` / `cb_failed` / `(opus AND haiku failed)`.

But #53 added the `light` single-judge path, whose failure clause writes `judge_health: { sonnet: "failed", single_judge: true }` — **none of those flags.** So if the sole Sonnet judge *crashed* on a `light` PR, the gate didn't trip and the run reached a clean non-blocking `COMMENT` (a silent pass) instead of the visible degraded review.

**Fix:** add `(single_judge AND sonnet failed)` to the gate. A full run with one of two judges failed is unchanged (the surviving judge is a legitimate review); a `light` run whose sole judge failed now degrades like both-failed.

- `scripts/build-review.sh` — one clause + an updated comment.
- `tests/judge_health_gate_test.sh` (new) — mirrors the gate jq; asserts the fix (light-sole-failed → trip) and the non-trip cases (light-ok, full-survivor, string-`"false"`, no judge_health). Wired into `tests.yml`.

## Why

Cursor flagged this on #53 (High). It's an edge case — the sole judge has to actually crash on a `light` PR — but a *failed* review should never read as a clean pass. Not yet released (`@v2` hasn't moved), so this lands before consumers see it.

## Test plan
- [x] `tests/judge_health_gate_test.sh` — 9/9.
- [x] `shellcheck --severity=error scripts/*.sh tests/*.sh` clean.
- [x] Regression: round2_inherit / round2_resolution / verdict_ladder / functional_findings_merge / review_plan all green.
- [x] `actionlint .github/workflows/tests.yml` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small verdict-gate condition plus shell fixture tests; no auth or runtime product surface beyond review outcome correctness.
> 
> **Overview**
> **Light single-judge crash no longer looks like a clean pass.** The judge-health gate in `build-review.sh` now treats `single_judge: true` with `sonnet: "failed"` like a total judge failure, forcing **COMMENT** instead of letting an empty findings list reach **APPROVE** when the sole Sonnet judge died on a `light` review. Full runs where only one of Opus/Haiku failed are unchanged.
> 
> A new **`tests/judge_health_gate_test.sh`** mirrors the gate’s `jq` (trip vs non-trip cases) and is wired into **`.github/workflows/tests.yml`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d46315a18367c1fa560902ec6c51829662db445. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->