### PR TITLE
feat(pipeline): generic opt-in dev-env build cache (dev_cache_*)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -102,6 +102,26 @@ on:
         required: false
         type: string
         default: "staging develop dev release hotfix"
+      dev_cache_paths:
+        description: "Optional, stack-agnostic. Newline-separated filesystem paths to restore BEFORE the dev-env bring-up and save AFTER the review, so dev-start.sh compiles/installs against a warm build/dependency cache instead of cold every run. Examples: `~/.gradle/caches` + `~/.gradle/wrapper` (Gradle), `~/.m2/repository` (Maven), `~/.cache/go-build` + `~/go/pkg/mod` (Go), `~/.cargo` + `target` (Rust), `~/.cache/pip` (Python). Empty (default) disables it — no cache step runs and behaviour is unchanged. Pair with `dev_cache_key`. The pnpm/npm store is already cached separately, so this is for everything else dev-start.sh builds."
+        required: false
+        type: string
+        default: ""
+      dev_cache_key:
+        description: "Cache key for dev_cache_paths. Compute it in your caller workflow so it rotates when your lockfiles/build config change — typically the runner OS plus a hashFiles() of your build descriptors, e.g. an expression resolving to 'Linux-devcache-<hash of **/gradle/libs.versions.toml, **/*.gradle*, **/gradle-wrapper.properties>'. The reusable workflow treats the value as an opaque literal (it never re-hashes a dev-start-mutated tree), so restore and save share the exact same key with no post-save mismatch. Required when dev_cache_paths is set; if empty the cache is skipped."
+        required: false
+        type: string
+        default: ""
+      dev_cache_restore_keys:
+        description: "Optional. Newline-separated restore-key prefixes for partial hits. GitHub falls through them in order and across the run's branch then base branch then default branch, so a prefix like 'Linux-devcache-' lets a cold PR reuse the most recent compatible cache from main. Caches are repo-scoped, so a cache your main CI saves under the same prefix is reused here too."
+        required: false
+        type: string
+        default: ""
+      dev_cache_warm_command:
+        description: "Optional. Shell command the warm-cache job runs (in main scope, against the trusted BASE ref — never PR head) to populate dev_cache_paths, then saves under dev_cache_key. This is what makes the cache available to EVERY PR rather than only re-pushes of the same branch. Keep it cheap and PR-code-free — a dependency resolve/prefetch, not a full build. It runs only on a cache miss (i.e. after the key rotates), so steady-state cost is one prefetch per dependency change. The warm-cache job is a vanilla ubuntu-latest with only Node set up, so the command owns its own toolchain — use the runner's preinstalled versions (e.g. JAVA_HOME_21_X64 / GOROOT_1_22_X64) or install what it needs. Example: 'cd backend/java && JAVA_HOME=$JAVA_HOME_21_X64 ./gradlew :api:dependencies --no-daemon'. Leave empty to skip main-scope warming (the functional job still restores whatever exists under the key/prefix, e.g. a cache your own main CI writes)."
+        required: false
+        type: string
+        default: ""
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         # No longer strictly required: callers can supply CLAUDE_CODE_OAUTH_TOKENS
@@ -1073,6 +1093,24 @@ jobs:
           fi
           echo "Disk after:"; df -h / | tail -1
 
+      # Generic, opt-in dev build/dependency cache (the dev_cache_* inputs).
+      # Restore-ONLY here — after disk cleanup, before the bring-up — so
+      # dev-start.sh compiles/installs against a warm cache instead of cold every
+      # run. The matching SAVE lives in the warm-cache job (main scope), exactly
+      # like the package-store: warming there makes the cache available to every
+      # PR, not just re-pushes of the same branch. Stack-agnostic: the consumer
+      # picks the paths + key. restore (not the all-in-one cache action) so
+      # dev-start.sh mutating the tree can't trigger an all-in-one post(save)
+      # re-hash that errors and reds an otherwise-green run.
+      - name: Restore dev build cache
+        id: dev_build_cache
+        if: steps.actor_gate.outputs.proceed == 'true' && steps.code_check.outputs.needs_build == 'true' && hashFiles('.github/claude-review/dev-start.sh') != '' && steps.review_plan2.outputs.run_functional == 'true' && inputs.dev_cache_paths != '' && inputs.dev_cache_key != ''
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ inputs.dev_cache_paths }}
+          key: ${{ inputs.dev_cache_key }}
+          restore-keys: ${{ inputs.dev_cache_restore_keys }}
+
       # Launch the consumer's dev environment in the background so it brings
       # up alongside the context-builder + Playwright MCP setup, instead of
       # blocking the analyzer fan. The wait step further down reaps the PID
@@ -1471,3 +1509,42 @@ jobs:
             ~/.local/share/pnpm/store
             ~/.npm
           key: ${{ runner.os }}-pkg-store-${{ hashFiles('**/pnpm-lock.yaml', '**/package-lock.json') }}
+
+      # Generic dev build/dependency cache — warmed here in main scope (same as
+      # the package store above) so EVERY PR's functional job, which only
+      # restores it, starts warm. restore → run the consumer's warm command
+      # against the trusted BASE ref → save. Opt-in: the whole block is inert
+      # unless dev_cache_paths + dev_cache_key + dev_cache_warm_command are set.
+      # The warm command runs only on a cache miss (key rotated since the last
+      # warm), so steady-state this is a no-op — keeping the aggressive caching
+      # short-lived: entries churn only as fast as the cache key's hashFiles
+      # inputs change, and GitHub idle-evicts unused entries (7 days / 10 GB LRU).
+      - name: Restore dev build cache
+        id: dev_cache_restore
+        if: inputs.dev_cache_paths != '' && inputs.dev_cache_key != '' && inputs.dev_cache_warm_command != ''
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ inputs.dev_cache_paths }}
+          key: ${{ inputs.dev_cache_key }}
+          restore-keys: ${{ inputs.dev_cache_restore_keys }}
+      - name: Warm dev build cache (base ref)
+        id: dev_cache_warm
+        if: inputs.dev_cache_paths != '' && inputs.dev_cache_key != '' && inputs.dev_cache_warm_command != '' && steps.dev_cache_restore.outputs.cache-hit != 'true'
+        shell: bash
+        env:
+          # Caller-supplied (trusted consumer config), passed via env and quoted
+          # — never interpolated into the script body.
+          DEV_CACHE_WARM_COMMAND: ${{ inputs.dev_cache_warm_command }}
+        run: |
+          echo "warmed=false" >> "$GITHUB_OUTPUT"
+          if bash -lc "$DEV_CACHE_WARM_COMMAND"; then
+            echo "warmed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::dev_cache_warm_command failed — cache warm is best-effort, reviews are unaffected."
+          fi
+      - name: Save dev build cache
+        if: inputs.dev_cache_paths != '' && inputs.dev_cache_key != '' && steps.dev_cache_warm.outputs.warmed == 'true' && steps.dev_cache_restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ inputs.dev_cache_paths }}
+          key: ${{ inputs.dev_cache_key }}

--- a/README.md
+++ b/README.md
@@ -60,6 +60,32 @@ with:
 
 Empty (the default) skips all bot-initiated runs. Two notes for allowed bots: dependabot-triggered events receive *Dependabot secrets*, not Actions secrets — add `CLAUDE_CODE_OAUTH_TOKEN` there too or the token picker fails. And bot-authored PRs waive the manual-spec gate (a machine PR can never link a human spec), so they can reach APPROVE on review merit alone.
 
+**Caching the dev-env build (`dev_cache_*`).** The functional tester runs `dev-start.sh` on a fresh runner every review, so any compiled/downloaded artefacts (a Gradle/Maven build, a Go module cache, a Rust `target`, …) are rebuilt cold each time — often the single biggest chunk of bring-up wall-time. The pnpm/npm store is already cached for you; everything else is opt-in and **stack-agnostic** via four inputs. It reuses the same producer/consumer split as the package store — the lightweight **warm-cache job** (which runs in `main` scope on `pull_request_target`) populates the cache, and the functional job only restores it:
+
+```yaml
+with:
+  pr_number: ${{ inputs.pr_number || '' }}
+  dev_cache_paths: |          # what to cache (newline-separated). Keep it tight.
+    ~/.gradle/caches/modules-2
+    ~/.gradle/wrapper
+  dev_cache_key: ${{ runner.os }}-gradle-${{ hashFiles('**/gradle/libs.versions.toml', '**/*.gradle*', '**/gradle-wrapper.properties') }}
+  dev_cache_restore_keys: |   # fall-back prefixes for partial hits
+    ${{ runner.os }}-gradle-
+  dev_cache_warm_command: cd backend/java && JAVA_HOME=$JAVA_HOME_21_X64 ./gradlew :api:dependencies --no-daemon
+```
+
+Other stacks are the same shape — Go: `~/go/pkg/mod` keyed on `go.sum`, warm `go mod download`; Maven: `~/.m2/repository` keyed on `pom.xml`, warm `mvn -q dependency:go-offline`; Rust: `~/.cargo` keyed on `Cargo.lock`, warm `cargo fetch`.
+
+> The warm-cache job is a vanilla `ubuntu-latest` with only Node set up, so the warm command owns its toolchain. Use the runner's preinstalled versions (`$JAVA_HOME_21_X64`, `$GOROOT_1_22_X64`, …) or install what it needs — no `setup-java`/`setup-go` runs for you there.
+
+How it works and how far the warmth reaches:
+- **`dev_cache_warm_command`** runs in the warm-cache job — `main` scope, against the trusted **base ref** (never PR head). Because it writes to `main` scope, **every** PR's functional job restores it, not just re-pushes of the same branch. It runs **only on a cache miss** (i.e. after the key rotates), so steady-state it's a no-op. Keep it cheap and PR-code-free — a dependency *resolve/prefetch*, not a full build.
+- The functional job **restores** the cache after disk cleanup, before the bring-up, so `dev-start.sh` builds warm. It does **not** save (no extra weight on the long review job).
+- Omit `dev_cache_warm_command` and only the restore runs — useful if your **own** main CI already writes a cache under the same key/prefix (Actions caches are repo-scoped, so it's reused here).
+- Leave all of it unset to disable caching entirely — no cache step runs.
+
+**Keep it short-lived.** Build caches are large and the repo shares a 10 GB Actions-cache budget (LRU-evicted, plus 7-day idle eviction). Two habits keep it bounded: cache the **dependency** dir, not whole build trees (`~/.gradle/caches/modules-2`, not `~/.gradle` — the latter drags in transient daemon/build state), and let the **key rotate via `hashFiles`** of your lockfiles so entries churn only when dependencies actually change. The warm-on-miss design means a new entry is written only when the key rotates, not on every PR.
+
 ### 2. Set secrets
 
 Add `CLAUDE_CODE_OAUTH_TOKEN` as a repo or org secret. Generate it with:


### PR DESCRIPTION
## Problem

The functional tester runs `dev-start.sh` on a **fresh runner every review**, so any compiled/downloaded build artefacts are rebuilt **cold every time** — typically the single biggest chunk of bring-up wall-time. Today only the pnpm/npm store is cached; every other stack (Gradle, Maven, Go, Rust, pip, …) pays full cold cost on each run, and there's no consumer-side hook (a bash `dev-start.sh` step can't call `actions/cache`).

## Design — reuse the package-store producer/consumer split

Rather than save inside the long functional job (PR-branch scope only, extra weight on the heavy job), this mirrors how the **pnpm store** is already handled:

- **warm-cache job** (`pull_request_target` → **main scope**): restore → run the consumer's warm command against the **trusted base ref** → save. Writing to main scope is what makes the cache available to **every** PR, not just re-pushes of the same branch.
- **functional job**: restore-only, after disk cleanup and before the bring-up, so `dev-start.sh` builds warm. No save → no extra weight on the review job.

Four **stack-agnostic, opt-in** inputs:

| input | purpose |
|---|---|
| `dev_cache_paths` | newline-separated paths (e.g. `~/.gradle/caches/modules-2`, `~/go/pkg/mod`) |
| `dev_cache_key` | opaque literal key — caller computes via `hashFiles(...)`; never re-hashed here |
| `dev_cache_restore_keys` | fallback prefixes for partial / cross-scope hits |
| `dev_cache_warm_command` | command the warm-cache job runs (base ref) to populate the paths |

## Least overhead + short-lived (per review feedback)

- The warm command runs **only on a cache miss** — i.e. after the key rotates. Steady-state it's a **no-op**, so entry churn tracks the key's `hashFiles` inputs (a dependency bump), not PR volume.
- Restore uses `actions/cache/restore` (not the all-in-one) so `dev-start.sh` mutating the tree can't trigger a post-save re-hash that reds an otherwise-green run.
- README guidance: cache the **dependency dir** (`~/.gradle/caches/modules-2`), not whole build trees, and let the key rotate via lockfile `hashFiles` — keeps it bounded under the 10 GB / 7-day-idle Actions cache budget.
- **Unset inputs ⇒ no cache step runs** — zero behaviour change for current consumers. Trivial to rip out if it doesn't pull its weight.

## Consumer example (Gradle)

```yaml
with:
  pr_number: ${{ inputs.pr_number || '' }}
  dev_cache_paths: |
    ~/.gradle/caches/modules-2
    ~/.gradle/wrapper
  dev_cache_key: ${{ runner.os }}-gradle-${{ hashFiles('**/gradle/libs.versions.toml', '**/*.gradle*', '**/gradle-wrapper.properties') }}
  dev_cache_restore_keys: |
    ${{ runner.os }}-gradle-
  dev_cache_warm_command: cd backend/java && ./gradlew :api:dependencies --no-daemon
```

## Validation

- `actionlint` clean on the new inputs/steps (the only findings are pre-existing `SC2001/SC2086` style notes in untouched scripts, identical on `main`).
- New steps reuse the surrounding gating; the warm command is passed via `env:` and quoted (caller-supplied trusted config, never interpolated into the script body).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional CI caching with defaults off; warm commands run in main scope on base ref only, and failures are best-effort warnings that do not block reviews.
> 
> **Overview**
> Adds **opt-in, stack-agnostic caching** for non-Node build/dependency artifacts (Gradle, Maven, Go, Rust, pip, etc.) so `dev-start.sh` can warm up faster on functional review runs.
> 
> The reusable workflow gains four inputs (`dev_cache_paths`, `dev_cache_key`, `dev_cache_restore_keys`, `dev_cache_warm_command`) that mirror the existing **pnpm store** producer/consumer split: the **`warm-cache`** job (main scope, trusted base ref) restores, runs the consumer’s cheap warm command **only on cache miss**, then saves; the **functional review job** **restore-only** after disk cleanup and before dev bring-up, using `actions/cache/restore` so post-save re-hashing after `dev-start.sh` mutates the tree cannot fail the run.
> 
> **Unset inputs leave behavior unchanged** — no cache steps run. The README documents Gradle/Go/Maven/Rust examples, cache-budget guidance, and that callers can omit warming if their own main CI already writes the same key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0be182d402058caab692129baed23f326bd9e59c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->