### PR TITLE
fix(review): render linked issue number, not the /tmp/issue.json path

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,5 +67,8 @@ jobs:
       - name: Run finding_title_fallback_test.sh
         run: bash tests/finding_title_fallback_test.sh
 
+      - name: Run linked_issue_render_test.sh
+        run: bash tests/linked_issue_render_test.sh
+
       - name: Shellcheck scripts (error-level only)
         run: shellcheck --severity=error scripts/*.sh tests/*.sh

--- a/scripts/build-review.sh
+++ b/scripts/build-review.sh
@@ -803,7 +803,12 @@ jq -n \
 # `external_issue` is the tracker identifier (e.g. ABC-123) surfaced by the
 # consumer's optional fetch-issue.sh hook. Show #N when present, otherwise the
 # external identifier, falling back to "none found" only when neither exists.
-ISSUE=$(jq -r '.spec_sources.linked_issue // "none found"' review-result.json)
+#
+# Guard: only render `linked_issue` when it's a bare issue number. Upstream
+# (the judge, via context.md) has mis-copied the `/tmp/issue.json` path into
+# this field, which then rendered as `#/tmp/issue.json` (issue #59). Accept
+# digits only; anything else (path, prose, null) → "none found".
+ISSUE=$(jq -r '(.spec_sources.linked_issue // "") | tostring | if test("^[0-9]+$") then . else "none found" end' review-result.json)
 EXTERNAL=$(jq -r '.spec_sources.external_issue // empty' review-result.json)
 {
   echo "## Claude PR Review — $VERDICT"

--- a/skills/review-context-builder.md
+++ b/skills/review-context-builder.md
@@ -288,7 +288,7 @@ If the diff is genuinely tiny (≤20 lines, single file) and the title already c
 
 ### `## Spec sources` (single-purpose, REQUIRED)
 List which spec sources exist as paths reviewers can Read:
-- Linked GitHub issue: `/tmp/issue.json` (or "none")
+- Linked GitHub issue: `#<number>` then ` (body at /tmp/issue.json)` — e.g. `#57 (body at /tmp/issue.json)`, or "none". Lead with the bare `#<number>` (the value `${ISSUE}` you resolved in Turn 1); downstream consumers read the number from the front of this line, so never lead with the path.
 - PRD: `/tmp/prd-content.md` (or "none — file empty")
 - External tracker issue: `/tmp/external-issue.md` (or "none — file empty")
 - Manually-written PR body: yes / no (yes when the PR body has prose that's not auto-generated; see the AI-content filter below)

--- a/skills/review-judge.md
+++ b/skills/review-judge.md
@@ -198,6 +198,8 @@ Write a single JSON object to the path the orchestrator passed via `OUTPUT_PATH`
 
 `id` prefix convention: use `j1, j2, …` — the orchestrator namespaces both judges' ids when comparing/merging.
 
+`spec_sources.linked_issue` is the **integer** GitHub issue number from context.md's `## Spec sources` line (e.g. `57`), or `null` when none — **never** the `/tmp/issue.json` file path. The renderer prints it as `#<value>`, so a path here surfaces as `#/tmp/issue.json` in the posted review.
+
 `manual_spec_present` rules: `true` when ANY of these is non-empty: linked GitHub issue body (`/tmp/issue.json`), PRD (`/tmp/prd-content.md`), external-tracker spec (`/tmp/external-issue.md`), OR substantive human-written PR-body prose. **PR bodies are usually mixed** — strip Cursor/CodeRabbit/Gemini/Claude footer blocks and `> [!NOTE]` bot-attribution alerts before judging; if ≥1 paragraph of human-written prose remains explaining the WHY/scope/criteria, it's a spec.
 
 `requires_human_review` is `true` ONLY when the diff genuinely cannot be judged: PR modifies existing auth/billing/tenant-isolation infrastructure, schema-altering migrations on existing data, cross-cutting architecture changes (new middleware/global interceptor), >500 LoC of novel business-logic with ambiguous requirements. **Missing auth is a finding, not ambiguity** — flag it and leave `requires_human_review` false.

--- a/tests/linked_issue_render_test.sh
+++ b/tests/linked_issue_render_test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# linked_issue_render_test.sh — regression guard for issue #59.
+#
+# `spec_sources.linked_issue` is the GitHub-native issue NUMBER; the renderer
+# prints it as `#<value>`. A regression (judge copying the `/tmp/issue.json`
+# path into the field) made the Spec-sources line render `#/tmp/issue.json`
+# on a real review (PR #58). build-review.sh must accept the value only when
+# it's a bare issue number and fall back to "none found" otherwise.
+#
+# Three checks:
+#   1. Behaviour: the guard yields the number for digits, "none found" for a
+#      path / null / missing.
+#   2. Invariant (drift-proof): build-review.sh's linked_issue read carries the
+#      digit guard — reads the real script, so removing it re-breaks this test.
+#   3. Contract: the judge skill states linked_issue is the integer number,
+#      never the file path.
+
+cd "$(dirname "$0")/.."
+
+fail=0
+
+assert_eq() {
+  local label="$1" want="$2" got="$3"
+  if [ "$want" != "$got" ]; then
+    echo "FAIL: $label — want '$want', got '$got'"
+    fail=$((fail + 1))
+  else
+    echo "OK:   $label"
+  fi
+}
+
+# Mirrors the guard in scripts/build-review.sh.
+guard() {
+  jq -r '(.spec_sources.linked_issue // "") | tostring | if test("^[0-9]+$") then . else "none found" end'
+}
+
+echo "── Behaviour: linked_issue guard ──"
+assert_eq "path     → none found" "none found" "$(echo '{"spec_sources":{"linked_issue":"/tmp/issue.json"}}' | guard)"
+assert_eq "string # → number"     "57"         "$(echo '{"spec_sources":{"linked_issue":"57"}}' | guard)"
+assert_eq "numeric  → number"     "57"         "$(echo '{"spec_sources":{"linked_issue":57}}' | guard)"
+assert_eq "null     → none found" "none found" "$(echo '{"spec_sources":{"linked_issue":null}}' | guard)"
+assert_eq "missing  → none found" "none found" "$(echo '{"spec_sources":{}}' | guard)"
+# A path must never survive into the rendered `#<value>` token.
+RENDERED="#$(echo '{"spec_sources":{"linked_issue":"/tmp/issue.json"}}' | guard)"
+if printf '%s' "$RENDERED" | grep -q '/tmp'; then
+  echo "FAIL: rendered token still contains a path: '$RENDERED'"
+  fail=$((fail + 1))
+else
+  echo "OK:   path never reaches the '#<value>' token (got '$RENDERED')"
+fi
+
+echo ""
+echo "── Invariant: build-review.sh guards the linked_issue read ──"
+# The read of .spec_sources.linked_issue must constrain it to digits.
+if grep -qE '\.spec_sources\.linked_issue.*test\("\^\[0-9\]\+\$"\)' scripts/build-review.sh; then
+  echo "OK:   build-review.sh constrains linked_issue to a bare number"
+else
+  echo "FAIL: build-review.sh reads linked_issue without a digit guard (would render '#/tmp/...')"
+  fail=$((fail + 1))
+fi
+
+echo ""
+echo "── Contract: judge skill defines linked_issue as the integer number ──"
+if grep -qiE 'linked_issue.*integer.*issue number|integer.*GitHub issue number' skills/review-judge.md; then
+  echo "OK:   review-judge.md states linked_issue is the integer issue number"
+else
+  echo "FAIL: review-judge.md does not define linked_issue as the integer issue number"
+  fail=$((fail + 1))
+fi
+
+echo ""
+if [ "$fail" -eq 0 ]; then
+  echo "All linked-issue render tests passed."
+  exit 0
+else
+  echo "$fail linked-issue render test(s) failed."
+  exit 1
+fi


### PR DESCRIPTION
Closes #59.

## Problem

The posted review's **Spec sources** section rendered the linked issue as a file path instead of a number:

```
- Linked issue: #/tmp/issue.json
```

Seen on the claude-review self-review of [PR #58](https://github.com/Panenco/claude-review/pull/58#pullrequestreview-4435752723). Confirmed from that run's artifacts — `review-result.json` carried `"linked_issue": "/tmp/issue.json"`. Same class as #57 (a raw internal value leaking into rendered output), different field.

## Root cause

`spec_sources.linked_issue` should be the GitHub issue **number** (the renderer prints `#$ISSUE`), but it held the `/tmp/issue.json` path:

1. **Context-builder** wrote the `## Spec sources` line as a path pointer (`review-context-builder.md`), so the backticked path was the prominent token and the number only a trailing parenthetical.
2. **Judge** fills `spec_sources` from context.md (`review-judge.md`) and copied the obvious token — the path. The schema had no prose saying it must be the number. (`spec_sources` flows judge → orchestrator → `review-result.json`.)
3. **Renderer** at `build-review.sh:806` printed `#$ISSUE` with no validation.

## Fix (defense in depth)

- **Context-builder** leads the line with the bare `#<number>` so the number is the obvious value to copy.
- **Judge contract** states `linked_issue` is the integer issue number (e.g. `57`) or `null` — never the `/tmp/issue.json` path.
- **Renderer** accepts `linked_issue` only when it's bare digits; anything else (path, prose, null) → `none found`.
- New `tests/linked_issue_render_test.sh`, wired into `tests.yml`: behavioural guard (path/null/missing → `none found`, digits → number, and a path never reaches the `#<value>` token) + a drift-proof grep that `build-review.sh` constrains the read to digits + a contract grep on the judge skill.

## Test plan

- [x] `bash tests/linked_issue_render_test.sh` passes
- [x] `shellcheck --severity=error scripts/*.sh tests/*.sh` clean
- [x] Sibling tests (`finding_title_fallback`, `verdict_ladder`) still pass
- [x] Guard verified against path / numeric / string-number / null / missing inputs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes review markdown rendering and agent skill contracts only; no runtime auth, data, or consumer-app behavior.
> 
> **Overview**
> Fixes **Spec sources** showing `#/tmp/issue.json` instead of a real issue number when `spec_sources.linked_issue` held the issue body path (issue #59).
> 
> **Defense in depth:** `build-review.sh` now accepts `linked_issue` only when it matches bare digits; paths and other junk become `none found` before `#$ISSUE` is printed. The context-builder skill leads `## Spec sources` with `#<number>` so judges copy the number, not `/tmp/issue.json`. The judge skill documents that `linked_issue` must be the integer GitHub issue number or `null`.
> 
> Adds `tests/linked_issue_render_test.sh` (behavior, `build-review.sh` invariant grep, judge contract grep) and runs it in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7495d1a4df021b82d6758dd7b9722be88d3ea5c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->