### PR TITLE
feat: expose allowed_bots passthrough on pr-review workflow

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -47,6 +47,11 @@ on:
         required: false
         type: number
         default: 200
+      allowed_bots:
+        description: "Comma-separated bot logins allowed to trigger the review (e.g. 'panenco-automation'), or '*' for all bots. Empty (default) preserves the action's default of blocking all bot-initiated runs."
+        required: false
+        type: string
+        default: ""
       gate_skip_label:
         description: "Label that forces review_level=skip (respects an explicit human opt-out). See docs/review-plan.md."
         required: false
@@ -1061,6 +1066,11 @@ jobs:
         with:
           claude_code_oauth_token: ${{ env.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.review_identity.outputs.token }}
+          # Pass-through opt-in: empty (default) keeps the action's default of
+          # blocking all bot-initiated runs. A consumer repo sets allowed_bots
+          # (e.g. 'panenco-automation') on its caller's `with:` block to let
+          # that bot's PRs through. See README → "Allowing bot-opened PRs".
+          allowed_bots: ${{ inputs.allowed_bots }}
           prompt: |
             Read ${{ env.CLAUDE_REVIEW_PIPELINE_DIR }}/skills/review-orchestrator.md and follow it exactly. PR number: ${{ github.event.pull_request.number || inputs.pr_number }}. You are the single top-level agent for this review. Honor the review plan passed via env (REVIEW_LEVEL / RUN_FUNCTIONAL / GATE / GATE_REASON) per the skill's "Review-plan gate" section FIRST, then dispatch the appropriate subagents (context builder, judges, round-2 thread classifier, functional tester) via the Task tool exactly as the skill directs for that review level. The functional tester is registered as the custom subagent type `review-functional-tester` (auto-discovered from .claude/agents/, owns Playwright MCP directly — just dispatch it, do not pass MCP config in the prompt). Write /tmp/all-findings.json + /tmp/review-meta.json before exiting.
           claude_args: |

--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ with:
 
 Without `pipeline_ref`, the install defaults to `@v2` and consumers get new orchestration on old skills, which fails at max-turns. The `@v2` default is correct for normal use; only override during testing.
 
+**Allowing bot-opened PRs.** By default the underlying action blocks any run triggered by a non-human actor, so PRs opened by an automation bot fail at the orchestrator step with `Workflow initiated by non-human actor`. Opt in per-repo by passing `allowed_bots` (comma-separated bot logins, or `*` for all bots) on the caller's `with:` block. Use the login **without** the `[bot]` suffix — it matches `github.actor`:
+
+```yaml
+with:
+  pr_number: ${{ inputs.pr_number || '' }}
+  allowed_bots: panenco-automation   # not "panenco-automation[bot]"
+```
+
+Empty (the default) preserves today's behaviour — all bot-initiated runs stay blocked. This is a safe, opt-in change for every existing consumer.
+
 ### 2. Set secrets
 
 Add `CLAUDE_CODE_OAUTH_TOKEN` as a repo or org secret. Generate it with:


### PR DESCRIPTION
## Problem

PRs opened by our automation bot (`panenco-automation[bot]`) fail at the **Review: orchestrate** step:

```
Action failed with error: Workflow initiated by non-human actor: panenco-automation (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

`anthropics/claude-code-action` blocks any bot-initiated run unless its `allowed_bots` input is set. The reusable workflow `.github/workflows/pr-review.yml` neither exposed `allowed_bots` as a `workflow_call` input nor set it on the action step, so consumer repos had no way to opt their automation bots in.

## Change

- Add `allowed_bots` as a `workflow_call` input (after `functional_max_turns`), `type: string`, `default: ""`.
- Pass it through to the single `anthropics/claude-code-action` step (`with: allowed_bots: ${{ inputs.allowed_bots }}`).
- Document the per-repo opt-in in the README Quick Start.

The pinned action (`@9db782c3…`, Claude Code 2.1.132) accepts an input named exactly `allowed_bots` whose empty-string default allows no bots — verified against the upstream `action.yml` at that SHA.

## Opt-in default preserves current behaviour

The empty default (`""`) is the action's own default — **all bot-initiated runs stay blocked**. No existing consumer's behaviour changes; this is purely additive and opt-in. No other input's default or behaviour is touched.

## Consumer caller side

A consumer repo opts a bot in on its caller's `with:` block — using the login **without** the `[bot]` suffix (it matches `github.actor`):

```yaml
with:
  allowed_bots: panenco-automation   # not "panenco-automation[bot]"
```

## Release

This repo has no release automation; consumers float `@v2`. A new config-affecting input is a **minor** bump. After merge, publish per the documented process (latest published is `v2.2.0`):

```bash
scripts/release.sh v2.3.0    # cuts immutable v2.3.0 first, then force-moves v2 onto the same tip
```

Until `v2` is moved, `@v2` consumers won't see this. Push the tag at idle (no in-flight reviews) per the tag-resolution caveat.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive workflow input with empty default; no change to existing consumers until they explicitly allow bot actors.
> 
> **Overview**
> Exposes **`allowed_bots`** on the reusable **`pr-review`** workflow so consumer repos can opt automation into reviews. **`anthropics/claude-code-action`** rejects non-human actors unless this input is set; the workflow previously had no passthrough, so bot-opened PRs failed at **Review: orchestrate**.
> 
> Adds a **`workflow_call`** string input (default `""`) and forwards **`allowed_bots: ${{ inputs.allowed_bots }}`** to the orchestrator action. README documents per-repo opt-in: comma-separated logins or `*`, using **`github.actor`** without the **`[bot]`** suffix.
> 
> **Default unchanged:** empty string keeps blocking all bot-initiated runs; existing callers need no updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6302e15a111ed7850028be33f95003942e50d5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->