### PR TITLE
fix(review): anchor config-gap detection to the consumer checkout root

### DIFF
--- a/skills/review-context-builder.md
+++ b/skills/review-context-builder.md
@@ -177,11 +177,15 @@ fi
 for prd in $PRD_FILES; do [ -f "$prd" ] && { echo "<!-- $prd -->"; cat "$prd"; echo; } >> /tmp/prd-content.md; done
 
 # ── Config-gap detection (replaces the deleted workflow lint step) ──
+# Anchor to the consumer checkout ($GITHUB_WORKSPACE) — the Bash CWD here is the
+# pipeline install dir, so a relative `.github/...` resolves against claude-review's
+# own files and spuriously reports the consumer's dev-start.sh as missing.
+WS="${GITHUB_WORKSPACE:-.}"
 SETUP_NOTES=""
-[ -f .github/claude-review/dev-start.sh ] || SETUP_NOTES="no \`.github/claude-review/dev-start.sh\` (functional testing unavailable)"
-if [ -f .github/review-config.md ]; then
-  grep -q '^### Auth' .github/review-config.md || SETUP_NOTES="${SETUP_NOTES:+$SETUP_NOTES; }review-config.md lacks \`### Auth\`"
-  grep -qE '^### (Known service ports|Services)' .github/review-config.md || SETUP_NOTES="${SETUP_NOTES:+$SETUP_NOTES; }review-config.md lacks \`### Known service ports\`"
+[ -f "$WS/.github/claude-review/dev-start.sh" ] || SETUP_NOTES="no \`.github/claude-review/dev-start.sh\` (functional testing unavailable)"
+if [ -f "$WS/.github/review-config.md" ]; then
+  grep -q '^### Auth' "$WS/.github/review-config.md" || SETUP_NOTES="${SETUP_NOTES:+$SETUP_NOTES; }review-config.md lacks \`### Auth\`"
+  grep -qE '^### (Known service ports|Services)' "$WS/.github/review-config.md" || SETUP_NOTES="${SETUP_NOTES:+$SETUP_NOTES; }review-config.md lacks \`### Known service ports\`"
 fi
 echo "SETUP_NOTES=${SETUP_NOTES:-none}"
 cat /tmp/dev-env/outputs 2>/dev/null || echo "dev-env outputs not available yet"


### PR DESCRIPTION
## Problem

On downstream PRs, the review comment's footer always reads:

> Setup notes: no `.github/claude-review/dev-start.sh` (functional testing unavailable).

…even when the consumer repo **does** have `.github/claude-review/dev-start.sh` committed (e.g. Panenco/mason#344 — the file is present on the branch, `main`, `staging`, and `dev`).

## Root cause

The config-gap detection block in `skills/review-context-builder.md` uses **relative** paths:

```sh
[ -f .github/claude-review/dev-start.sh ] || SETUP_NOTES="…"
if [ -f .github/review-config.md ]; then grep '^### Auth' .github/review-config.md …
```

The consumer PR is checked out at `$GITHUB_WORKSPACE`, but the **Bash tool runs from the pipeline install dir** (`$CLAUDE_REVIEW_PIPELINE_DIR` = `$GITHUB_WORKSPACE/__claude-review-pipeline`), not the consumer root. So:

- `.github/claude-review/dev-start.sh` resolves against claude-review's *own* checkout, which has no such file → spurious "functional testing unavailable".
- `.github/review-config.md` resolves to claude-review's *own* config (which has `### Auth` + `### Known service ports`), so those greps pass — which is why only the `dev-start.sh` note ever fires.

The Read-tool reads later in the same skill (Turn 2) resolve against the agent root and *do* see the consumer's files, so this is specific to the Bash `[ -f ]`/`grep` filesystem checks. The PR-head checkout is full (`fetch-depth: 0`, no sparse patterns), so this is a path/CWD issue, not a missing file.

## Fix

Anchor the three filesystem checks to `$GITHUB_WORKSPACE` (the consumer PR checkout), with a `${GITHUB_WORKSPACE:-.}` fallback so behavior is unchanged when the var is unset (and dogfood — where claude-review genuinely has no `dev-start.sh` — still reports the note, as before). 8 lines, no behavioral change beyond resolving the paths correctly.

## Verification / impact

- Downstream repos with a committed `dev-start.sh` stop getting the false "functional testing unavailable" note.
- Note: this is cosmetic — functional testing for the example PR was skipped for the correct reason (`RUN_FUNCTIONAL=false`, non-runtime gate: docs-only diff). The note's wrong reason string was the only defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small path-resolution fix in review pipeline setup notes only; no auth, data, or runtime behavior changes.
> 
> **Overview**
> Fixes **false “functional testing unavailable” setup notes** on downstream repos that already ship `.github/claude-review/dev-start.sh`.
> 
> In `skills/review-context-builder.md`, the Turn 1 Bash **config-gap** checks (`dev-start.sh` presence and `review-config.md` `### Auth` / ports sections) now use **`$WS/.github/...`** with `WS="${GITHUB_WORKSPACE:-.}"` instead of relative `.github/...` paths. Bash runs from the pipeline install directory, so the old paths were evaluated against claude-review’s own tree, not the PR checkout at `$GITHUB_WORKSPACE`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a66f042e97c2008f07da72adbd0ec83f0e3fcaeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->