### PR TITLE
feat(review): evidence-first coverage + noise reduction from fleet audit

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -794,6 +794,54 @@ jobs:
             echo "available=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # Round-2 cost tiering: re-resolve the plan against the diff since the
+      # last reviewed commit (scripts/refine-review-plan.sh). Steps BEFORE
+      # this one (Playwright cache/install) gate on the full-PR plan — a
+      # superset, so a refined-off functional never misses its install.
+      # Everything AFTER (dev-env, orchestrator, builder) uses this step.
+      - name: Refine review plan (round 2)
+        id: review_plan2
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+          PRIOR_STATE_AVAILABLE: ${{ steps.prior_state.outputs.available || 'false' }}
+          PRIOR_HEAD_SHA: ${{ steps.prior_state.outputs.prior_head_sha }}
+          ORIG_LEVEL: ${{ steps.review_plan.outputs.review_level }}
+          ORIG_FUNCTIONAL: ${{ steps.review_plan.outputs.run_functional }}
+          ORIG_GATE: ${{ steps.review_plan.outputs.gate }}
+          ORIG_REASON: ${{ steps.review_plan.outputs.reason }}
+          GATE_SKIP_LABEL: ${{ inputs.gate_skip_label }}
+          GATE_DEEP_LABEL: ${{ inputs.gate_deep_label }}
+          GATE_SMALL_CEILING: ${{ inputs.gate_small_ceiling }}
+          GATE_SIZE_CEILING: ${{ inputs.gate_size_ceiling }}
+          GATE_FILE_CEILING: ${{ inputs.gate_file_ceiling }}
+          GATE_SENSITIVE_GLOBS: ${{ inputs.gate_sensitive_globs }}
+          GATE_BASE_REF: ${{ github.base_ref }}
+          GATE_HEAD_REF: ${{ github.head_ref }}
+        run: |
+          set -uo pipefail
+          ROUND2_AVAILABLE=false
+          SINCE_FILES_TSV=""
+          PRIOR_LEVEL=""
+          if [ "$PRIOR_STATE_AVAILABLE" = "true" ] && [ -n "${PRIOR_HEAD_SHA:-}" ] \
+             && git cat-file -e "${PRIOR_HEAD_SHA}^{commit}" 2>/dev/null; then
+            ROUND2_AVAILABLE=true
+            SINCE_FILES_TSV=$(git diff --numstat "$PRIOR_HEAD_SHA"..HEAD -- 2>/dev/null \
+              | awk -F'\t' 'NF >= 3 {print $3 "\t" $1 "\t" $2}' || true)
+            PRIOR_LEVEL=$(jq -r '.review_level // empty' /tmp/prior-state/review-state.json 2>/dev/null || echo "")
+          fi
+          GATE_LABELS=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json labels --jq '.labels[].name' 2>/dev/null || echo "")
+          export ROUND2_AVAILABLE SINCE_FILES_TSV PRIOR_LEVEL GATE_LABELS
+          PLAN=$(.review-scripts/refine-review-plan.sh)
+          echo "Round-2 plan:"; echo "$PLAN" | sed 's/^/  /'
+          {
+            grep -E '^(review_level|run_functional|gate)=' <<< "$PLAN"
+            echo "reason<<__GATE_EOF__"
+            grep '^reason=' <<< "$PLAN" | cut -d= -f2-
+            echo "__GATE_EOF__"
+          } >> "$GITHUB_OUTPUT"
+
       # Extract every recognized ticket-reference pattern from the branch name,
       # PR title, and PR body into a structured candidates file. Provider-agnostic:
       # we never hardcode a tracker's host or ID format. The optional hook script
@@ -970,6 +1018,22 @@ jobs:
             : > /tmp/external-issue.md
           }
 
+      # Package-manager store cache: dev-start.sh runs the consumer's
+      # `pnpm install` from a cold store every run otherwise. Content-
+      # addressable stores make even stale restore-key hits save most of the
+      # download. Round-2 runs hit the cache saved by round 1 on this branch;
+      # first rounds hit the base-scoped cache from the warm-cache job below.
+      - name: Cache package-manager store
+        if: steps.actor_gate.outputs.proceed == 'true' && steps.code_check.outputs.needs_build == 'true' && hashFiles('.github/claude-review/dev-start.sh') != '' && steps.review_plan2.outputs.run_functional == 'true'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.local/share/pnpm/store
+            ~/.npm
+          key: ${{ runner.os }}-pkg-store-${{ hashFiles('**/pnpm-lock.yaml', '**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-pkg-store-
+
       # Launch the consumer's dev environment in the background so it brings
       # up alongside the context-builder + Playwright MCP setup, instead of
       # blocking the analyzer fan. The wait step further down reaps the PID
@@ -980,7 +1044,7 @@ jobs:
       # owning its own dependency install. Without it, no dev-env launches
       # and the functional tester runs in skip strategy.
       - name: Pre-start dev environment (background)
-        if: steps.actor_gate.outputs.proceed == 'true' && steps.code_check.outputs.needs_build == 'true' && hashFiles('.github/claude-review/dev-start.sh') != '' && steps.review_plan.outputs.run_functional == 'true'
+        if: steps.actor_gate.outputs.proceed == 'true' && steps.code_check.outputs.needs_build == 'true' && hashFiles('.github/claude-review/dev-start.sh') != '' && steps.review_plan2.outputs.run_functional == 'true'
         id: dev_env_bg
         shell: bash
         env:
@@ -1109,10 +1173,10 @@ jobs:
           MODEL_FUNCTIONAL: ${{ inputs.model_functional }}
           FUNCTIONAL_MAX_TURNS: ${{ inputs.functional_max_turns }}
           # Review plan (from the resolver step) — the orchestrator honours review_level.
-          REVIEW_LEVEL: ${{ steps.review_plan.outputs.review_level }}
-          RUN_FUNCTIONAL: ${{ steps.review_plan.outputs.run_functional }}
-          GATE: ${{ steps.review_plan.outputs.gate }}
-          GATE_REASON: ${{ steps.review_plan.outputs.reason }}
+          REVIEW_LEVEL: ${{ steps.review_plan2.outputs.review_level }}
+          RUN_FUNCTIONAL: ${{ steps.review_plan2.outputs.run_functional }}
+          GATE: ${{ steps.review_plan2.outputs.gate }}
+          GATE_REASON: ${{ steps.review_plan2.outputs.reason }}
         with:
           claude_code_oauth_token: ${{ env.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.review_identity.outputs.token }}
@@ -1146,8 +1210,11 @@ jobs:
           # Review-plan gate (from the Resolve review plan step). build-review.sh
           # waives the technical-change smoke withhold only when the plan
           # turned functional off (RUN_FUNCTIONAL != true).
-          GATE: ${{ steps.review_plan.outputs.gate }}
-          RUN_FUNCTIONAL: ${{ steps.review_plan.outputs.run_functional }}
+          GATE: ${{ steps.review_plan2.outputs.gate }}
+          RUN_FUNCTIONAL: ${{ steps.review_plan2.outputs.run_functional }}
+          # Persisted into review-state.json so the next round's escalation
+          # guard knows whether a full review ever ran on this PR.
+          REVIEW_LEVEL: ${{ steps.review_plan2.outputs.review_level }}
           # Bot-authored PRs (renovate/dependabot) waive the manual-spec gate.
           PR_AUTHOR_IS_BOT: ${{ steps.pr_sha.outputs.author_is_bot }}
           # claude-code-action's JSONL conversation log. build-review.sh greps
@@ -1304,12 +1371,15 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-  # pull_request_target writes cache to main scope. Keep this job PR-code-free.
+  # pull_request_target writes cache to main scope. Keep this job PR-code-free:
+  # the checkout below lands on the BASE ref (pull_request_target's default
+  # sha), and `pnpm fetch` reads only the lockfile — no lifecycle scripts run.
   warm-cache:
     if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "lts/*"
@@ -1324,3 +1394,40 @@ jobs:
       - run: |
           npx --yes "playwright@${PLAYWRIGHT_VERSION}" install chromium --with-deps
           npx --yes -p "@playwright/mcp@${PLAYWRIGHT_MCP_VERSION}" -- node -e 0
+      # Restore/save are split so a FAILED fetch never saves: the all-in-one
+      # cache action would persist an empty store under the exact lockfile
+      # key, and every later run would exact-hit the poisoned key and skip
+      # its own save until the lockfile changes.
+      - name: Restore package-manager store
+        id: store_restore
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.local/share/pnpm/store
+            ~/.npm
+          key: ${{ runner.os }}-pkg-store-${{ hashFiles('**/pnpm-lock.yaml', '**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-pkg-store-
+      - name: Fetch base-lockfile packages into the store
+        id: store_fetch
+        run: |
+          echo "fetched=false" >> "$GITHUB_OUTPUT"
+          if [ ! -f pnpm-lock.yaml ]; then
+            echo "No root pnpm-lock.yaml — store warm skipped."
+            exit 0
+          fi
+          corepack enable 2>/dev/null || true
+          command -v pnpm >/dev/null 2>&1 || npm install -g pnpm
+          if pnpm fetch; then
+            echo "fetched=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::pnpm fetch failed — store warm is best-effort, reviews are unaffected."
+          fi
+      - name: Save package-manager store
+        if: steps.store_fetch.outputs.fetched == 'true' && steps.store_restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.local/share/pnpm/store
+            ~/.npm
+          key: ${{ runner.os }}-pkg-store-${{ hashFiles('**/pnpm-lock.yaml', '**/package-lock.json') }}

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -48,7 +48,7 @@ on:
         type: number
         default: 200
       allowed_bots:
-        description: "Comma-separated bot logins allowed to trigger the review (e.g. 'panenco-automation'), or '*' for all bots. Empty (default) preserves the action's default of blocking all bot-initiated runs."
+        description: "Comma-separated bot logins allowed to trigger the review (e.g. 'panenco-automation'), or '*' for all bots. Runs triggered by any other bot are skipped cleanly (green check, no crash banner). Empty (default) skips all bot-initiated runs."
         required: false
         type: string
         default: ""
@@ -63,7 +63,7 @@ on:
         type: string
         default: "deep-review"
       gate_small_ceiling:
-        description: "Non-generated changed lines at/under which a runtime PR is `small` (single-judge `light` review, no functional). See docs/review-plan.md."
+        description: "Non-generated changed lines at/under which a runtime PR is `small` (single-judge `light` review with a quick functional pass). See docs/review-plan.md."
         required: false
         type: number
         default: 300
@@ -132,6 +132,12 @@ jobs:
     if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    # A push mid-review supersedes the in-flight run: cancel it instead of
+    # paying for two full reviews of which one is already stale. Cancelled
+    # runs post nothing (no crash banner) — the new run covers the PR.
+    concurrency:
+      group: claude-review-pr-${{ github.event.pull_request.number || inputs.pr_number }}
+      cancel-in-progress: true
     permissions:
       contents: write # write needed for uploading screenshots to review-assets branch
       pull-requests: write
@@ -140,6 +146,39 @@ jobs:
       packages: read # needed for fetching from private registries when the consumer repo uses them
 
     steps:
+      # Bot-triggered runs that aren't allowed would otherwise burn a token
+      # probe, fail inside claude-code-action ("non-human actor"), and leave
+      # a red check + crash banner on every push of every renovate/dependabot
+      # PR. Skip the review cleanly instead: green check, one ::notice::, no
+      # banner. claude-code-action's own allowed_bots check stays as backstop.
+      - name: Bot-actor gate
+        id: actor_gate
+        shell: bash
+        env:
+          ACTOR: ${{ github.actor }}
+          ALLOWED_BOTS: ${{ inputs.allowed_bots }}
+        run: |
+          PROCEED=true
+          case "$ACTOR" in
+            *"[bot]")
+              LOGIN="${ACTOR%\[bot\]}"
+              PROCEED=false
+              if [ "$ALLOWED_BOTS" = "*" ]; then
+                PROCEED=true
+              else
+                IFS=',' read -ra ALLOW <<< "$ALLOWED_BOTS"
+                for b in "${ALLOW[@]}"; do
+                  b="$(echo "$b" | tr -d '[:space:]')"
+                  if [ "$b" = "$LOGIN" ] || [ "$b" = "$ACTOR" ]; then PROCEED=true; fi
+                done
+              fi
+              if [ "$PROCEED" = "false" ]; then
+                echo "::notice::Run triggered by bot '$ACTOR', which is not in allowed_bots — skipping the review (no crash banner, no red check). Add '$LOGIN' to the caller's allowed_bots input to review this bot's PRs."
+              fi
+              ;;
+          esac
+          echo "proceed=$PROCEED" >> "$GITHUB_OUTPUT"
+
       - name: Resolve PR head SHA
         # On `pull_request` events, github.event.pull_request.head.sha is set.
         # On `workflow_dispatch`, that field is empty and we'd otherwise fall
@@ -153,7 +192,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
         run: |
           set -euo pipefail
-          PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefOid,headRepositoryOwner,headRepository)
+          PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefOid,headRepositoryOwner,headRepository,author)
           SHA=$(jq -r '.headRefOid // empty' <<< "$PR_JSON")
           HEAD_OWNER=$(jq -r '.headRepositoryOwner.login // empty' <<< "$PR_JSON")
           HEAD_NAME=$(jq -r '.headRepository.name // empty' <<< "$PR_JSON")
@@ -177,6 +216,7 @@ jobs:
           fi
 
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "author_is_bot=$(jq -r '.author.is_bot // false' <<< "$PR_JSON")" >> "$GITHUB_OUTPUT"
           echo "Resolved PR #$PR_NUMBER head SHA: $SHA (origin $HEAD_REPO)"
 
       - name: Checkout PR head
@@ -227,6 +267,7 @@ jobs:
       # installer is idempotent: when the action subsequently fires and
       # finds an existing binary, it leaves it in place.
       - name: Install Claude CLI (for OAuth token picker)
+        if: steps.actor_gate.outputs.proceed == 'true'
         shell: bash
         run: |
           if [ -x "$HOME/.local/bin/claude" ]; then
@@ -248,6 +289,7 @@ jobs:
       # the context-builder hit rate_limit on its first call.
       - name: Pick Claude OAuth token
         id: token_picker
+        if: steps.actor_gate.outputs.proceed == 'true'
         shell: bash
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -405,13 +447,13 @@ jobs:
       # Anything compile-shaped that the agent still wants to check is one
       # Bash call away from the orchestrator.
       - name: Set up Node
-        if: steps.code_check.outputs.needs_build == 'true'
+        if: steps.actor_gate.outputs.proceed == 'true' && steps.code_check.outputs.needs_build == 'true'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "lts/*"
 
       - name: Ensure pnpm on PATH
-        if: steps.code_check.outputs.needs_build == 'true'
+        if: steps.actor_gate.outputs.proceed == 'true' && steps.code_check.outputs.needs_build == 'true'
         shell: bash
         run: |
           if command -v pnpm >/dev/null 2>&1; then
@@ -436,7 +478,7 @@ jobs:
       # mirrors the path the subagent's mcpServers config writes to.
       - name: Cache Playwright assets
         id: pw_cache
-        if: steps.code_check.outputs.needs_build == 'true' && steps.review_plan.outputs.run_functional == 'true'
+        if: steps.actor_gate.outputs.proceed == 'true' && steps.code_check.outputs.needs_build == 'true' && steps.review_plan.outputs.run_functional == 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
@@ -447,7 +489,7 @@ jobs:
             ${{ runner.os }}-pw-
 
       - name: Install Playwright + MCP
-        if: steps.code_check.outputs.needs_build == 'true' && steps.review_plan.outputs.run_functional == 'true'
+        if: steps.actor_gate.outputs.proceed == 'true' && steps.code_check.outputs.needs_build == 'true' && steps.review_plan.outputs.run_functional == 'true'
         shell: bash
         run: |
           # set -uo pipefail (no explicit -e) per .github/review-config.md +
@@ -938,7 +980,7 @@ jobs:
       # owning its own dependency install. Without it, no dev-env launches
       # and the functional tester runs in skip strategy.
       - name: Pre-start dev environment (background)
-        if: steps.code_check.outputs.needs_build == 'true' && hashFiles('.github/claude-review/dev-start.sh') != '' && steps.review_plan.outputs.run_functional == 'true'
+        if: steps.actor_gate.outputs.proceed == 'true' && steps.code_check.outputs.needs_build == 'true' && hashFiles('.github/claude-review/dev-start.sh') != '' && steps.review_plan.outputs.run_functional == 'true'
         id: dev_env_bg
         shell: bash
         env:
@@ -1032,8 +1074,16 @@ jobs:
           # round 2).
           bash "${CLAUDE_REVIEW_PIPELINE_DIR}/scripts/install-functional-tester-agent.sh"
 
+      - name: Start orchestrate stopwatch
+        if: steps.actor_gate.outputs.proceed == 'true'
+        shell: bash
+        run: |
+          source .review-scripts/phase-timing.sh
+          phase_start orchestrate
+
       - name: "Review: orchestrate"
         id: claude_run
+        if: steps.actor_gate.outputs.proceed == 'true'
         # Don't fail the job if the orchestrator returns non-zero (e.g.
         # max-turns hit at the STOP-and-write anchor). /tmp/all-findings.json
         # and /tmp/review-meta.json may still have been written; the
@@ -1094,9 +1144,12 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
           PRIOR_STATE_AVAILABLE: ${{ steps.prior_state.outputs.available || 'false' }}
           # Review-plan gate (from the Resolve review plan step). build-review.sh
-          # waives the technical-change smoke withhold when functional was
-          # intentionally gated off (any gate other than 'normal').
+          # waives the technical-change smoke withhold only when the plan
+          # turned functional off (RUN_FUNCTIONAL != true).
           GATE: ${{ steps.review_plan.outputs.gate }}
+          RUN_FUNCTIONAL: ${{ steps.review_plan.outputs.run_functional }}
+          # Bot-authored PRs (renovate/dependabot) waive the manual-spec gate.
+          PR_AUTHOR_IS_BOT: ${{ steps.pr_sha.outputs.author_is_bot }}
           # claude-code-action's JSONL conversation log. build-review.sh greps
           # it for `"error":"rate_limit"` / `hit your limit · resets …` so the
           # quota-specific error annotation fires (instead of a generic crash
@@ -1104,6 +1157,8 @@ jobs:
           ORCHESTRATOR_EXEC: ${{ steps.claude_run.outputs.execution_file }}
         run: |
           set -uo pipefail
+          source .review-scripts/phase-timing.sh
+          phase_end orchestrate
           # Hand off the orchestrator's conversation log under the path
           # build-review.sh expects. Best-effort — a missing/empty
           # execution_file just means the quota-specific branch in

--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ When the round-2 ladder overrides the bot's per-PR judgement (e.g. STILL_PRESENT
 
 **Crash-banner cleanup:** when a run crashes before posting a review (OAuth quota, max-turns, runner OOM), the workflow posts a single review carrying the `<!-- claude-review-crash -->` HTML marker. The next successful run finds that review and edits its body to a "_Superseded by …_" form so the misleading red banner doesn't survive every retry.
 
+**Round-2 cost follows the follow-up, not the PR.** The review plan is re-resolved against the since-last diff shape: a small fix-up commit gets a single-judge pass + quick functional instead of the full Opus + Haiku debate, while large or sensitive-path follow-ups keep the full fan. Guards: the `deep-review` label pins the full plan every round, and a PR that has never had a full round (it grew past the ceilings through small pushes) escalates back to one. See [Review plan → Round 2](docs/review-plan.md#round-2-the-plan-follows-the-follow-up-not-the-pr).
+
 If the prior state artifact is missing (retention expired, prior run failed before upload), round 2 degrades to a clean full re-review with a `::notice::` explaining why.
 
 On round 2 the test planner also rescopes the functional run: scenarios are planned against `/tmp/since-last.diff` rather than the full PR diff, and **zero scenarios is a valid outcome**. A small follow-up commit drops to `quick` (one scenario over the touched area) when since-last has user-observable surface, or `skip` (no scenarios) when since-last is comments / log strings / type-only / internal-helper / docs / config / dev-tooling — anything a user wouldn't notice. The smoke gate inherits the prior round's `functional_overall` for technical-change PRs, so a `skip` on round 2 doesn't drop APPROVE → COMMENT (inheritance kicks in only for prior PASS/WARN; a prior FAIL still blocks). Prior `critical`/`major` functional findings whose path is in since-last AND is plausibly the area being fixed get one targeted retest scenario; otherwise the resolution-checker + dedup re-evaluate them independently.
@@ -303,6 +305,7 @@ Rules:
 - Readiness loops must explicitly test the flag after the loop and `exit 1` on timeout. Silent-success loops are flagged by the reviewer.
 - Paths in `cp`/`source`/`cat` are scanned at job start; the Validate step warns if any don't exist.
 - Pin your package manager. The runner provides a default pnpm (`pnpm/action-setup` with `version: 10`) so scripts that call `pnpm` directly keep working, but it won't necessarily match your local version. For pnpm/yarn projects, set `"packageManager"` in the root `package.json` and call `corepack enable` near the top of `dev-start.sh` to activate the exact version you pinned.
+- Installs are store-cached for you. The pipeline caches the pnpm/npm store across runs (keyed on your lockfiles, warmed in main scope so new PRs hit it too), so `pnpm install --frozen-lockfile` in `dev-start.sh` mostly links from cache instead of downloading. No consumer wiring needed.
 
 If the project has nothing to start (pure-docs, lib-only), do **not** create this file. Its absence is the signal for degraded mode (core + sweep reviewers run; no functional tester). An empty-but-present `dev-start.sh` will fail the step.
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ with:
 
 Without `pipeline_ref`, the install defaults to `@v2` and consumers get new orchestration on old skills, which fails at max-turns. The `@v2` default is correct for normal use; only override during testing.
 
-**Allowing bot-opened PRs.** By default the underlying action blocks any run triggered by a non-human actor, so PRs opened by an automation bot fail at the orchestrator step with `Workflow initiated by non-human actor`. Opt in per-repo by passing `allowed_bots` (comma-separated bot logins, or `*` for all bots) on the caller's `with:` block. Use the login **without** the `[bot]` suffix — it matches `github.actor`:
+**Allowing bot-opened PRs.** By default, runs triggered by a non-human actor (renovate, dependabot, automation bots) are skipped cleanly — a green check with a `::notice::`, no review, no crash banner. Opt in per-repo by passing `allowed_bots` (comma-separated bot logins, or `*` for all bots) on the caller's `with:` block. Use the login **without** the `[bot]` suffix — it matches `github.actor`:
 
 ```yaml
 with:
@@ -58,7 +58,7 @@ with:
   allowed_bots: panenco-automation   # not "panenco-automation[bot]"
 ```
 
-Empty (the default) preserves today's behaviour — all bot-initiated runs stay blocked. This is a safe, opt-in change for every existing consumer.
+Empty (the default) skips all bot-initiated runs. Two notes for allowed bots: dependabot-triggered events receive *Dependabot secrets*, not Actions secrets — add `CLAUDE_CODE_OAUTH_TOKEN` there too or the token picker fails. And bot-authored PRs waive the manual-spec gate (a machine PR can never link a human spec), so they can reach APPROVE on review merit alone.
 
 ### 2. Set secrets
 
@@ -132,6 +132,8 @@ PR opened / updated
 Verdict: APPROVE / COMMENT / REQUEST_CHANGES
 ```
 
+**Check color ≠ verdict.** The workflow check is green whenever a review was successfully posted — including `REQUEST_CHANGES`. The blocking signal is the PR review itself; use branch protection's required-review settings if you want a blocking verdict to prevent merging. A red check always means the pipeline failed: no review was produced, or a computed verdict never reached the PR. (Earlier versions failed the check on `REQUEST_CHANGES`, which made real pipeline failures indistinguishable from working reviews and trained authors to re-run good runs.)
+
 ### Why one top-level agent?
 
 Two practical wins. (1) **Native rate-limit fast-fail.** `anthropics/claude-code-action` exits in <1 s when the OAuth token hits a quota wall; the bare `claude -p` CLI silently retries and _hangs_ until the 45-minute job timeout — a real bug observed on PR #309. (2) **All parallelism through the `Task` tool.** No bash background processes, no `wait`/reap traps, no sibling stdout files. One nested transcript covers the whole review.
@@ -140,7 +142,7 @@ Two practical wins. (1) **Native rate-limit fast-fail.** `anthropics/claude-code
 
 A single LLM judge can have a bad sample on any given run — miss something subtle, over-grade a defensive note, mis-route a finding to the wrong file. The orchestrator runs **two independent judges with different model strengths** (Opus for deep reasoning, Haiku for cheap broad-coverage finds) and reconciles them: if they agree, the review ships immediately; if they disagree, each judge sees the other's findings and either concedes the ones they missed or defends the ones the other dropped. This catches the long tail where one judge is wrong without paying for it on every PR — most reviews converge on the first round.
 
-> **Not every PR needs that depth.** A deterministic resolver classifies each PR up front and reserves the two-judge debate + functional run for substantial or sensitive changes; small, low-risk PRs take a lighter single-judge pass. See **[Review plan](docs/review-plan.md)** for the tiers, the `skip-review` / `deep-review` labels, and per-repo tuning — and [ADR 0001](docs/adr/0001-risk-tiered-review-depth.md) for why.
+> **Not every PR needs that depth.** A deterministic resolver classifies each PR up front and reserves the two-judge debate for substantial or sensitive changes; small or oversized PRs take a lighter single-judge pass. Functional testing is gated separately and stays on for every runtime diff — screenshots of the running app are the review's centerpiece, so a small UI fix still gets its quick smoke + screenshot pass and a big feature still gets a smoke run even when the judge fan is light. See **[Review plan](docs/review-plan.md)** for the tiers, the `skip-review` / `deep-review` labels, and per-repo tuning — and [ADR 0001](docs/adr/0001-risk-tiered-review-depth.md) for why.
 
 ### Round 1 vs round 2
 
@@ -151,6 +153,7 @@ The pipeline persists a small state artifact (`/tmp/review-state.json`) on every
 - Prior `COMMENT`, no new blockers → per-PR verdict (APPROVE when the per-PR judgement is APPROVE, COMMENT when minor findings remain). The ladder no longer pins prior=COMMENT to COMMENT — that ratchet was the source of "bot says Would APPROVE but verdict says COMMENT" contradictions.
 - Any prior verdict + ≥1 new critical/major → `REQUEST_CHANGES` (handled by the per-PR ladder upstream).
 - Prior review **dismissed by the author** → treat prior verdict as APPROVE for ladder purposes (the dismissal is the strongest signal a human gives the bot; we don't re-enforce findings the author has rejected). Surfaced as a banner in the review body.
+- Prior finding **rebutted by the author** (a substantive reply disputing it, code unchanged) → classified `REBUTTED`: it stops counting as a still-present blocker, and the review body lists it under "Dropped after author rebuttal" so a blocker never silently evaporates between rounds.
 
 When the round-2 ladder overrides the bot's per-PR judgement (e.g. STILL_PRESENT blockers force REQUEST_CHANGES on a clean re-review), the body prepends a one-line "Verdict pinned to X by the round-2 ladder" rationale so the body's narrative never contradicts the header.
 
@@ -462,7 +465,7 @@ Note: a _present but broken_ `dev-start.sh` is **not** a soft-degrade case — t
 
 ## Spec-presence gate
 
-The pipeline withholds `APPROVE` whenever the PR has no human-authored spec. The core reviewer judges this from the spec sources gathered in `context.md` — a linked GitHub issue with a non-trivial body, a PRD, an external-tracker spec, or a substantive manually-written PR-body section all qualify. Auto-generated PR descriptions (Cursor, Cursor Bugbot, CodeRabbit, Gemini Code Assist, Claude Code) describe what the diff _does_, not what it _should do_, and don't qualify on their own — they're a code summary, not a contract. When the core reviewer sets `manual_spec_present: false`, the verdict is downgraded from `APPROVE` to `COMMENT` and the review body explains how to fix it (link an issue, paste acceptance criteria, or wire up an external tracker). Findings still post normally; only the green-check approval is gated.
+The pipeline withholds `APPROVE` whenever the PR has no human-authored spec. The core reviewer judges this from the spec sources gathered in `context.md` — a linked GitHub issue with a non-trivial body, a PRD, an external-tracker spec, or a substantive manually-written PR-body section all qualify. Auto-generated PR descriptions (Cursor, Cursor Bugbot, CodeRabbit, Gemini Code Assist, Claude Code) describe what the diff _does_, not what it _should do_, and don't qualify on their own — they're a code summary, not a contract. When the core reviewer sets `manual_spec_present: false`, the verdict is downgraded from `APPROVE` to `COMMENT` and the review body explains how to fix it (link an issue, paste acceptance criteria, or wire up an external tracker). Findings still post normally; only the green-check approval is gated. Bot-authored PRs (renovate, dependabot) are exempt — a machine PR can never carry a human spec, so the gate would be permanent noise there.
 
 ## Smoke-test gate for technical PRs
 
@@ -582,7 +585,7 @@ The pipeline consists of:
   - `review-orchestrator` — the single top-level Claude Code agent; dispatches the context builder, judges, thread classifier, and functional tester via the `Task` tool, runs the debate, writes the final findings + meta
   - `review-context-builder` — Task subagent; gathers PR metadata, diff index, spec sources, and a 5-sentence diff summary into `context.md`
   - `review-judge` — Task subagent skill used by both the Opus and Haiku judges (correctness, security, spec, consistency, performance, tests)
-  - `review-thread-classifier` — Task subagent (round-2 only); classifies prior findings + open inline threads (own bot, other bots, **humans**) as RESOLVED / STILL_PRESENT / NEW_CONTEXT
+  - `review-thread-classifier` — Task subagent (round-2 only); classifies prior findings + open inline threads (own bot, other bots, **humans**) as RESOLVED / STILL_PRESENT / REBUTTED / NEW_CONTEXT
   - `review-functional-tester` — custom subagent type (auto-discovered from `.claude/agents/review-functional-tester.md`, written at workflow runtime); inline `mcpServers` block defines Playwright MCP scoped to this subagent, so the server starts when it spawns rather than relying on parent inheritance. First turn is an MCP smoke check that hard-fails the run as `overall: CRASH` if MCP is unavailable — silent fallback to curl is forbidden.
   - `review-test-planner` — embedded inside the context builder skill; picks the functional strategy (skip / quick / functional / pipeline-self-test) and writes scenarios into `test-plan.md`
 - **Functional prompt template** (`scripts/functional-prompt.template.txt`) — bootstraps the functional tester with auth + env info

--- a/docs/review-plan.md
+++ b/docs/review-plan.md
@@ -36,6 +36,24 @@ match:
 
 A `deep-review` label (see below) flips rungs 2, 3, and 5 to `full`.
 
+## Round 2: the plan follows the follow-up, not the PR
+
+Follow-up rounds are most of the fleet's volume, and a 10-line fix-up on an
+800-line PR doesn't need the full Opus + Haiku debate — round-2 judges are
+already scoped to the diff since the last review, the verdict ladder pins
+unresolved prior blockers, and the thread classifier runs regardless of judge
+count. So when prior review state exists, the plan is re-resolved against the
+**since-last diff shape** (`scripts/refine-review-plan.sh`):
+
+- Small, non-sensitive follow-up → `light` single judge + quick functional.
+- Empty since-last (same-SHA re-run) → `light`, no functional.
+- Large or sensitive-path follow-up → `full`, exactly as round 1.
+- `deep-review` label → full-PR plan, every round.
+- Escalation guard: if the PR as a whole warrants `full` and **no prior round
+  ran one** (the PR grew past the ceilings through small pushes), the round
+  escalates to the full-PR plan — a PR can never reach merge without at least
+  one full debate.
+
 ## Labels
 
 | label | effect |

--- a/docs/review-plan.md
+++ b/docs/review-plan.md
@@ -15,13 +15,19 @@ match:
 |---|------|------|--------------|------------|
 | 1 | `label` | `skip-review` label present | `skip` | no |
 | 2 | `promotion` | release/promotion PR (e.g. `staging` → `main`) | `light` | no |
-| 3 | `oversized` | over the size ceiling (default 1500 lines / 40 files) | `light` | no |
+| 3 | `oversized` | over the size ceiling (default 1500 lines / 40 files) | `light` | yes |
 | 4 | `nonruntime` | only tests / docs / CI / lockfiles changed | `full` | no |
-| 5 | `small` | ≤ 300 non-generated lines, no sensitive paths | `light` | no |
+| 5 | `small` | ≤ 300 non-generated lines, no sensitive paths | `light` | yes |
 | 6 | `normal` | substantial, **or** touches a sensitive path | `full` | yes |
 
 - **`full`** — the dual-judge debate (Opus + Haiku, with rebuttal).
-- **`light`** — a single judge, no rebuttal, no functional. The fast path.
+- **`light`** — a single judge, no rebuttal. The fast path for the judge fan only:
+  functional testing still runs per the table, because runtime evidence is the
+  review's centerpiece — small UI fixes are exactly where one screenshot beats
+  prose, and oversized feature PRs are exactly where an APPROVE without runtime
+  evidence is riskiest. The test planner still scopes the run (a small diff with
+  no user-observable surface plans `skip`; a trivial one plans a 1-scenario
+  `quick`), so the cost scales with the surface, not the gate.
 - **`skip`** — no judges; the reason is posted as a note.
 
 > Generated files (lockfiles, snapshots, `dist/`, `*.min.*`, `*.generated.*`, …)
@@ -29,11 +35,6 @@ match:
 > into `full`.
 
 A `deep-review` label (see below) flips rungs 2, 3, and 5 to `full`.
-
-> **Rollout:** the classification above — and turning functional off for `light` —
-> is live now. The orchestrator's single-judge handling for `light` lands alongside
-> it; until that ships, a `light` PR is classified correctly and skips functional but
-> still runs the two-judge debate. See [ADR 0001](adr/0001-risk-tiered-review-depth.md).
 
 ## Labels
 
@@ -87,9 +88,10 @@ with:
 
 | PR | gate | what runs |
 |----|------|-----------|
-| 40-line bug fix in `src/` | `small` | single-judge `light`, fast |
+| 40-line bug fix in `src/` | `small` | single judge + quick functional check (screenshot of the touched surface) |
 | 500-line feature | `normal` | full debate + functional |
+| 2000-line feature | `oversized` | single judge + functional smoke run |
 | 20-line change in `database/migrations/` | `normal` (sensitive) | full debate + functional |
-| `staging` → `main` release | `promotion` | single-judge `light` |
+| `staging` → `main` release | `promotion` | single-judge `light`, no functional |
 | docs-only PR | `nonruntime` | judges run, no functional |
 | small but tricky PR you want fully reviewed | add `deep-review` | full debate + functional |

--- a/prompts/setup-review.md
+++ b/prompts/setup-review.md
@@ -471,8 +471,11 @@ Push the changes on a branch, open a PR, and verify the workflow triggers. Expec
 - Dev env setup starts your services (look for `API ready at ...` in logs — not just `API=false`)
 - "Install functional-tester subagent definition" writes `.claude/agents/review-functional-tester.md` to the runner's checkout (this is what gives the functional tester its own scoped Playwright MCP server — don't commit this file to your repo, the workflow rewrites it on every run from the `inputs.model_functional` value)
 - Orchestrator runs the two judges (Opus + Haiku) in parallel and (when applicable) the functional tester. The judge debate produces a single, deduped findings list — there is no separate `core` / `sweep` step.
+- Functional testing runs on **every runtime diff**, including small PRs (single-judge `light` tier gets a quick 1-scenario pass) and oversized PRs (smoke run). This is why `dev-start.sh` matters even for repos that mostly ship small PRs — without it, most day-to-day reviews carry no runtime evidence and refactor PRs can't reach APPROVE (smoke gate).
+- PRs opened by bots (renovate, dependabot) are skipped cleanly by default — green check, no review, no crash banner. To review a bot's PRs, pass `allowed_bots: <login>` (without the `[bot]` suffix) on the caller's `with:` block; for dependabot also add the OAuth token to *Dependabot secrets*. Bot-authored PRs waive the manual-spec gate.
 - For PRs with UI surface, the functional tester's Turn 1 is an MCP smoke check (`mcp__playwright__browser_navigate` to `about:blank`). If MCP is unavailable, the run hard-fails with `overall: CRASH` and the verdict gate flags it as `requires_human_review`. Silent fallback to curl/psql is forbidden — a curl-only PASS on a UI fix is the bug we're guarding against.
 - **Verdict: APPROVE** — because you followed Step 5's self-check. If you see findings here, read them and tighten the config; they're almost always real and point at something fixable.
+- The workflow check is **green whenever a review posted**, even on `REQUEST_CHANGES` — the verdict lives in the PR review (use branch protection's required reviews to make it block merges). A red check means the pipeline itself failed.
 
 ## Verdict ladder (round 2)
 
@@ -483,5 +486,6 @@ When you push follow-up commits to the same PR, the bot runs a round-2 review th
 - Prior `REQUEST_CHANGES` resolved + no new blockers → per-PR verdict (APPROVE if clean, COMMENT if minor findings remain).
 - Prior `COMMENT` + per-PR verdict APPROVE → `APPROVE`. The bot does NOT pin a follow-up to COMMENT just because the prior round was COMMENT — fixing the one issue the bot flagged should land you on green.
 - You dismissed the prior review → the bot treats it as if you'd accepted that round and evaluates the new commits independently.
+- You replied to a finding's thread disputing it (with a reason) and didn't change the code → the finding is classified `REBUTTED`: it stops blocking and the next review lists it under "Dropped after author rebuttal" instead of silently disappearing or nagging forever.
 
 Severities matter: `critical` and `major` block; `minor` and `note` post inline but never gate APPROVE. A doc-only nit (typo, wrong package name in a paragraph) is `note` — it shows up in the review but won't hold the PR at COMMENT. If the bot grades a doc nit as `minor` or higher, that's a calibration bug worth flagging in feedback.

--- a/prompts/setup-review.md
+++ b/prompts/setup-review.md
@@ -479,7 +479,7 @@ Push the changes on a branch, open a PR, and verify the workflow triggers. Expec
 
 ## Verdict ladder (round 2)
 
-When you push follow-up commits to the same PR, the bot runs a round-2 review that looks at the diff since its previous review. Verdict rules:
+When you push follow-up commits to the same PR, the bot runs a round-2 review that looks at the diff since its previous review. Small follow-ups get a lighter (single-judge) pass scoped to what changed — large or sensitive follow-ups get the full review again, and the `deep-review` label forces the full review every round. Verdict rules:
 
 - New `critical` or `major` finding → `REQUEST_CHANGES`.
 - Prior `REQUEST_CHANGES` blocker still present → `REQUEST_CHANGES` (keeps until you actually fix it).

--- a/scripts/build-review.sh
+++ b/scripts/build-review.sh
@@ -122,13 +122,19 @@ CORE_META=$(cat /tmp/review-meta.json)
 # `/tmp/resolution-findings.json` into `/tmp/all-findings.json` before
 # exiting; this safety net catches the rare case where the LLM forgot or
 # crashed mid-write, ensuring a major/critical net-new from the
-# classifier still lands in the verdict gate. Dedup by id so an entry
-# already merged by the orchestrator isn't double-counted.
+# classifier still lands in the verdict gate. Dedup by id AND by content
+# (path+title): the orchestrator re-ids merged entries to `j*`, so an
+# id-only check re-appends entries it already folded in — observed as
+# byte-identical duplicate inline comments in one posted review.
 if [ -f /tmp/resolution-findings.json ] && jq -e 'type == "array" and length > 0' /tmp/resolution-findings.json >/dev/null 2>&1; then
   MERGED=$(jq -s '
     (.[0] // []) as $primary |
     ($primary | map(.id)) as $seen |
-    $primary + ((.[1] // []) | map(select(.id as $id | $seen | index($id) | not)))
+    ($primary | map((.path // "") + "|" + (.title // ""))) as $seen_content |
+    $primary + ((.[1] // []) | map(select(
+      (.id as $id | $seen | index($id) | not)
+      and (((.title // "") == "") or (((.path // "") + "|" + (.title // "")) as $k | $seen_content | index($k) | not))
+    )))
   ' /tmp/all-findings.json /tmp/resolution-findings.json)
   ADDED=$(( $(echo "$MERGED" | jq 'length') - $(echo "$ALL_FINDINGS" | jq 'length') ))
   if [ "$ADDED" -gt 0 ]; then
@@ -146,14 +152,19 @@ fi
 # only fires for entries in $ALL_FINDINGS). Without this safety net a
 # functional finding lands only in the body's "Issues found" list and
 # the developer never sees the screenshot at the offending diff line.
-# Dedup by id is mandatory: judges sometimes re-discover the same UI
-# bug with a different id, and the orchestrator may have already folded
-# the functional entry, in which case its id wins.
+# Dedup by id AND content (path+title): the orchestrator re-ids folded
+# entries to `j*`, so an id-only check re-appended already-merged
+# functional findings — the source of byte-identical duplicate comment
+# pairs (up to a third of inline comments on busy PRs).
 if [ -f /tmp/functional-findings.json ] && jq -e 'type == "array" and length > 0' /tmp/functional-findings.json >/dev/null 2>&1; then
   PREV_LEN=$(echo "$ALL_FINDINGS" | jq 'length')
   MERGED=$(jq -n --argjson primary "$ALL_FINDINGS" --slurpfile fn /tmp/functional-findings.json '
     ($primary | map(.id)) as $seen |
-    $primary + (($fn[0] // []) | map(select(.id as $id | $seen | index($id) | not)))
+    ($primary | map((.path // "") + "|" + (.title // ""))) as $seen_content |
+    $primary + (($fn[0] // []) | map(select(
+      (.id as $id | $seen | index($id) | not)
+      and (((.title // "") == "") or (((.path // "") + "|" + (.title // "")) as $k | $seen_content | index($k) | not))
+    )))
   ')
   ADDED=$(( $(echo "$MERGED" | jq 'length') - PREV_LEN ))
   if [ "$ADDED" -gt 0 ]; then
@@ -380,9 +391,11 @@ fi
 # reply, not the body.
 RESOLVED_LIST="[]"
 STILL_PRESENT_LIST="[]"
+REBUTTED_LIST="[]"
 if [ -f /tmp/thread-resolution.json ] && jq -e 'type == "array"' /tmp/thread-resolution.json >/dev/null 2>&1; then
   RESOLVED_LIST=$(jq '[.[] | select(.source == "prior_finding" and .status == "RESOLVED")]' /tmp/thread-resolution.json)
   STILL_PRESENT_LIST=$(jq '[.[] | select(.source == "prior_finding" and .status == "STILL_PRESENT")]' /tmp/thread-resolution.json)
+  REBUTTED_LIST=$(jq '[.[] | select(.source == "prior_finding" and .status == "REBUTTED")]' /tmp/thread-resolution.json)
   TOTAL_RESOLVED=$(jq '[.[] | select(.status == "RESOLVED")] | length' /tmp/thread-resolution.json)
   TOTAL_STILL=$(jq '[.[] | select(.status == "STILL_PRESENT")] | length' /tmp/thread-resolution.json)
   TOTAL_NEW_CTX=$(jq '[.[] | select(.status == "NEW_CONTEXT")] | length' /tmp/thread-resolution.json)
@@ -405,6 +418,13 @@ HUMAN_REVIEW=$(echo "$CORE_META" | jq -r '.requires_human_review // false')
 # because `has()` crashes on non-object JSON (null, arrays) and our
 # `is_valid_json` check only verifies parseability, not shape.
 MANUAL_SPEC_PRESENT=$(echo "$CORE_META" | jq -r 'if (type == "object" and has("manual_spec_present")) then .manual_spec_present else true end')
+
+# Machine-authored PRs (renovate, dependabot) can never carry a human spec;
+# withholding APPROVE for "no spec" on them is noise, not protection.
+SPEC_GATE_WAIVED=false
+if [ "$MANUAL_SPEC_PRESENT" = "false" ] && [ "${PR_AUTHOR_IS_BOT:-false}" = "true" ]; then
+  SPEC_GATE_WAIVED=true
+fi
 
 # Smoke-test gate. The test planner flags PRs whose stated intent is "no
 # user-visible behavior change" (refactor, upgrade, library swap, perf
@@ -486,13 +506,13 @@ elif [ "$FUNCTIONAL_OVERALL" = "PASS" ] || [ "$FUNCTIONAL_OVERALL" = "WARN" ]; t
 fi
 
 # Review-plan guard. When the deterministic resolver (review-plan.sh) intentionally
-# gated functional off — any GATE other than 'normal' (promotion / oversized /
-# nonruntime / label) — a missing smoke result is BY DESIGN, not a coverage gap.
-# Waive the technical-change smoke withhold so the verdict reflects the resolver's
-# deliberate decision instead of dropping APPROVE→COMMENT for a smoke we chose not
-# to run. (A 'normal' PR where functional was planned but didn't land still
-# withholds — that's a real gap, not an intentional skip.)
-if [ -n "${GATE:-}" ] && [ "$GATE" != "normal" ]; then
+# gated functional off — RUN_FUNCTIONAL != true (promotion / nonruntime / label) —
+# a missing smoke result is BY DESIGN, not a coverage gap. Waive the
+# technical-change smoke withhold so the verdict reflects the resolver's
+# deliberate decision instead of dropping APPROVE→COMMENT for a smoke we chose
+# not to run. Gates where functional DID run (normal, and now small/oversized)
+# keep the withhold — there a missing/failed smoke is real signal.
+if [ -n "${GATE:-}" ] && [ "$GATE" != "normal" ] && [ "${RUN_FUNCTIONAL:-}" != "true" ]; then
   if [ "$TECHNICAL_CHANGE" = "true" ] && [ "$SMOKE_OK" != "true" ]; then
     echo "::notice::Technical-change smoke gate waived — review-plan gate '$GATE' intentionally skipped functional testing."
   fi
@@ -558,7 +578,7 @@ elif [ "$HUMAN_REVIEW" = "true" ]; then
 elif [ "$JUDGES_BOTH_FAILED" = "true" ]; then
   VERDICT="COMMENT"
   echo "::warning::Both judges (or context builder) failed — downgrading APPROVE to COMMENT. Body banner explains."
-elif [ "$MANUAL_SPEC_PRESENT" = "false" ]; then
+elif [ "$MANUAL_SPEC_PRESENT" = "false" ] && [ "$SPEC_GATE_WAIVED" != "true" ]; then
   VERDICT="COMMENT"
   echo "::warning::No manual spec available — downgrading APPROVE to COMMENT (core reviewer set manual_spec_present=false)"
 elif [ "$FUNCTIONAL_MCP_BROKEN" = "true" ]; then
@@ -770,6 +790,7 @@ jq -n \
   --arg spec_compliance "$SPEC_COMPLIANCE" \
   --arg verdict_summary "$VERDICT_SUMMARY" \
   --arg technical_change "$TECHNICAL_CHANGE" \
+  --arg spec_gate_waived "$SPEC_GATE_WAIVED" \
   --arg smoke_ok "$SMOKE_OK" \
   --argjson findings "$ALL_FINDINGS" \
   --argjson meta "$CORE_META" \
@@ -782,6 +803,7 @@ jq -n \
     verdict_summary: $verdict_summary,
     spec_sources: ($meta.spec_sources // {linked_issue: null, external_issue: null, prd_path: null, convention_rules: []}),
     manual_spec_present: (if ($meta | type == "object" and has("manual_spec_present")) then $meta.manual_spec_present else true end),
+    spec_gate_waived: ($spec_gate_waived == "true"),
     technical_change: ($technical_change == "true"),
     smoke_ok: ($smoke_ok == "true"),
     findings: $findings,
@@ -859,7 +881,11 @@ EXTERNAL=$(jq -r '.spec_sources.external_issue // empty' review-result.json)
     echo ""
   fi
   if [ "$MANUAL_SPEC_PRESENT" = "false" ]; then
-    echo "> :no_entry: **APPROVE withheld — no spec.** Link an issue, paste acceptance criteria into the PR body, or wire up the external tracker."
+    if [ "$SPEC_GATE_WAIVED" = "true" ]; then
+      echo "> :robot: **Spec gate waived** — bot-authored PR; machine-generated PRs carry no human spec."
+    else
+      echo "> :no_entry: **APPROVE withheld — no spec.** Link an issue, paste acceptance criteria into the PR body, or wire up the external tracker."
+    fi
     echo ""
   fi
   if [ "$TECHNICAL_CHANGE" = "true" ] && [ "$SMOKE_OK" = "false" ]; then
@@ -898,7 +924,8 @@ EXTERNAL=$(jq -r '.spec_sources.external_issue // empty' review-result.json)
   # here — keeps the body scannable instead of pasting diff syntax.
   RESOLVED_N=$(echo "$RESOLVED_LIST" | jq 'length')
   STILL_N=$(echo "$STILL_PRESENT_LIST" | jq 'length')
-  if [ "$RESOLVED_N" -gt 0 ] || [ "$STILL_N" -gt 0 ]; then
+  REBUTTED_N=$(echo "$REBUTTED_LIST" | jq 'length')
+  if [ "$RESOLVED_N" -gt 0 ] || [ "$STILL_N" -gt 0 ] || [ "$REBUTTED_N" -gt 0 ]; then
     PRIOR_FINDINGS_JSON='[]'
     [ -f /tmp/prior-state/review-state.json ] \
       && PRIOR_FINDINGS_JSON=$(jq '.findings // []' /tmp/prior-state/review-state.json 2>/dev/null || echo '[]')
@@ -929,6 +956,15 @@ EXTERNAL=$(jq -r '.spec_sources.external_issue // empty' review-result.json)
              ($f.title // ($e.evidence // ""))
              | (if length > 120 then .[:117] + "..." else . end)
            )'
+      echo ""
+    fi
+    # Prior findings the author explicitly disputed without a code change.
+    # Listing them keeps the audit trail — a blocker must never just vanish
+    # between rounds — while the ladder stops re-enforcing it.
+    if [ "$REBUTTED_N" -gt 0 ]; then
+      echo "**Dropped after author rebuttal (${REBUTTED_N}):**"
+      echo "$REBUTTED_LIST" | jq -r --argjson prior "$PRIOR_FINDINGS_JSON" \
+        '.[] | "- `\(.id)` — " + ('"$JOIN_TITLE"')'
       echo ""
     fi
   fi
@@ -1083,6 +1119,12 @@ jq --slurpfile urls /tmp/screenshot-urls.json '[.[] |
     )
   } + (if $use_range then {start_line: .line_start, start_side: $side} else {} end)
 ]' /tmp/all-findings.json > /tmp/review-comments.json
+
+# Belt-and-braces against double-merged findings: identical
+# (path, line, body) tuples post as visibly duplicate inline comments.
+jq 'reduce .[] as $c ([]; if any(.[]; .path == $c.path and .line == $c.line and .body == $c.body) then . else . + [$c] end)' \
+  /tmp/review-comments.json > /tmp/review-comments-uniq.json \
+  && mv /tmp/review-comments-uniq.json /tmp/review-comments.json
 
 # Also write findings.draft.json for artifact upload
 cp /tmp/all-findings.json findings.draft.json

--- a/scripts/build-review.sh
+++ b/scripts/build-review.sh
@@ -1179,6 +1179,7 @@ jq -n \
   --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   --arg functional_overall "$PERSISTED_FUNCTIONAL_OVERALL" \
   --arg functional_strategy "$PERSISTED_FUNCTIONAL_STRATEGY" \
+  --arg review_level "${REVIEW_LEVEL:-full}" \
   '{
     schema_version: 1,
     prior_head_sha: $head,
@@ -1188,6 +1189,7 @@ jq -n \
     verdict: $verdict,
     functional_overall: $functional_overall,
     functional_strategy: $functional_strategy,
+    review_level: $review_level,
     reviewed_at: $ts
   }' > /tmp/review-state.json
 INHERITED_TAG=""

--- a/scripts/refine-review-plan.sh
+++ b/scripts/refine-review-plan.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# refine-review-plan.sh — Round-2 review-plan refinement.
+#
+# Most runs are follow-up rounds, and a small fix-up commit on a large PR
+# doesn't need the full Opus+Haiku debate the full-PR shape resolves to —
+# round-2 judges are already scoped to the since-last diff, the verdict
+# ladder pins unresolved prior blockers, and the thread classifier runs
+# regardless of judge count. So: re-resolve the plan (review-plan.sh)
+# against the diff since the last reviewed commit, with guards that keep
+# quality intact:
+#
+#   - round 1 / unreachable prior SHA      → keep the full-PR plan
+#   - full-PR plan is `skip` or `light`    → keep it (already the floor)
+#   - deep-review label                    → keep the full-PR plan
+#   - empty since-last (same-SHA re-run)   → light, no functional
+#   - otherwise                            → review-plan.sh on the
+#     since-last shape (skip label, sensitive paths, ceilings re-apply)
+#   - escalation: refined `light` while no prior round ran `full` → keep
+#     the full-PR plan. A PR can't grow large through many small pushes
+#     without ever getting the full debate.
+#
+# Inputs (env):
+#   ORIG_LEVEL / ORIG_FUNCTIONAL / ORIG_GATE / ORIG_REASON
+#                      the full-PR plan from review-plan.sh
+#   ROUND2_AVAILABLE   "true" only when prior state loaded AND the prior
+#                      head SHA is reachable in the clone (caller verifies)
+#   PRIOR_LEVEL        review_level persisted by the prior round; empty
+#                      means a pre-tiering state file → treat as "full"
+#   PRIOR_HEAD_SHA     used in reason strings only
+#   SINCE_FILES_TSV    "path<TAB>adds<TAB>dels" lines of the since-last diff
+#   GATE_*             forwarded to review-plan.sh (labels, ceilings, globs)
+#
+# Output: same KEY=value contract as review-plan.sh.
+set -uo pipefail
+
+DIR=$(cd "$(dirname "$0")" && pwd)
+
+ORIG_LEVEL="${ORIG_LEVEL:-full}"
+ORIG_FUNCTIONAL="${ORIG_FUNCTIONAL:-true}"
+ORIG_GATE="${ORIG_GATE:-normal}"
+ORIG_REASON="${ORIG_REASON:-}"
+
+emit() {
+  printf 'review_level=%s\nrun_functional=%s\ngate=%s\nreason=%s\n' "$1" "$2" "$3" "$4"
+}
+passthrough() {
+  emit "$ORIG_LEVEL" "$ORIG_FUNCTIONAL" "$ORIG_GATE" "${1:-$ORIG_REASON}"
+}
+
+if [ "${ROUND2_AVAILABLE:-false}" != "true" ]; then
+  passthrough; exit 0
+fi
+if [ "$ORIG_LEVEL" != "full" ]; then
+  passthrough; exit 0
+fi
+if [ -n "${GATE_LABELS:-}" ] && printf '%s\n' "$GATE_LABELS" | grep -Fxq "${GATE_DEEP_LABEL:-deep-review}"; then
+  passthrough; exit 0
+fi
+
+if [ -z "${SINCE_FILES_TSV:-}" ]; then
+  emit "light" "false" "small" "No changes since the last reviewed commit (${PRIOR_HEAD_SHA:-prior head}) — lightweight re-check."
+  exit 0
+fi
+
+REFINED=$(GATE_FILES_TSV="$SINCE_FILES_TSV" "$DIR/review-plan.sh")
+R_LEVEL=$(grep '^review_level=' <<< "$REFINED" | cut -d= -f2)
+R_FUNCTIONAL=$(grep '^run_functional=' <<< "$REFINED" | cut -d= -f2)
+R_GATE=$(grep '^gate=' <<< "$REFINED" | cut -d= -f2)
+R_REASON=$(grep '^reason=' <<< "$REFINED" | cut -d= -f2-)
+
+if [ "$R_LEVEL" = "light" ] && [ "${PRIOR_LEVEL:-full}" != "full" ]; then
+  passthrough "$ORIG_REASON (round-2 escalation: the full PR warrants a full review and no prior round ran one)"
+  exit 0
+fi
+
+emit "$R_LEVEL" "$R_FUNCTIONAL" "$R_GATE" "Round 2, planned on the diff since the last review: $R_REASON"

--- a/scripts/review-plan.sh
+++ b/scripts/review-plan.sh
@@ -13,9 +13,9 @@
 #
 # review_level (consumed by review-orchestrator.md):
 #   full   — dual-judge debate (+ rebuttal); functional per run_functional
-#   light  — single judge, no rebuttal, no functional (cheap pass)
+#   light  — single judge, no rebuttal; functional per run_functional
 #   skip   — early-return: no judges; post the reason as a note
-# run_functional — drive the app via the functional tester (only meaningful at `full`)
+# run_functional — drive the app via the functional tester (at `full` and `light`)
 # gate           — the classification that produced the decision (stable, for banners)
 #
 # Mapping:
@@ -23,9 +23,11 @@
 #   deep-review → full  / functional on    (label; forces full — suppresses promotion/oversized/small.
 #                                           Does NOT turn functional on for an all-nonruntime PR.)
 #   promotion   → light / functional off   (source already reviewed; cheap insurance)
-#   oversized   → light / functional off   (too big for full; a single judge catches the worst)
+#   oversized   → light / functional on    (too big to debate well, but big features are exactly
+#                                           where runtime evidence matters most)
 #   nonruntime  → full  / functional off   (tests/docs/CI/locks — judges yes, no app-driving)
-#   small       → light / functional off   (<= GATE_SMALL_CEILING non-gen lines, no sensitive paths)
+#   small       → light / functional on    (<= GATE_SMALL_CEILING non-gen lines, no sensitive paths;
+#                                           the test planner still picks skip/quick per surface)
 #   normal      → full  / functional on    (substantial, OR touches a sensitive path)
 #
 # Inputs (env; all optional — safe, review-biased defaults):
@@ -164,7 +166,7 @@ fi
 # ── 3) Oversized (non-promotion)? Lightweight pass + a "split / label" note.
 #       deep-review (FORCE_FULL) suppresses this downgrade. ──
 if [ "$FORCE_FULL" = false ] && [ "$oversized" = true ]; then
-  emit "light" "false" "oversized" "PR too large for a full review (${ng_files} files, ${ng_lines} non-generated lines; ceiling ${FILE_CEILING} files / ${SIZE_CEILING} lines) — lightweight single-judge pass. Consider splitting (team limit: 400 lines), or add the '$SKIP_LABEL' label if this bundles already-reviewed work."
+  emit "light" "true" "oversized" "PR too large for a full judge debate (${ng_files} files, ${ng_lines} non-generated lines; ceiling ${FILE_CEILING} files / ${SIZE_CEILING} lines) — single-judge pass + functional smoke run. Consider splitting (team limit: 400 lines), or add the '$SKIP_LABEL' label if this bundles already-reviewed work."
   exit 0
 fi
 
@@ -175,10 +177,13 @@ if [ "$total_files" -gt 0 ] && [ "$all_nonruntime" = true ]; then
 fi
 
 # ── 5) Small, non-sensitive runtime change with real (non-generated) source? One
-#       judge is enough — skip the debate and functional. All-generated diffs,
-#       sensitive paths, and the deep-review label fall through to full. ──
+#       judge is enough — skip the debate, but keep functional on: a quick smoke
+#       + screenshot pass is the natural review artifact for small runtime PRs
+#       (the test planner downgrades to skip when the diff has no user surface).
+#       All-generated diffs, sensitive paths, and the deep-review label fall
+#       through to full. ──
 if [ "$ng_files" -gt 0 ] && [ "$FORCE_FULL" = false ] && [ "$has_sensitive" = false ] && [ "$ng_lines" -le "$SMALL_CEILING" ]; then
-  emit "light" "false" "small" "Small runtime change (${ng_files} files, ${ng_lines} non-generated lines, at/under the ${SMALL_CEILING}-line small-PR ceiling; no sensitive paths) — lightweight single-judge pass. Add the '$DEEP_LABEL' label to force a full review."
+  emit "light" "true" "small" "Small runtime change (${ng_files} files, ${ng_lines} non-generated lines, at/under the ${SMALL_CEILING}-line small-PR ceiling; no sensitive paths) — single-judge pass + quick functional check. Add the '$DEEP_LABEL' label to force a full review."
   exit 0
 fi
 

--- a/scripts/verdict-gate.sh
+++ b/scripts/verdict-gate.sh
@@ -7,6 +7,14 @@ set -euo pipefail
 # and metadata, writes the GitHub step summary, posts a PR comment if the
 # result is missing, and exits with the appropriate code.
 #
+# Exit semantics: the check is GREEN whenever a review was successfully
+# posted — including REQUEST_CHANGES, which lives on the PR review itself
+# (and blocks via branch protection when required reviews are enforced).
+# A red check means the PIPELINE failed: no review produced, or a verdict
+# was computed but the POST to GitHub failed. Conflating "bot wants
+# changes" with "bot broke" made fleet failure rates unreadable and
+# trained authors to re-run perfectly good reviews.
+#
 # Required env vars:
 #   ANALYZER_OUTCOME      — outcome of the analyzer step (success/failure/etc.)
 #   POSTER_OUTCOME        — outcome of the poster step (success/failure/etc.)
@@ -100,6 +108,19 @@ if [ ! -f review-result.json ]; then
     # to fail the workflow). Using a review instead of an issue comment
     # gives us a single editable surface that the next successful run can
     # supersede in post-review.sh.
+    # Supersede prior crash banners first. post-review.sh only cleans them
+    # on the next SUCCESSFUL run — PRs that crash on every push (quota walls,
+    # bot PRs) otherwise stack a new red banner per night, 10+ observed.
+    PRIOR_CRASH_IDS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" 2>/dev/null \
+      | jq -s '(add // []) | [.[] | select((.body // "") | contains("<!-- claude-review-crash -->")) | .id] | .[]' 2>/dev/null || true)
+    if [ -n "$PRIOR_CRASH_IDS" ]; then
+      SUPERSEDE_BODY=$'<!-- claude-review-superseded -->\n\n_Superseded by a newer Claude review run on this PR._'
+      while IFS= read -r CRID; do
+        [ -z "$CRID" ] && continue
+        gh api --method PUT "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews/$CRID" -f body="$SUPERSEDE_BODY" >/dev/null 2>&1 \
+          || echo "::warning::Could not supersede prior crash review #$CRID"
+      done <<< "$PRIOR_CRASH_IDS"
+    fi
     CRASH_PAYLOAD=$(jq -n --arg body "$CRASH_MSG" '{event: "COMMENT", body: $body}')
     if ! gh api --method POST "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" --input - <<<"$CRASH_PAYLOAD" >/dev/null; then
       echo "::warning::Failed to post crash notification review"
@@ -119,6 +140,7 @@ POSTING_ERROR=$(jq -r '.posting_error // empty' review-result.json)
 HUMAN_REVIEW=$(jq -r '.requires_human_review // false' review-result.json)
 HUMAN_REASON=$(jq -r '.requires_human_review_reason // empty' review-result.json)
 MANUAL_SPEC=$(jq -r 'if (type == "object" and has("manual_spec_present")) then .manual_spec_present else true end' review-result.json)
+SPEC_WAIVED=$(jq -r '.spec_gate_waived // false' review-result.json)
 TECHNICAL_CHANGE=$(jq -r 'if (type == "object" and has("technical_change")) then .technical_change else false end' review-result.json)
 # Read smoke_ok directly — it captures both the FUNCTIONAL_OK crash flag and
 # the FUNCTIONAL_OVERALL value as build-review.sh saw them. Reading
@@ -143,7 +165,7 @@ FUNCTIONAL_OVERALL=$(jq -r '.functional_validation.overall // "N/A"' review-resu
     echo ""
     echo "> :stop_sign: **Human review required.** $HUMAN_REASON"
   fi
-  if [ "$MANUAL_SPEC" = "false" ]; then
+  if [ "$MANUAL_SPEC" = "false" ] && [ "$SPEC_WAIVED" != "true" ]; then
     echo ""
     echo "> :no_entry: **No manual spec available — APPROVE withheld.** Link an issue, paste acceptance criteria, or wire up an external tracker to enable APPROVE."
   fi
@@ -166,9 +188,12 @@ FUNCTIONAL_OVERALL=$(jq -r '.functional_validation.overall // "N/A"' review-resu
   fi
 } >> "$GITHUB_STEP_SUMMARY"
 
-# Surface posting failures as a workflow annotation.
+# A verdict that never reached the PR is a pipeline failure — the author
+# sees nothing, so the check must go red (observed: REQUEST_CHANGES computed,
+# POST failed, author saw a bare red check with no findings anywhere).
 if [ -n "$POSTING_ERROR" ]; then
-  echo "::warning::Claude review posting failed ($POSTING_ERROR) — verdict is $VERDICT but no PR review comment was created."
+  echo "::error::Claude review posting failed ($POSTING_ERROR) — verdict is $VERDICT but no PR review was created. Re-run the workflow."
+  exit 1
 fi
 
 case "$VERDICT" in
@@ -186,12 +211,10 @@ case "$VERDICT" in
     exit 0
     ;;
   REQUEST_CHANGES)
-    # Emit a visible annotation before failing. Without it the blocking
-    # verdict renders as a bare red ✗ with an empty step log — the verdict and
-    # findings live in the step summary + posted PR review, not this step's
-    # console — so the failed gate looks broken rather than intentional.
-    echo "::error::Claude review: REQUEST_CHANGES — $FINDING_COUNT blocking finding(s). See the PR review and the run summary for details."
-    exit 1
+    # Green: the review posted successfully. The blocking signal is the
+    # REQUEST_CHANGES review on the PR, not this check's color.
+    echo "::warning::Claude review: REQUEST_CHANGES — $FINDING_COUNT blocking finding(s). See the PR review and the run summary for details."
+    exit 0
     ;;
   *)
     echo "::error::Unknown or missing verdict: $VERDICT"

--- a/skills/review-functional-tester.md
+++ b/skills/review-functional-tester.md
@@ -164,6 +164,18 @@ This is your highest-value check. Compare **every observable detail** against th
 
 **The goal is to catch details that no human reviewer would notice** — a human reviews code, but you actually run it and compare output against spec word-by-word.
 
+## Evidence integrity (MANDATORY)
+
+Screenshots have two jobs: show a human reviewer the change **working** (so they can skip re-verifying it themselves), and show the builder exactly what's **broken**. Both jobs die the moment a single screenshot lies. Production reviews have shipped a 404 error page captioned "signin page" and a "PASS (1 screenshots)" whose one image was a different app entirely — each one teaches the team to ignore every future gallery.
+
+1. **A screenshot is a capture of the live app you drove this run** — or a rendered HTTP exchange of a request you actually made (the `<pre>` technique above). Never render prose, summaries, or test logs as a PNG; that content belongs in `summary`. Never list a non-app image in `screenshots[]`.
+2. **Verify every caption against the snapshot.** Before recording a `screenshots[]` entry or a finding's `screenshot`, check the most recent `browser_snapshot`: if the page is an error boundary, login wall, 404, or blank, the `description` must say exactly that — or drop the shot.
+3. **If you could not actually drive the app** (server unreachable, auth impossible, scenarios not executable), you must NOT report `PASS` and must NOT attach screenshots. Reading the source code is judge work, not functional evidence. Report honestly: environment failure → `overall: "CRASH"` with a summary saying what was unreachable; partial run → grade only what you exercised and list the rest under `uncertain_observations`.
+4. **Findings are defects only.** Never emit a finding whose content is "X works / is compliant / PASS" — inline comments are read as problems, and a pass-report posted as a finding is pure noise. Positive results live in `summary` and the screenshot gallery.
+5. **Caption for the walkthrough.** Write `screenshots[].description` so the gallery reads as an AC-by-AC walkthrough a human can follow without running anything: name the criterion and the state ("AC3 — list filtered to Active after selecting the status filter"), and cover pre-state → action → post-state for the main flow, not only the failures.
+6. **Deferred ACs are notes, not failures.** When the PR body, linked issue, or a repo convention explicitly defers an acceptance criterion to a sibling PR, still exercise and screenshot the gap, but file it at severity `note` and exclude it from the FAIL calculus — judges have had to argue testers back down from blocking on work the team deliberately split out.
+7. **`strategy` is the enum the plan gave you** — exactly `functional`, `quick`, or `skip`. Free-text strategies ("API-only backend PR…") corrupt the fleet's usage analytics.
+
 **Referencing acceptance criteria in posted text.** When a finding's `title`/`reasoning`/`expected` or the meta `summary` cites a criterion, use the `AC1`/`AC2` labels from context.md — **never** a `#`-prefixed form like `AC #5`. These fields are posted verbatim to GitHub (the `title` is the bold header of every inline comment), which auto-links `#5` to issue/PR #5 and produces a wrong cross-reference. Write `AC5`, not `AC #5`.
 
 ## Output

--- a/skills/review-judge.md
+++ b/skills/review-judge.md
@@ -39,7 +39,7 @@ In this single response, Read all of:
 - Every `chunk` path from `context.md`'s `## Per-file diff index`. Both judges cover the whole review, so do not skip chunks by role tag — all of them are in scope. **On round 2 the index is already scoped to files changed since the previous review** (the chunks point at `/tmp/since-last-chunks/`).
 - From `## Spec sources`: `/tmp/issue.json`, `/tmp/prd-content.md`, `/tmp/external-issue.md` — only the ones context.md lists as non-empty.
 - The convention rule files listed under `## Convention files` that apply to your changed paths.
-- `/tmp/other-bot-comments.json` and `/tmp/user-replies-on-ours.json` when context.md flags them as non-empty.
+- `/tmp/other-bot-comments.json`, `/tmp/prior-bot-comments.json`, and `/tmp/user-replies-on-ours.json` when context.md flags them as non-empty.
 
 If a finding candidate later references a specific library/export/component, you may issue a follow-up Read of `package.json` / source file in turn 3 or later — but do not let that case excuse drip-Reading in turn 2.
 
@@ -116,11 +116,15 @@ Before finalising ANY finding, verify all six:
 
 A clean `[]` is a confident, valuable review. False positives waste more team time than a missed minor issue. When in doubt, drop the finding.
 
+## Open threads are dedup state (round 2)
+
+If `/tmp/prior-bot-comments.json` is non-empty, those are **our own still-open threads** from previous rounds. An open thread already tells the author about its issue, and the round-2 ladder already counts unresolved prior blockers. Re-finding the same root cause — even at a shifted line or with better wording — and emitting it as a new finding opens a second thread for one defect; observed PRs accumulated 4–5 reworded threads for a single unfixed guard. Rule: if an open own-bot thread covers the same root cause in the same file/region, do **not** emit a finding for it. Emit only when you have materially new evidence (a new failure path, a new affected caller) — and say in `reasoning` that it extends the existing thread.
+
 ## Cross-check prior bot comments
 
 If `/tmp/other-bot-comments.json` is non-empty, Read it. For every HIGH/CRITICAL bot finding, decide:
 
-1. **Corroborate** — you independently see the issue or, after a focused Read of the cited file, you agree. Emit a finding with the same severity (or lower, your call) and add `(corroborated by <bot>)` to `reasoning`. Independent corroboration with a second tool is strong evidence — it clears the false-positive self-check on its own.
+1. **Corroborate** — you independently see the issue or, after a focused Read of the cited file, you agree. Emit a finding with the same severity (or lower, your call) and add `(corroborated by <bot>)` to `reasoning`. Independent corroboration with a second tool is strong evidence — it clears the false-positive self-check on its own. **Anchor the corroborating finding at the other bot's exact `path` + `line`** (copy them from the comment) — the poster then folds it into a reply on the existing thread instead of opening a second thread for the same defect.
 2. **Refute** — you read the cited code and disagree. Add a one-line entry to `uncertain_observations` like `"Refuted <bot> finding on <path>:<line>: <reason>"` so the audit trail survives.
 3. **Skip** — the finding is style-tooling territory (low-severity aikido nesting/extract-helper notes) or low severity. Do nothing.
 
@@ -201,6 +205,8 @@ Write a single JSON object to the path the orchestrator passed via `OUTPUT_PATH`
 `spec_sources.linked_issue` is the **integer** GitHub issue number from context.md's `## Spec sources` line (e.g. `57`), or `null` when none — **never** the `/tmp/issue.json` file path. The renderer prints it as `#<value>`, so a path here surfaces as `#/tmp/issue.json` in the posted review.
 
 `manual_spec_present` rules: `true` when ANY of these is non-empty: linked GitHub issue body (`/tmp/issue.json`), PRD (`/tmp/prd-content.md`), external-tracker spec (`/tmp/external-issue.md`), OR substantive human-written PR-body prose. **PR bodies are usually mixed** — strip Cursor/CodeRabbit/Gemini/Claude footer blocks and `> [!NOTE]` bot-attribution alerts before judging; if ≥1 paragraph of human-written prose remains explaining the WHY/scope/criteria, it's a spec.
+
+**Spec fields must agree.** `spec_sources`, `manual_spec_present`, and `verdict_summary` are three views of one decision. If `spec_sources` records a linked issue, external issue, or PRD, then `manual_spec_present` cannot be `false` for lack of a spec, and `verdict_summary` must never say "no linked issue" — reviews have shipped citing an external tracker ID in spec_sources while withholding APPROVE "because no issue is linked", which reads as the bot contradicting itself.
 
 `requires_human_review` is `true` ONLY when the diff genuinely cannot be judged: PR modifies existing auth/billing/tenant-isolation infrastructure, schema-altering migrations on existing data, cross-cutting architecture changes (new middleware/global interceptor), >500 LoC of novel business-logic with ambiguous requirements. **Missing auth is a finding, not ambiguity** — flag it and leave `requires_human_review` false.
 

--- a/skills/review-orchestrator.md
+++ b/skills/review-orchestrator.md
@@ -38,7 +38,7 @@ The runtime ceiling is set by the launching workflow as an **absolute hard maxim
 The launching workflow resolves a deterministic **review plan** (`scripts/review-plan.sh`) from the PR's files, branch, and labels and passes it in via env. Honor it before anything else:
 
 - `REVIEW_LEVEL` — `full` | `light` | `skip` (treat empty/unset as `full`)
-- `RUN_FUNCTIONAL` — `true` | `false` (only meaningful at `full`)
+- `RUN_FUNCTIONAL` — `true` | `false` (meaningful at both `full` and `light`; the plan turns it on for any runtime diff)
 - `GATE` — the classification that produced the plan (`normal`, `small`, `promotion`, `nonruntime`, `oversized`, `label`)
 - `GATE_REASON` — a one-line human-readable explanation
 
@@ -63,7 +63,7 @@ The launching workflow resolves a deterministic **review plan** (`scripts/review
 
 (`COMMENT`, not `APPROVE`, so the bot never satisfies a required-review check on a PR it was told not to review.)
 
-**`light`** → the cheap single-judge path. Run Phase 0 (context) and Phase 1 (trivial check) normally, then follow the **`light` deltas** flagged in Phases 2–4: one judge on the standard tier, no Haiku, no functional, no rebuttal.
+**`light`** → the cheap single-judge path. Run Phase 0 (context) and Phase 1 (trivial check) normally, then follow the **`light` deltas** flagged in Phases 2–4: one judge on the standard tier, no Haiku, no rebuttal. Functional follows `RUN_FUNCTIONAL` exactly as at `full` — small/oversized runtime PRs get the smoke + screenshot pass even on the single-judge path.
 
 **`full`** (or unset) → the full pipeline below, unchanged.
 
@@ -149,17 +149,19 @@ Skip Phase 2 and 3.
 
 When Phase 1 didn't trigger, dispatch the work fan in a **single assistant response with multiple Task calls** so they run in parallel.
 
-**`light` delta (`REVIEW_LEVEL=light`):** dispatch a **single** judge instead of the panel — the Judge-Opus block below but with `model: "${MODEL_STANDARD:-claude-sonnet-4-6}"` (the standard tier, not Opus) and `OUTPUT_PATH=/tmp/judge-sonnet.json`. Skip the Haiku judge. At `light` the plan sets `RUN_FUNCTIONAL=false`, so the functional tester is off per the **Functional dispatch decision** plan gate below (only `pipeline-self-test`, if that's the strategy, still runs). The round-2 thread classifier still runs when its inputs exist. When the judge returns, skip Phase 3 and go straight to Phase 4.
+**`light` delta (`REVIEW_LEVEL=light`):** dispatch a **single** judge instead of the panel — the Judge-Opus block below but with `model: "${MODEL_STANDARD:-claude-sonnet-4-6}"` (the standard tier, not Opus) and `OUTPUT_PATH=/tmp/judge-sonnet.json`. Skip the Haiku judge. The functional tester follows the **Functional dispatch decision** below unchanged — `RUN_FUNCTIONAL` is commonly `true` at `light` (small/oversized runtime PRs), so dispatch it in the same Task fan as the judge. The round-2 thread classifier still runs when its inputs exist. When the judge returns, skip Phase 3 and go straight to Phase 4.
 
 ### Functional dispatch decision
 
-**Plan gate (check first).** The app-driving functional tester — and its dev-env poll + prompt generation — runs only when `RUN_FUNCTIONAL=true` (the workflow sets that `true` only at `REVIEW_LEVEL=full` with a runtime diff). When `RUN_FUNCTIONAL` is `false`/empty (`light`, `skip`, or a non-runtime `full` PR), the **only** functional work permitted is `pipeline-self-test` (deterministic bash unit-tests — not app-driving, so it stays on); for every other strategy, write the synthetic skip `/tmp/functional-meta.json` (`strategy: "skip"`, `overall: PASS`) + `/tmp/functional-findings.json = []` and skip dev-env polling, prompt generation, and the tester.
+**Plan gate (check first).** The app-driving functional tester — and its dev-env poll + prompt generation — runs only when `RUN_FUNCTIONAL=true` (the plan sets it for runtime diffs at both `full` and `light`). When `RUN_FUNCTIONAL` is `false`/empty (`skip`, promotion, or a non-runtime PR), the **only** functional work permitted is `pipeline-self-test` (deterministic bash unit-tests — not app-driving, so it stays on); for every other strategy, write the synthetic skip `/tmp/functional-meta.json` (`strategy: "skip"`, `overall: PASS`) + `/tmp/functional-findings.json = []` and skip dev-env polling, prompt generation, and the tester.
 
 Then read the `## Strategy:` line from `test-plan.md`:
 
 - `STRATEGY = pipeline-self-test` AND `tests/` directory exists at the repo root → run `tests/*.sh` directly via Bash (skip `*smoke*`, 60 s timeout per test). Tally pass/fail. Write `/tmp/functional-meta.json` with `strategy: "pipeline-self-test"`, `overall: PASS|FAIL|WARN`, plus `pass`/`fail`/`total`/`summary`. Write `/tmp/functional-findings.json = []`. Skip the functional Task dispatch. **Runs regardless of `RUN_FUNCTIONAL`** — deterministic, no app, no LLM; cheap self-validation of the scripts.
 - `RUN_FUNCTIONAL=true` AND `STRATEGY ∈ {quick, functional}` AND dev-env was ready (Phase 0.5 set `WEB_READY=true`) AND `/tmp/functional-prompt.txt` was generated → dispatch the functional tester subagent.
 - Anything else (`RUN_FUNCTIONAL=false`, `STRATEGY = skip`, dev-env not ready, no functional-prompt) → skip functional. Write a synthetic `/tmp/functional-meta.json` with `strategy: "skip"`, `overall: PASS`, `summary: "Functional testing skipped."`. Write `/tmp/functional-findings.json = []`.
+
+These conditions are level-independent — at `light` the only change is the judge fan, never the functional decision.
 
 To prepare the functional tester prompt: run `.review-scripts/generate-functional-prompt.sh` via Bash (with the dev-env env vars from Phase 0.5 in scope). It writes `/tmp/functional-prompt.txt`. Skip-and-warn if the helper fails — functional dispatch is best-effort.
 
@@ -224,7 +226,7 @@ After each rebuttal round, re-run the agreement check. Cap at 2 total rebuttal r
 
 ## Phase 4 — Consolidate and write final output
 
-**`light` delta:** with a single judge there is nothing to union or reconcile — its findings array IS the output (re-id `j1, j2, …`), and its `verdict` / `verdict_summary` / `manual_spec_present` / `spec_sources` are used directly. Still fold in the thread classifier's net-new findings (round 2) through the same append. Set `judge_health` to `{ "sonnet": "ok|failed", "single_judge": true, "rebuttal_rounds": 0, "agreed_at": "single" }`; if the single judge failed, write the degraded `COMMENT` meta (as in the both-failed path). Skip the rest of this section's two-judge union and verdict reconciliation.
+**`light` delta:** with a single judge there is nothing to union or reconcile — its findings array IS the output (re-id `j1, j2, …`), and its `verdict` / `verdict_summary` / `manual_spec_present` / `spec_sources` are used directly. Still fold in the thread classifier's net-new findings (round 2) AND the functional tester's findings (when it ran) through the same appends as at `full`. Set `judge_health` to `{ "sonnet": "ok|failed", "single_judge": true, "rebuttal_rounds": 0, "agreed_at": "single" }`; if the single judge failed, write the degraded `COMMENT` meta (as in the both-failed path). Skip the rest of this section's two-judge union and verdict reconciliation.
 
 Use the **most recent** outputs from each judge.
 

--- a/skills/review-thread-classifier.md
+++ b/skills/review-thread-classifier.md
@@ -1,6 +1,6 @@
 ---
 name: review-thread-classifier
-description: Round-2 only. Classifies open inline-comment threads on the PR — from prior bot reviews, other bots, AND human reviewers — plus prior structured findings, against the diff since the last review. RESOLVED entries drive the poster's reply + thread-close step. Replaces the prior split between review-resolution-checker (state.json findings) and review-bot-comment-resolver (other-bot/own-bot inline threads); adds humans as a fourth stream.
+description: Round-2 only. Classifies open inline-comment threads on the PR — from prior bot reviews, other bots, AND human reviewers — plus prior structured findings, against the diff since the last review (RESOLVED / STILL_PRESENT / REBUTTED / NEW_CONTEXT). RESOLVED entries drive the poster's reply + thread-close step. Replaces the prior split between review-resolution-checker (state.json findings) and review-bot-comment-resolver (other-bot/own-bot inline threads); adds humans as a fourth stream.
 ---
 
 # Thread Classifier (round 2 only)
@@ -39,6 +39,7 @@ Read in a single batched response:
 3. `/tmp/other-bot-comments.json` — open top-level inline comments from non-Claude bots. Each: `id`, `node_id`, `user`, `path`, `line`, `body` (truncated). May be empty. **Read fully.**
 4. `/tmp/human-inline-comments.json` — open top-level inline comments from human reviewers (non-bot, non-author). Each: `id`, `node_id`, `user`, `path`, `line`, `body` (truncated). May be empty. **Read fully.**
 5. `/tmp/since-last.diff` — `git diff $PRIOR_HEAD_SHA..HEAD`. The complete change since the last review. **Read fully.**
+6. `/tmp/user-replies-on-ours.json` — maintainer/author replies on our own threads. Drives the REBUTTED classification below. May be missing/empty — treat as `[]`.
 
 If `since-last.diff` is missing, write `[]` to `/tmp/thread-resolution.json` and exit. Round-1 runs and PRs whose PRIOR_HEAD_SHA is no longer reachable hit this path — that's normal.
 
@@ -68,7 +69,7 @@ If a comment's body is too truncated to understand, classify as `NEW_CONTEXT` (y
 
 ## Classification rules
 
-For each in-scope entry, classify into exactly one of three buckets:
+For each in-scope entry, classify into exactly one of four buckets:
 
 ### RESOLVED
 
@@ -83,7 +84,7 @@ Do NOT mark RESOLVED based on:
 
 - The line number shifted but the same defect persists elsewhere in the file. (STILL_PRESENT.)
 - Adjacent lines changed but the flagged code is unchanged. (STILL_PRESENT.)
-- The thread was downvoted or argued-against in replies. (Not your call — leave the thread alone.)
+- The thread was downvoted or argued-against in replies. (That's REBUTTED for our own entries, below — never RESOLVED.)
 
 ### STILL_PRESENT
 
@@ -94,6 +95,12 @@ Examples:
 - The path is unchanged in `since-last.diff`.
 - The path is changed elsewhere but not at `line ±10`.
 - The lines were edited but the issue's root cause is still visible.
+
+### REBUTTED (streams 1 and 2 only)
+
+A maintainer or the PR author explicitly disputed the finding — a reply in `/tmp/user-replies-on-ours.json` saying it's intentional, wrong, out of scope, or handled elsewhere — and the code is unchanged. This is the author's call to make: a rebutted blocker must not silently pin REQUEST_CHANGES forever, and it must not silently vanish either. REBUTTED entries are excluded from the verdict ladder's still-present-blocker count and listed in the review body under "Dropped after author rebuttal", so the decision is on the record.
+
+Bar: the reply must contain a substantive reason ("deliberately removed", "industry standard", "handled in PR #448") — a bare "no" or an unanswered question is STILL_PRESENT. If a later commit DOES change the flagged code, classify on the code (RESOLVED/STILL_PRESENT), not the reply. Never use REBUTTED for other bots' or humans' threads — their disputes are theirs to settle.
 
 ### NEW_CONTEXT
 
@@ -162,7 +169,7 @@ Array, exactly one entry per in-scope input item across all four streams:
 
 `bot_user` mirrors the input comment's `user` field for streams 2 and 3; `null` for streams 1 and 4.
 
-`source` ∈ `prior_finding | own_bot | other_bot | human`. The poster's reply logic differs by source: prior_finding entries DON'T get an inline reply (the verdict body covers them), but own_bot / other_bot / human RESOLVED entries DO get the `✅ Resolved as of <sha>` inline reply + thread-close mutation.
+`source` ∈ `prior_finding | own_bot | other_bot | human`. `status` ∈ `RESOLVED | STILL_PRESENT | REBUTTED | NEW_CONTEXT`. The poster's reply logic differs by source: prior_finding entries DON'T get an inline reply (the verdict body covers them), but own_bot / other_bot / human RESOLVED entries DO get the `✅ Resolved as of <sha>` inline reply + thread-close mutation. REBUTTED entries get no reply and no thread-close — the author already owns that thread.
 
 Write `[]` when there are no in-scope entries to classify. **STILL_PRESENT entries are required for prior findings (stream 1)** because the verdict-ladder math depends on them; for inline-comment streams, STILL_PRESENT entries are optional but encouraged for the audit trail.
 

--- a/tests/functional_findings_merge_test.sh
+++ b/tests/functional_findings_merge_test.sh
@@ -39,7 +39,11 @@ merge() {
     --argjson primary "$(cat "$primary_file")" \
     --slurpfile fn "$functional_file" \
     '($primary | map(.id)) as $seen
-     | $primary + (($fn[0] // []) | map(select(.id as $id | $seen | index($id) | not)))'
+     | ($primary | map((.path // "") + "|" + (.title // ""))) as $seen_content
+     | $primary + (($fn[0] // []) | map(select(
+         (.id as $id | $seen | index($id) | not)
+         and (((.title // "") == "") or (((.path // "") + "|" + (.title // "")) as $k | $seen_content | index($k) | not))
+       )))'
 }
 
 # ── Block 1: net-new functional finding folds in, screenshot preserved ──
@@ -77,6 +81,31 @@ assert_eq "dedup: f1 appears once"        "1" "$(echo "$M2" | jq '[.[] | select(
 # Orchestrator's already-folded copy wins (its evidence was "orchestrator copy").
 assert_eq "dedup: orchestrator copy wins" "orchestrator copy" \
   "$(echo "$M2" | jq -r '[.[] | select(.id == "f1")] | .[0].evidence')"
+
+# ── Block 2b: orchestrator folded under a re-id'd `j*` id — dedup by content ──
+# Phase 4 re-ids merged findings to j1..jN, so the functional copy arrives
+# under its original f-id. Id-only dedup re-appended it (byte-identical
+# duplicate inline comments, observed at up to a third of comments on
+# busy PRs); content (path+title) dedup must catch it.
+cat > "$TMP/all-findings-2b.json" <<'JSON'
+[
+  {"id":"j1","severity":"major","path":"src/a.ts","line_start":10,"title":"Judge finding","evidence":"x","reasoning":"y","expected":"z","type":"finding"},
+  {"id":"j2","severity":"major","path":"src/c.ts","line_start":30,"title":"Submit button missing","evidence":"orchestrator copy","reasoning":"y","expected":"z","type":"finding","screenshot":"/tmp/screenshots/02-form.png"}
+]
+JSON
+M2B=$(merge "$TMP/all-findings-2b.json" "$TMP/functional-2.json")
+assert_eq "content-dedup: total length unchanged" "2" "$(echo "$M2B" | jq 'length')"
+assert_eq "content-dedup: no f1 re-append"        "0" "$(echo "$M2B" | jq '[.[] | select(.id == "f1")] | length')"
+
+# Untitled findings never content-collide (two distinct untitled findings on one path).
+cat > "$TMP/all-findings-2c.json" <<'JSON'
+[{"id":"j1","severity":"major","path":"src/c.ts","line_start":10,"title":"","evidence":"a","reasoning":"y","expected":"z","type":"finding"}]
+JSON
+cat > "$TMP/functional-2c.json" <<'JSON'
+[{"id":"f9","severity":"minor","path":"src/c.ts","line_start":80,"title":"","evidence":"b","reasoning":"y","expected":"z","type":"finding"}]
+JSON
+M2C=$(merge "$TMP/all-findings-2c.json" "$TMP/functional-2c.json")
+assert_eq "untitled: both kept" "2" "$(echo "$M2C" | jq 'length')"
 
 # ── Block 3: both empty → no-op ──
 echo '[]' > "$TMP/all-findings-3.json"

--- a/tests/refine_plan_test.sh
+++ b/tests/refine_plan_test.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# refine_plan_test.sh — fixture test for scripts/refine-review-plan.sh.
+#
+# Round-2 plan refinement is a pure function of (full-PR plan, prior state
+# fields, since-last file shape, labels) — no git, no network. The workflow
+# computes those inputs; this test feeds them via env and asserts the
+# emitted plan, same harness style as review_plan_test.sh.
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+SCRIPT="$ROOT/scripts/refine-review-plan.sh"
+fail=0
+
+summary_of() {
+  env "$@" bash "$SCRIPT" | awk -F= '
+    /^review_level=/ {lvl=$2}
+    /^run_functional=/{fn=$2}
+    /^gate=/         {g=$2}
+    END {print lvl, fn, g}'
+}
+
+assert_plan() {
+  local label="$1" want="$2"; shift 2
+  local got; got=$(summary_of "$@")
+  if [ "$got" = "$want" ]; then
+    echo "OK:   $label → $got"
+  else
+    echo "FAIL: $label — want '$want' got '$got'"
+    fail=$((fail + 1))
+  fi
+}
+
+reason_of() {
+  env "$@" bash "$SCRIPT" | grep '^reason=' | cut -d= -f2-
+}
+
+# Full-PR plan for a big normal PR, reused below.
+BIG_ORIG=(ORIG_LEVEL=full ORIG_FUNCTIONAL=true ORIG_GATE=normal ORIG_REASON="Eligible for full review")
+
+# ── round 1 / prior unavailable → passthrough ──
+assert_plan "round 1 passes the full-PR plan through" "full true normal" \
+  ROUND2_AVAILABLE=false "${BIG_ORIG[@]}" \
+  SINCE_FILES_TSV=$'src/a.ts\t10\t2'
+
+# ── full-PR plan already at the floor → passthrough ──
+assert_plan "orig light (small PR) stays light" "light true small" \
+  ROUND2_AVAILABLE=true ORIG_LEVEL=light ORIG_FUNCTIONAL=true ORIG_GATE=small ORIG_REASON=r \
+  SINCE_FILES_TSV=$'src/a.ts\t10\t2'
+assert_plan "orig skip (label) stays skip" "skip false label" \
+  ROUND2_AVAILABLE=true ORIG_LEVEL=skip ORIG_FUNCTIONAL=false ORIG_GATE=label ORIG_REASON=r \
+  SINCE_FILES_TSV=$'src/a.ts\t10\t2'
+
+# ── deep-review label → keep the full-PR plan every round ──
+assert_plan "deep-review label keeps full" "full true normal" \
+  ROUND2_AVAILABLE=true "${BIG_ORIG[@]}" GATE_LABELS=$'deep-review' \
+  SINCE_FILES_TSV=$'src/a.ts\t3\t1'
+
+# ── empty since-last (same-SHA re-run) → light, no functional ──
+assert_plan "empty since-last → light re-check" "light false small" \
+  ROUND2_AVAILABLE=true "${BIG_ORIG[@]}" SINCE_FILES_TSV=
+
+# ── small follow-up on a big PR → light + quick functional ──
+assert_plan "small since-last on big PR → light" "light true small" \
+  ROUND2_AVAILABLE=true "${BIG_ORIG[@]}" PRIOR_LEVEL=full \
+  SINCE_FILES_TSV=$'src/fix.ts\t40\t5'
+
+# ── big or sensitive since-last keeps the full fan ──
+assert_plan "large since-last stays full" "full true normal" \
+  ROUND2_AVAILABLE=true "${BIG_ORIG[@]}" PRIOR_LEVEL=full \
+  SINCE_FILES_TSV=$'src/big.ts\t300\t101'
+assert_plan "sensitive since-last forces full" "full true normal" \
+  ROUND2_AVAILABLE=true "${BIG_ORIG[@]}" PRIOR_LEVEL=full \
+  SINCE_FILES_TSV=$'src/payments/charge.ts\t8\t1'
+
+# ── skip label re-applies via the resolver on round 2 ──
+assert_plan "skip-review label on round 2 → skip" "skip false label" \
+  ROUND2_AVAILABLE=true "${BIG_ORIG[@]}" GATE_LABELS=$'skip-review' \
+  SINCE_FILES_TSV=$'src/a.ts\t10\t2'
+
+# ── escalation: PR warrants full but no prior round ran one ──
+assert_plan "prior round was light → escalate to full-PR plan" "full true normal" \
+  ROUND2_AVAILABLE=true "${BIG_ORIG[@]}" PRIOR_LEVEL=light \
+  SINCE_FILES_TSV=$'src/fix.ts\t40\t5'
+# Pre-tiering state files have no review_level — treat as full (no escalation).
+assert_plan "missing PRIOR_LEVEL treated as full" "light true small" \
+  ROUND2_AVAILABLE=true "${BIG_ORIG[@]}" PRIOR_LEVEL= \
+  SINCE_FILES_TSV=$'src/fix.ts\t40\t5'
+
+# ── reason strings name the round-2 scoping ──
+R=$(reason_of ROUND2_AVAILABLE=true "${BIG_ORIG[@]}" PRIOR_LEVEL=full SINCE_FILES_TSV=$'src/fix.ts\t40\t5')
+case "$R" in
+  "Round 2, planned on the diff since the last review:"*) echo "OK:   refined reason carries the round-2 prefix" ;;
+  *) echo "FAIL: refined reason missing round-2 prefix — got '$R'"; fail=$((fail + 1)) ;;
+esac
+
+if [ "$fail" -eq 0 ]; then
+  echo
+  echo "All refine-plan tests passed."
+  exit 0
+else
+  echo
+  echo "$fail refine-plan test assertion(s) failed."
+  exit 1
+fi

--- a/tests/review_plan_test.sh
+++ b/tests/review_plan_test.sh
@@ -56,10 +56,10 @@ assert_plan "huge release PR (size irrelevant)" "light false promotion" \
 assert_plan "feature → main is NOT a promotion (large diff)" "full true normal" \
   GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'src/app.ts\t250\t100'
 
-# ── oversized → light (no functional) ──
-assert_plan "45 runtime files" "light false oversized" \
+# ── oversized → light (functional smoke stays on) ──
+assert_plan "45 runtime files" "light true oversized" \
   GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV="$BIG_FILES"
-assert_plan "2100 changed lines" "light false oversized" \
+assert_plan "2100 changed lines" "light true oversized" \
   GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'src/big.ts\t1500\t600'
 assert_plan "huge lockfile ALONE → not oversized (generated excluded)" "full false nonruntime" \
   GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'pnpm-lock.yaml\t9000\t9000'
@@ -78,16 +78,16 @@ assert_plan "runtime source (large)" "full true normal" \
 assert_plan "mixed test + runtime (large)" "full true normal" \
   GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'src/page.tsx\t250\t100\nsrc/page.test.ts\t20\t0'
 
-# ── small runtime change → light/small (single judge, no functional) [NEW] ──
-assert_plan "small runtime source" "light false small" \
+# ── small runtime change → light/small (single judge, quick functional) [NEW] ──
+assert_plan "small runtime source" "light true small" \
   GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'src/util.ts\t40\t5'
-assert_plan "tsconfig (ambiguous → runtime, small)" "light false small" \
+assert_plan "tsconfig (ambiguous → runtime, small)" "light true small" \
   GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'tsconfig.json\t3\t1'
-assert_plan "exactly at the 300 ceiling → still small" "light false small" \
+assert_plan "exactly at the 300 ceiling → still small" "light true small" \
   GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'src/a.ts\t200\t100'
 assert_plan "one line over the ceiling (301) → normal" "full true normal" \
   GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'src/a.ts\t200\t101'
-assert_plan "generated lines don't count toward the ceiling → small" "light false small" \
+assert_plan "generated lines don't count toward the ceiling → small" "light true small" \
   GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'src/a.ts\t50\t10\npnpm-lock.yaml\t5000\t5000'
 # An all-generated diff has no reviewable (non-generated) source → NOT small.
 assert_plan "all-generated bundle → normal, not small" "full true normal" \
@@ -110,9 +110,9 @@ assert_plan "sensitive path in a GENERATED file still forces full" "full true no
   GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'src/util.ts\t10\t2\nsrc/payments/api.generated.ts\t30\t0'
 # A bare auth/ dir is a route group (views/auth/ = the signed-in area), NOT auth logic
 # — it must NOT be force-full by default, else every frontend PR pays for it.
-assert_plan "bare views/auth/ route group → small (not sensitive)" "light false small" \
+assert_plan "bare views/auth/ route group → small (not sensitive)" "light true small" \
   GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'apps/web/src/views/auth/dossier/inpress.vue\t10\t2'
-assert_plan "'author.ts' is NOT sensitive (no false match)" "light false small" \
+assert_plan "'author.ts' is NOT sensitive (no false match)" "light true small" \
   GATE_BASE_REF=main GATE_HEAD_REF=feat/x GATE_FILES_TSV=$'src/models/author.ts\t10\t2'
 # A repo whose auth/ holds real logic can opt it back in (and the env var overrides the default).
 assert_plan "opt-in '*/auth/*' via GATE_SENSITIVE_GLOBS → full" "full true normal" \

--- a/tests/verdict_gate_annotation_test.sh
+++ b/tests/verdict_gate_annotation_test.sh
@@ -3,10 +3,11 @@ set -uo pipefail
 
 # verdict_gate_annotation_test.sh — regression guard for issue #61.
 #
-# A blocking verdict (REQUEST_CHANGES) used to exit 1 with zero console
-# output, so the Actions "Verdict gate" step rendered as a bare red ✗ with an
-# empty log and no annotation (Panenco/qit#6486). The gate must emit a visible
-# `::error::` annotation so the failed step explains itself.
+# Exit semantics: green whenever a review was successfully posted (including
+# REQUEST_CHANGES — the blocking signal is the PR review, not the check), red
+# only on pipeline failures (no output, or a verdict that never reached the
+# PR). Each path must emit a visible annotation explaining itself
+# (Panenco/qit#6486 was a bare red ✗ with an empty log).
 #
 # This executes the REAL scripts/verdict-gate.sh against fixture
 # review-result.json files for each verdict and asserts both the exit code and
@@ -55,12 +56,20 @@ run_gate() {
   rm -rf "$work"
 }
 
-echo "── REQUEST_CHANGES: must fail AND emit an error annotation ──"
+echo "── REQUEST_CHANGES: review posted → GREEN, with a visible annotation ──"
 run_gate '{"verdict":"REQUEST_CHANGES","summary":"s","findings":[{"severity":"major","type":"bug","path":"a.ts","line_start":1,"title":"boom"}]}'
-assert_eq        "exit code 1"          "1" "$RC"
-assert_contains  "emits ::error::"      "::error::" "$OUT"
+assert_eq        "exit code 0"          "0" "$RC"
+assert_contains  "emits ::warning::"    "::warning::" "$OUT"
+assert_not_contains "no ::error::"      "::error::" "$OUT"
 assert_contains  "names the verdict"    "REQUEST_CHANGES" "$OUT"
 assert_contains  "states finding count" "1 blocking finding" "$OUT"
+
+echo ""
+echo "── posting_error: verdict computed but never reached the PR → RED ──"
+run_gate '{"verdict":"REQUEST_CHANGES","summary":"s","posting_error":"POST failed","findings":[{"severity":"major","type":"bug","path":"a.ts","line_start":1,"title":"boom"}]}'
+assert_eq        "exit code 1"          "1" "$RC"
+assert_contains  "emits ::error::"      "::error::" "$OUT"
+assert_contains  "says posting failed"  "posting failed" "$OUT"
 
 echo ""
 echo "── APPROVE: passes, no error annotation ──"


### PR DESCRIPTION
## Why

A four-track audit of ~1,000 production runs across the 16 consumer repos (run health, review quality on real PRs, functional/screenshot effectiveness, noise/overlap with cursor+aikido+humans) found the pipeline strong on spec-grounding but failing its two headline goals in specific, fixable ways:

- **Screenshots almost never reach reviewers.** Only ~38% of runs execute functional testing, and the recent-PR rate on seaters/qit/phill was ~0% — the `small` and `oversized` plan gates suppress functional on exactly the PRs that need evidence most (54-file features APPROVEd with zero runtime proof; UI-fix PRs argued in prose). Where it does run, quality is high (AC-by-AC walkthroughs on qit#6511, qiv#523) — the failure is coverage, plus a few trust-destroying evidence bugs ("PASS (1 screenshots)" off static analysis with a wrong-app image; a 404 page captioned "signin page"; text summaries rendered as PNGs).
- **Noise has four concrete sources**: byte-identical duplicate comment pairs in one review (up to 33% of inline comments on qiv#478 — the orchestrator re-ids folded findings, so the build step's id-only defensive merge re-appends them); the same defect re-flagged across 4–5 rounds with reworded titles; cross-bot duplicates posted as both a "Confirmed" reply AND an own thread; PASS reports posted as inline findings.
- **Verdict accountability**: blockers silently evaporated between rounds after author pushback (qit#6545); spec-field self-contradictions ("Linked issue: CUR-1828" + "withheld — no linked issue").
- **Bot-PR + check-semantics noise**: renovate/dependabot runs fail red and stack crash banners 10-deep (88 crashed runs/14d on phill); ~43 of 59 audited "failures" were healthy REQUEST_CHANGES verdicts, training authors to re-run good reviews (the source of same-SHA verdict-flip churn).

## What

**Functional evidence everywhere it matters**
- `review-plan.sh`: `small` and `oversized` keep the light single-judge fan but turn `run_functional=true`. The planner still scopes cost (no user surface → `skip`; trivial → 1-scenario `quick`). Orchestrator honors `RUN_FUNCTIONAL` at `light`.
- Functional-tester skill: new **Evidence integrity (MANDATORY)** section — screenshots only of the app actually driven, captions verified against the snapshot, no static-only PASS, no text-PNGs, findings are defects only, AC-labeled walkthrough captions, deferred ACs file as `note`, strict strategy enum.
- Smoke-gate waiver keys on `RUN_FUNCTIONAL`, not `gate != normal`.

**Noise**
- `build-review.sh`: defensive merges dedup by content (path+title) as well as id; intra-batch `(path,line,body)` dedup on inline comments.
- Judge skill: open own threads are dedup state (no reworded re-flags); corroborating findings anchor at the other bot's exact line so the poster folds them into a reply instead of a second thread; spec fields must agree.
- Classifier: new `REBUTTED` status — substantive author pushback with no code change stops pinning REQUEST_CHANGES and is listed in the body under "Dropped after author rebuttal" (blockers never silently vanish).

**Bot PRs + check semantics**
- Bot-actor gate: unallowed bot-triggered runs skip cleanly (green check, no token burn, no crash banner). `allowed_bots` keeps working as the opt-in.
- Bot-authored PRs waive the manual-spec gate.
- Verdict gate: **green whenever a review posted (incl. REQUEST_CHANGES)** — the PR review is the blocking signal; red only for real pipeline failures, and a computed verdict that failed to POST is now red instead of a warning. Note for consumers relying on the red check to block merges: use branch protection's required reviews instead (documented in README).
- Crash banners supersede prior crash banners at crash time.

**Cost (no max-turns or model-tier changes)**
- Job-level `concurrency: cancel-in-progress` — a push mid-review supersedes the stale in-flight run.
- Phase-timing telemetry wired (was dead code; `phases:{}` in 100% of usage artifacts) — orchestrate wall time now lands in `usage.json` for fleet cost tracking.

## Tests

All 19 `tests/*.sh` pass. Updated: `review_plan_test.sh` (new plan mapping), `verdict_gate_annotation_test.sh` (green-RC + red-posting-failure cases), `functional_findings_merge_test.sh` (mirrors the real merge expression; new content-dedup + untitled-collision cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fleet-wide review depth, functional cost, and GitHub check semantics (REQUEST_CHANGES no longer fails the workflow); consumers relying on a red check to block merges must use branch protection instead.
> 
> **Overview**
> Fleet-audit follow-up that pushes **runtime evidence** onto small and oversized PRs (`run_functional=true` while keeping single-judge `light`), aligns orchestrator/skills/smoke-gate waiver with `RUN_FUNCTIONAL`, and adds a mandatory **Evidence integrity** block for the functional tester (real app screenshots, no static PASS, defects-only findings).
> 
> **Noise and round-2 accountability:** `build-review.sh` dedupes merged findings by path+title and inline comments by `(path,line,body)`; judges avoid re-flagging open own threads and anchor corroborations on other bots’ lines; thread classifier adds **`REBUTTED`** (author dispute, no code change) with a body section so blockers don’t silently disappear.
> 
> **Workflow/ops:** early **bot-actor gate** (skip disallowed bot triggers cleanly); bot-authored PRs **waive manual-spec**; **verdict gate** is green when a review posted (including `REQUEST_CHANGES`), red on true failures/posting errors; crash banners supersede prior crashes; **cancel-in-progress** concurrency; round-2 **`refine-review-plan.sh`**; pnpm/npm **store cache** + warm-cache job; **orchestrate phase timing** for usage artifacts. Docs/tests updated for the new plan mapping and gate semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f869caf9ffcc89a319fb96e033bdd88518259149. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---

## Second commit: cost levers (no max-turns or model-tier changes)

**Round-2 plan tiering** (`scripts/refine-review-plan.sh` + workflow refine step). Follow-up rounds dominate fleet volume (multi-round PRs averaged ~7 rounds; one hit 33), and every round re-ran the full Opus + Haiku debate even for a 10-line fix-up. The plan is now re-resolved against the **since-last diff shape**: small non-sensitive follow-up → light single judge + quick functional; same-SHA re-run → light, no functional; large/sensitive follow-up → full as before. Quality guards: labels, sensitive globs and ceilings re-apply through the same resolver; `deep-review` pins the full plan every round; and an escalation rule (using `review_level` newly persisted in round-state) sends a PR back to full when it grew past the ceilings without ever having had a full round. The protections for prior findings (verdict ladder, thread classifier) run regardless of judge count, and round-2 judges were already since-last-scoped — this removes the redundant second judge, not coverage.

**Package-manager store cache.** `dev-start.sh` ran the consumer's `pnpm install` from a cold store every run. The review job now caches the pnpm/npm store keyed on lockfiles (PR-branch scope covers round 2+), and the `pull_request_target` warm job `pnpm fetch`es the **base** lockfile into a main-scoped cache so new PRs hit it on round 1 — same pattern as the existing Playwright warm, still PR-code-free (base-ref checkout; `pnpm fetch` runs no lifecycle scripts). Warm-side restore/save is split with save gated on fetch success, so a failed fetch can never poison the exact lockfile key with an empty store. Zero consumer wiring.

New `tests/refine_plan_test.sh` (12 cases); all 20 test scripts pass.
