### PR TITLE
fix(review): annotate the verdict gate on REQUEST_CHANGES

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,5 +70,8 @@ jobs:
       - name: Run linked_issue_render_test.sh
         run: bash tests/linked_issue_render_test.sh
 
+      - name: Run verdict_gate_annotation_test.sh
+        run: bash tests/verdict_gate_annotation_test.sh
+
       - name: Shellcheck scripts (error-level only)
         run: shellcheck --severity=error scripts/*.sh tests/*.sh

--- a/scripts/verdict-gate.sh
+++ b/scripts/verdict-gate.sh
@@ -186,6 +186,11 @@ case "$VERDICT" in
     exit 0
     ;;
   REQUEST_CHANGES)
+    # Emit a visible annotation before failing. Without it the blocking
+    # verdict renders as a bare red ✗ with an empty step log — the verdict and
+    # findings live in the step summary + posted PR review, not this step's
+    # console — so the failed gate looks broken rather than intentional.
+    echo "::error::Claude review: REQUEST_CHANGES — $FINDING_COUNT blocking finding(s). See the PR review and the run summary for details."
     exit 1
     ;;
   *)

--- a/tests/verdict_gate_annotation_test.sh
+++ b/tests/verdict_gate_annotation_test.sh
@@ -44,13 +44,14 @@ run_gate() {
   local body="$1"
   local work; work="$(mktemp -d)"
   printf '%s' "$body" > "$work/review-result.json"
-  set +e
+  # This file runs `set -uo pipefail` (no errexit), so the gate's non-zero
+  # exit is captured in RC without aborting — no `set +e`/`set -e` toggling
+  # (which would leave errexit on for the rest of the script).
   OUT=$(cd "$work" && ANALYZER_OUTCOME=success POSTER_OUTCOME=success \
         GITHUB_STEP_SUMMARY="$work/summary.md" PR_NUMBER=1 \
         GITHUB_REPOSITORY=o/r GH_TOKEN=x \
         bash "$GATE" 2>&1)
   RC=$?
-  set -e
   rm -rf "$work"
 }
 

--- a/tests/verdict_gate_annotation_test.sh
+++ b/tests/verdict_gate_annotation_test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# verdict_gate_annotation_test.sh — regression guard for issue #61.
+#
+# A blocking verdict (REQUEST_CHANGES) used to exit 1 with zero console
+# output, so the Actions "Verdict gate" step rendered as a bare red ✗ with an
+# empty log and no annotation (Panenco/qit#6486). The gate must emit a visible
+# `::error::` annotation so the failed step explains itself.
+#
+# This executes the REAL scripts/verdict-gate.sh against fixture
+# review-result.json files for each verdict and asserts both the exit code and
+# the emitted annotation. The REQUEST_CHANGES / APPROVE / COMMENT paths make no
+# `gh` API calls (only the missing-file crash path does), so no network/stubs
+# are needed.
+
+cd "$(dirname "$0")/.."
+REPO="$(pwd)"
+GATE="$REPO/scripts/verdict-gate.sh"
+
+fail=0
+
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  case "$haystack" in
+    *"$needle"*) echo "OK:   $label" ;;
+    *) echo "FAIL: $label — expected to find '$needle' in:"; printf '%s\n' "$haystack" | sed 's/^/        /'; fail=$((fail + 1)) ;;
+  esac
+}
+assert_not_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  case "$haystack" in
+    *"$needle"*) echo "FAIL: $label — did NOT expect '$needle' in output"; fail=$((fail + 1)) ;;
+    *) echo "OK:   $label" ;;
+  esac
+}
+assert_eq() {
+  local label="$1" want="$2" got="$3"
+  if [ "$want" = "$got" ]; then echo "OK:   $label"; else echo "FAIL: $label — want '$want', got '$got'"; fail=$((fail + 1)); fi
+}
+
+# run_gate <review-result-json> → sets OUT (combined stdout+stderr) and RC.
+run_gate() {
+  local body="$1"
+  local work; work="$(mktemp -d)"
+  printf '%s' "$body" > "$work/review-result.json"
+  set +e
+  OUT=$(cd "$work" && ANALYZER_OUTCOME=success POSTER_OUTCOME=success \
+        GITHUB_STEP_SUMMARY="$work/summary.md" PR_NUMBER=1 \
+        GITHUB_REPOSITORY=o/r GH_TOKEN=x \
+        bash "$GATE" 2>&1)
+  RC=$?
+  set -e
+  rm -rf "$work"
+}
+
+echo "── REQUEST_CHANGES: must fail AND emit an error annotation ──"
+run_gate '{"verdict":"REQUEST_CHANGES","summary":"s","findings":[{"severity":"major","type":"bug","path":"a.ts","line_start":1,"title":"boom"}]}'
+assert_eq        "exit code 1"          "1" "$RC"
+assert_contains  "emits ::error::"      "::error::" "$OUT"
+assert_contains  "names the verdict"    "REQUEST_CHANGES" "$OUT"
+assert_contains  "states finding count" "1 blocking finding" "$OUT"
+
+echo ""
+echo "── APPROVE: passes, no error annotation ──"
+run_gate '{"verdict":"APPROVE","summary":"ok","findings":[]}'
+assert_eq          "exit code 0"     "0" "$RC"
+assert_not_contains "no ::error::"   "::error::" "$OUT"
+
+echo ""
+echo "── COMMENT: passes with a warning (non-blocking) ──"
+run_gate '{"verdict":"COMMENT","summary":"note","findings":[{"severity":"minor","type":"design-smell","path":"a.ts","line_start":1,"title":"nit"}]}'
+assert_eq          "exit code 0"     "0" "$RC"
+assert_contains    "emits ::warning::" "::warning::" "$OUT"
+assert_not_contains "no ::error::"   "::error::" "$OUT"
+
+echo ""
+if [ "$fail" -eq 0 ]; then
+  echo "All verdict-gate annotation tests passed."
+  exit 0
+else
+  echo "$fail verdict-gate annotation test(s) failed."
+  exit 1
+fi


### PR DESCRIPTION
Closes #61.

## Problem

On a blocking review (`verdict = REQUEST_CHANGES`), the **Verdict gate** step is a bare red ✗ with an empty log and no annotation. Full step output:

```
Run .review-scripts/verdict-gate.sh
##[error]Process completed with exit code 1.
```

Seen on [qit#6486](https://github.com/Panenco/qit/actions/runs/27014088573/job/79724579308). The verdict/findings exist (step summary + posted PR review) but the failed step itself explains nothing — it reads as broken rather than an intentional block.

## Root cause

`verdict-gate.sh` exited 1 for the blocking verdict with zero console output:

```bash
REQUEST_CHANGES)
  exit 1
  ;;
```

Every other branch surfaces something (`COMMENT` → `::warning::`, crash/unknown → `::error::`); only `REQUEST_CHANGES` was silent.

## Fix

Emit an `::error::` annotation (verdict + `$FINDING_COUNT` blocking findings) before `exit 1`, so the failed step is self-explanatory and shows in the run's Annotations list.

New `tests/verdict_gate_annotation_test.sh` (wired into CI) executes the **real** `verdict-gate.sh` against fixtures and asserts annotation + exit code for all three verdicts (REQUEST_CHANGES → exit 1 + `::error::`; APPROVE → exit 0, no error; COMMENT → exit 0 + `::warning::`).

## Test plan

- [x] `bash tests/verdict_gate_annotation_test.sh` passes
- [x] `shellcheck --severity=error scripts/*.sh tests/*.sh` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to CI gate logging and tests only; blocking behavior (exit 1) is unchanged.
> 
> **Overview**
> Fixes blocking reviews where the **Verdict gate** step failed with exit code 1 but showed an empty log and no GitHub Actions annotation, so the failure looked accidental instead of intentional.
> 
> **`verdict-gate.sh`** now prints a `::error::` line before `exit 1` on `REQUEST_CHANGES`, including the verdict and blocking finding count and pointing reviewers to the PR review and run summary (where details already live).
> 
> Adds **`tests/verdict_gate_annotation_test.sh`**, which runs the real gate script against fixture `review-result.json` files and checks exit codes plus annotations for `REQUEST_CHANGES`, `APPROVE`, and `COMMENT`. The test is wired into **`.github/workflows/tests.yml`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25691c09470d02ff9ed026be38fa54f9dce00cae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->