### PR TITLE
fix(review): preserve finding title through merge + renderer fallbacks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,5 +64,8 @@ jobs:
       - name: Run judge_health_gate_test.sh
         run: bash tests/judge_health_gate_test.sh
 
+      - name: Run finding_title_fallback_test.sh
+        run: bash tests/finding_title_fallback_test.sh
+
       - name: Shellcheck scripts (error-level only)
         run: shellcheck --severity=error scripts/*.sh tests/*.sh

--- a/scripts/build-review.sh
+++ b/scripts/build-review.sh
@@ -760,7 +760,7 @@ FUNCTIONAL_SUMMARY_TEXT=$(echo "$FUNCTIONAL_META" | jq -r '.summary // ""')
 if [ "$(echo "$ALL_FINDINGS" | jq 'length')" -eq 0 ]; then
   SUMMARY="${SPEC_COMPLIANCE:-No issues found. Code reviewed for correctness, spec compliance, security, consistency, and performance.}"
 else
-  SUMMARY=$(echo "$ALL_FINDINGS" | jq -r '[.[] | "\(.severity): \(.title)"] | join("; ")' | head -c 200)
+  SUMMARY=$(echo "$ALL_FINDINGS" | jq -r '[.[] | "\(.severity): \(.title // "Untitled")"] | join("; ")' | head -c 200)
 fi
 
 jq -n \
@@ -973,7 +973,7 @@ if [ "$FUNCTIONAL_OVERALL" != "N/A" ] && [ "$FUNCTIONAL_STRATEGY" != "skip" ]; t
       echo "#### Issues found"
       echo ""
       jq -r '.[] |
-        "- **[\(.severity | ascii_upcase)]** \(.title)\n" +
+        "- **[\(.severity | ascii_upcase)]** \(.title // "Untitled")\n" +
         "  <br/>_Evidence:_ " + (.evidence | gsub("\n"; " ") | .[:240]) + (if (.evidence | length) > 240 then "..." else "" end)
       ' /tmp/functional-findings.json
       echo ""
@@ -1022,7 +1022,7 @@ elif [ "${FUNCTIONAL_OK:-1}" -eq 0 ] && [ "$TEST_PLAN_EXISTS" = "true" ]; then
     if [ "$CRASH_FINDING_COUNT" -gt 0 ]; then
       echo ""
       echo "**Partial findings:**"
-      jq -r '.[] | "- **\(.title)**: \(.evidence[:200])"' /tmp/functional-findings.json
+      jq -r '.[] | "- **\(.title // "Untitled")**: \(.evidence[:200])"' /tmp/functional-findings.json
     fi
     if [ "$CRASH_SHOT_COUNT" -gt 0 ]; then
       echo ""

--- a/scripts/verdict-gate.sh
+++ b/scripts/verdict-gate.sh
@@ -138,7 +138,7 @@ FUNCTIONAL_OVERALL=$(jq -r '.functional_validation.overall // "N/A"' review-resu
   jq -r '.summary // "(no summary)"' review-result.json
   echo ""
   echo "### Confirmed findings ($FINDING_COUNT)"
-  jq -r '(.findings // [])[] | "- **\(.severity | ascii_upcase)** [\(.type)] `\(.path):\(.line_start)` — \(.title)"' review-result.json
+  jq -r '(.findings // [])[] | "- **\(.severity | ascii_upcase)** [\(.type)] `\(.path):\(.line_start)` — \(.title // "Untitled")"' review-result.json
   if [ "$HUMAN_REVIEW" = "true" ]; then
     echo ""
     echo "> :stop_sign: **Human review required.** $HUMAN_REASON"

--- a/skills/review-orchestrator.md
+++ b/skills/review-orchestrator.md
@@ -279,7 +279,7 @@ When the functional tester subagent ran AND wrote screenshots: collect from `/tm
 
 ### `/tmp/all-findings.json`
 
-JSON array of findings, identical schema to what the judges produce. Each entry must include at minimum `id`, `severity`, `type`, `path`, `line_start`, `evidence`, `reasoning`, `expected`. `line_end`, `side`, `screenshot`, `prd_quote`, `code_quote` are optional and copied verbatim from the source judge.
+JSON array of findings, identical schema to what the judges produce. Each entry must include at minimum `id`, `title`, `severity`, `type`, `path`, `line_start`, `evidence`, `reasoning`, `expected`. `line_end`, `side`, `screenshot`, `prd_quote`, `code_quote` are optional and copied verbatim from the source judge. **`title` is load-bearing — it is the bold header of every inline comment.** Never drop it during the merge; if a source finding somehow lacks one, synthesize a short title from its `evidence`/`reasoning` rather than emitting an entry without it.
 
 ### `/tmp/review-meta.json`
 

--- a/tests/finding_title_fallback_test.sh
+++ b/tests/finding_title_fallback_test.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# finding_title_fallback_test.sh — regression guard for issue #57.
+#
+# A finding that reaches the renderer without a `title` must never surface as
+# the literal "null" in any posted text: the PR review body, inline comments,
+# or the Actions step summary. The bug (Panenco/qit#6486) had two halves —
+# the orchestrator merge contract didn't list `title` as required (so the
+# orchestrator dropped it), and the renderers read `.title` bare, printing
+# "null"/"Untitled" headers on real REQUEST_CHANGES reviews.
+#
+# Two checks:
+#   1. Invariant (drift-proof): every `.title` read in scripts/*.sh carries a
+#      `//` fallback. This reads the real scripts, so deleting a fallback in a
+#      future edit re-breaks this test rather than silently regressing prod.
+#   2. Behaviour: the fallback jq fragments render "Untitled" — not "null" —
+#      for a title-less finding.
+#   3. Contract: the orchestrator's all-findings.json schema lists `title` as
+#      a required field, so the merge step is told to preserve it.
+
+cd "$(dirname "$0")/.."
+
+fail=0
+
+assert_eq() {
+  local label="$1" want="$2" got="$3"
+  if [ "$want" != "$got" ]; then
+    echo "FAIL: $label — want '$want', got '$got'"
+    fail=$((fail + 1))
+  else
+    echo "OK:   $label"
+  fi
+}
+
+echo "── Invariant: no bare .title read in scripts/*.sh ──"
+# A "bare" read is `.title` not followed (allowing spaces) by `//`. Every
+# legitimate render site clips to "Untitled" or to the evidence text.
+BARE=$(grep -rnE '\.title([^a-zA-Z0-9_]|$)' scripts/*.sh | grep -vE '\.title +//' || true)
+if [ -n "$BARE" ]; then
+  echo "FAIL: bare .title read(s) without a // fallback (these render 'null'):"
+  echo "$BARE"
+  fail=$((fail + 1))
+else
+  echo "OK:   every .title read in scripts/*.sh has a // fallback"
+fi
+
+echo ""
+echo "── Behaviour: title-less finding renders 'Untitled', never 'null' ──"
+
+TITLELESS='[{"id":"j1","severity":"major","type":"bug","path":"a.ts","line_start":1}]'
+
+# Mirrors build-review.sh summary line.
+got=$(echo "$TITLELESS" | jq -r '[.[] | "\(.severity): \(.title // "Untitled")"] | join("; ")')
+assert_eq "summary line"            "major: Untitled" "$got"
+
+# Mirrors build-review.sh inline-comment header.
+got=$(echo "$TITLELESS" | jq -r '.[] | "**[\((.type // "finding") | ascii_upcase)]** \(.title // "Untitled")"')
+assert_eq "inline-comment header"   "**[BUG]** Untitled" "$got"
+
+# Mirrors verdict-gate.sh step-summary line.
+got=$(echo "$TITLELESS" | jq -r '.[] | "- **\(.severity | ascii_upcase)** [\(.type)] `\(.path):\(.line_start)` — \(.title // "Untitled")"')
+assert_eq "step-summary line"       '- **MAJOR** [bug] `a.ts:1` — Untitled' "$got"
+
+# A finding WITH a title still renders the title verbatim (fallback only fires
+# when absent).
+WITH_TITLE='[{"severity":"minor","title":"real header"}]'
+got=$(echo "$WITH_TITLE" | jq -r '[.[] | "\(.severity): \(.title // "Untitled")"] | join("; ")')
+assert_eq "present title preserved" "minor: real header" "$got"
+
+echo ""
+echo "── Contract: orchestrator lists title as required in all-findings.json ──"
+# The schema sentence at skills/review-orchestrator.md must require `title`
+# before `severity`, so the merge step never drops it.
+if grep -qE '`id`, `title`, `severity`' skills/review-orchestrator.md; then
+  echo "OK:   review-orchestrator.md requires \`title\` in the merge contract"
+else
+  echo "FAIL: review-orchestrator.md all-findings.json contract does not require \`title\`"
+  fail=$((fail + 1))
+fi
+
+echo ""
+if [ "$fail" -eq 0 ]; then
+  echo "All finding-title fallback tests passed."
+  exit 0
+else
+  echo "$fail finding-title fallback test(s) failed."
+  exit 1
+fi


### PR DESCRIPTION
## Problem

On real `REQUEST_CHANGES` reviews, finding headers rendered as the literal string `null` or `Untitled` — see [issue #57](https://github.com/Panenco/claude-review/issues/57) and the [qit #6486 run](https://github.com/Panenco/qit/actions/runs/27008751246/job/79706845906?pr=6486).

```
#### Issues found
- **[MAJOR]** null
- **[NOTE]** null

### Findings outside diff hunks (4)
- …TherapistService.php:142 (RIGHT) — [SPEC-MISMATCH] Untitled
```

(The red ✗ on those PRs is `verdict-gate.sh` exiting 1 on `REQUEST_CHANGES` — that's by design. This PR fixes the `null`/`Untitled` rendering, not the gate.)

## Root cause

Two halves:

1. **Contract gap.** Producers emit `title` (`review-judge.md`, `review-functional-tester.md`), but the orchestrator's `all-findings.json` merge contract (`review-orchestrator.md`) listed `title` in **neither** the required nor optional field set. Findings are free-form JSON with no `StructuredOutput` enforcement, so the merge step could legitimately drop it.
2. **No renderer fallback.** Four sites read `.title` bare and printed whatever was there:
   - `build-review.sh` — summary line, functional "Issues found", crash partials
   - `verdict-gate.sh` — the Actions step summary

## Fix (defense in depth)

- Add `title` as a **required** field in the orchestrator merge contract, with a "load-bearing — never drop it" note and a synthesize-from-evidence fallback instruction.
- Add `// "Untitled"` to all four bare `.title` reads.
- New `tests/finding_title_fallback_test.sh`, wired into `tests.yml`:
  - **Invariant (drift-proof):** greps the real scripts to forbid any `.title` read without a `//` fallback — so removing a fallback re-breaks the test.
  - **Behaviour:** a title-less finding renders `Untitled`, never `null`; a present title is preserved verbatim.
  - **Contract:** asserts `review-orchestrator.md` requires `title`.

## Test plan

- [x] `bash tests/finding_title_fallback_test.sh` passes
- [x] `shellcheck --severity=error scripts/*.sh tests/*.sh` clean
- [x] Existing tests (`verdict_ladder`, `functional_findings_merge`, `crash_banner_marker`) still pass
- [x] Verified the invariant grep flags a deliberately-reintroduced bare `.title`

Closes #57

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display and documentation contract changes only; no auth, verdict logic, or data mutation paths.
> 
> **Overview**
> Fixes review output showing **`null`** or bare missing headers when findings lose **`title`** during orchestrator merge (#57).
> 
> **Merge contract:** `review-orchestrator.md` now lists **`title`** as required on `/tmp/all-findings.json`, with guidance to keep it (inline comment headers) and synthesize from evidence if missing.
> 
> **Renderers:** All jq reads of `.title` in `build-review.sh` (summary, functional issues, crash partials) and `verdict-gate.sh` (Actions step summary) use **`(.title // "Untitled")`** instead of bare `.title`.
> 
> **Regression test:** New `tests/finding_title_fallback_test.sh` greps scripts for bare `.title` reads, asserts title-less JSON renders `Untitled`, and checks the orchestrator contract; added to `.github/workflows/tests.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1bd7f0b18ee37910386d1cf3a49747e650cce76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->